### PR TITLE
Stop infinite loop on the home page URL.

### DIFF
--- a/disable-blog.php
+++ b/disable-blog.php
@@ -277,7 +277,7 @@ if ( ! class_exists( 'Disable_WordPress_Blog' ) ) {
 		 * @link http://codex.wordpress.org/Plugin_API/Action_Reference/template_redirect
 		 */
 		public function redirect_posts() {
-			if( is_admin() )
+			if( is_admin() || is_home() )
 				return;
 		
 			$url = home_url();


### PR DESCRIPTION
Dropping out of the redirect_posts function if the is_home() conditional is true seems to fix the issue of crashing PHP5-FPM.