### PR TITLE
Fix erroneous redirection of tools.php subpages.

### DIFF
--- a/admin/class-disable-blog-admin.php
+++ b/admin/class-disable-blog-admin.php
@@ -53,7 +53,7 @@ class Disable_Blog_Admin {
 		$this->version = $version;
 
 	}
-	
+
 	/**
 	 * Remove comment and pingback support for posts.
 	 *
@@ -63,42 +63,42 @@ class Disable_Blog_Admin {
 		if( post_type_supports( 'post', 'comments' ) && apply_filters( 'dwpb_remove_post_comment_support', true ) ) {
 			remove_post_type_support( 'post', 'comments' );
 		}
-		
-		// Remove 
+
+		// Remove
 		if( post_type_supports( 'post', 'trackbacks' ) && apply_filters( 'dwpb_remove_post_trackback_support', true ) ) {
 			remove_post_type_support( 'post', 'trackbacks' );
 		}
 	}
-	
+
 	/**
 	 * Filter the comment counts to remove comments to 'post' post type.
 	 *
 	 * @since 0.4.0
 	 *
-	 * @param object $comments 
-	 * @param int $post_id 
+	 * @param object $comments
+	 * @param int $post_id
 	 *
 	 * @return object $comments
 	 */
 	public function filter_wp_count_comments( $comments, $post_id ) {
-		
+
 		// if this is grabbing all the comments, filter out the 'post' comments.
 		if( 0 == $post_id )
 			$comments = $this->get_comment_counts();
-		
+
 		// If we filtered it above, it needs to be an object, not an array.
 		if( !empty( $comments ) )
 			$comments = (object) $comments;
-		
+
 		return $comments;
 	}
-	
+
 	/**
 	 * Alter the comment counts on the admin comment table to remove comments associated with posts.
 	 *
 	 * @since 0.4.0
 	 *
-	 * @param array $views 
+	 * @param array $views
 	 *
 	 * @return array $views
 	 */
@@ -106,7 +106,7 @@ class Disable_Blog_Admin {
 	    global $current_screen;
 
 	    if( 'edit-comments' == $current_screen->id ) {
-			
+
 			$updated_counts = $this->get_comment_counts();
 			foreach( $views as $view => $text ) {
 				if( isset( $updated_counts[ $view ] ) )
@@ -115,7 +115,7 @@ class Disable_Blog_Admin {
 	    }
 	    return $views;
 	}
-	
+
 	/**
 	 * Retreive the comment counts without the 'post' comments.
 	 *
@@ -128,21 +128,21 @@ class Disable_Blog_Admin {
 	 * @return array $comment_counts
 	 */
 	public function get_comment_counts( $count = null ) {
-		
+
 		global $wpdb;
-		
+
 		// Grab the comments that are not associated with 'post' post_type
 	    $totals = (array) $wpdb->get_results("
 	        SELECT comment_approved, COUNT( * ) AS total
 	        FROM {$wpdb->comments}
 		    WHERE comment_post_ID in (
-		         SELECT ID 
-		         FROM {$wpdb->posts} 
-		         WHERE post_type != 'post' 
+		         SELECT ID
+		         FROM {$wpdb->posts}
+		         WHERE post_type != 'post'
 		         AND post_status = 'publish')
 	        GROUP BY comment_approved
 	    ", ARRAY_A);
-		
+
 		$comment_count = array(
 			'moderated' 		  => 0,
 	        'approved'            => 0,
@@ -153,7 +153,7 @@ class Disable_Blog_Admin {
 	        'total_comments'      => 0,
 	        'all'                 => 0,
 		);
-		
+
 	    foreach ( $totals as $row ) {
 	        switch ( $row['comment_approved'] ) {
 	            case 'trash':
@@ -181,17 +181,17 @@ class Disable_Blog_Admin {
 	                break;
 	        }
 	    }
-		
+
 		return $comment_count;
 	}
-	
+
 	/**
 	 * Clear out the status of all post comments.
 	 *
 	 * @since 0.4.0
 	 *
-	 * @param boolean $open 
-	 * @param int $post_id 
+	 * @param boolean $open
+	 * @param int $post_id
 	 *
 	 * @return boolean
 	 */
@@ -199,13 +199,13 @@ class Disable_Blog_Admin {
 		$post_type = get_post_type( $post_id );
 		return ( 'post' == $post_type ) ? false : $open;
 	}
-	
+
 	/**
 	 * Clear comments from 'post' post type.
 	 *
 	 * @since 0.4.0
 	 *
-	 * @param boolean $comments 
+	 * @param boolean $comments
 	 * @param string $post_id
 	 *
 	 * @return boolean
@@ -214,23 +214,23 @@ class Disable_Blog_Admin {
 		$post_type = get_post_type( $post_id );
 		return ( 'post' == $post_type ) ? array() : $comments;
 	}
-	
+
 	/**
 	 * Remove the X-Pingback HTTP header.
 	 *
 	 * @since 0.4.0
 	 *
-	 * @param array $headers 
+	 * @param array $headers
 	 *
-	 * @return array $headers 
+	 * @return array $headers
 	 */
 	public function filter_wp_headers( $headers ) {
 		if( apply_filters( 'dwpb_remove_pingback_header', true ) && isset( $headers['X-Pingback'] ) )
 			unset( $headers['X-Pingback'] );
-		
+
 		return $headers;
 	}
-	
+
 	/**
 	 * Remove Post Related Menus
 	 *
@@ -243,31 +243,31 @@ class Disable_Blog_Admin {
 	 * @since 0.4.0 added tools and discussion subpages
 	 */
 	public function remove_menu_pages() {
-		
+
 		// Remove Top Level Menu Pages
 		$pages = apply_filters( 'dwpb_menu_pages_to_remove', array( 'edit.php' ) );
 		foreach( $pages as $page ) {
 			remove_menu_page( $page );
 		}
-		
+
 		// Submenu Pages
 		$remove_subpages = array(
 			'options-general.php' => 'options-writing.php',
 			'tools.php' => 'tools.php',
 		);
-		
+
 		// If there are no other post types supporting comments, remove the discussion page
 		if( ! dwpb_post_types_with_feature( 'comments' ) ) {
 			$remove_subpages[ 'options-general.php' ] = 'options-discussion.php'; // Settings > Discussion
 		}
-		
+
 		// Remove Admin Menu Subpages
 		$subpages = apply_filters( 'dwpb_menu_subpages_to_remove', $remove_subpages );
 		foreach( $subpages as $page => $subpage ) {
 			remove_submenu_page( $page, $subpage );
 		}
 	}
-	
+
 	/**
 	 * Redirect blog-related admin pages
 	 *
@@ -282,28 +282,28 @@ class Disable_Blog_Admin {
 		if( !isset( $pagenow ) ) {
 			return;
 		}
-		
+
 		// setup false redirect url value for final check
 		$redirect_url = false;
-		
+
 		//Redirect Edit Single Post to Dashboard.
 		if( 'post.php' == $pagenow && ( isset( $_GET['post'] ) && 'post' == get_post_type( $_GET['post'] ) ) && apply_filters( 'dwpb_redirect_admin_edit_single_post', true ) ) {
 			$url = admin_url( '/index.php' );
 			$redirect_url = apply_filters( 'dwpb_redirect_single_post_edit', $url );
 		}
-		
+
 		// Redirect Edit Posts Screen to Edit Page
 		if( 'edit.php' == $pagenow && ( !isset( $_GET['post_type'] ) || isset( $_GET['post_type'] ) && $_GET['post_type'] == 'post' ) && apply_filters( 'dwpb_redirect_admin_edit_post', true ) ) {
 			$url = admin_url( '/edit.php?post_type=page' );
 			$redirect_url = apply_filters( 'dwpb_redirect_edit', $url );
 		}
-	
+
 		// Redirect New Post to New Page
 		if( 'post-new.php' == $pagenow && ( !isset( $_GET['post_type'] ) || isset( $_GET['post_type'] ) && $_GET['post_type'] == 'post' ) && apply_filters( 'dwpb_redirect_admin_post_new', true ) ) {
 			$url = admin_url('/post-new.php?post_type=page' );
 			$redirect_url = apply_filters( 'dwpb_redirect_post_new', $url );
 		}
-	
+
 		// Redirect at edit tags screen
 		// If this is a post type other than 'post' that supports categories or tags,
 		// then bail. Otherwise if it is a taxonomy only used by 'post'
@@ -313,39 +313,39 @@ class Disable_Blog_Admin {
 		if( ( 'edit-tags.php' == $pagenow || 'term.php' == $pagenow ) && ( isset( $_GET['taxonomy'] ) && ! dwpb_post_types_with_tax( $_GET['taxonomy'] ) ) && apply_filters( 'dwpb_redirect_admin_edit_tags', true ) ) {
 			$url = admin_url( '/index.php' );
 			$redirect_url = apply_filters( 'dwpb_redirect_edit_tax', $url );
-		} 
-	
+		}
+
 		// Redirect posts-only comment queries to comments
 		if( 'edit-comments.php' == $pagenow && isset( $_GET['post_type'] ) && 'post' == $_GET['post_type'] && apply_filters( 'dwpb_redirect_admin_edit_comments', true ) ) {
 			$url = admin_url( '/edit-comments.php' );
 			$redirect_url = apply_filters( 'dwpb_redirect_edit_comments', $url );
 		}
-		
+
 		// Redirect disccusion options page if only supported by 'post' type
 		if( 'options-discussion.php' == $pagenow && ! dwpb_post_types_with_feature( 'comments' ) && apply_filters( 'dwpb_redirect_admin_options_discussion', true ) ) {
 			$url = admin_url( '/index.php' );
 			$redirect_url = apply_filters( 'dwpb_redirect_options_discussion', $url );
 		}
-		
+
 		// Redirect writing options to general options
 		if( 'options-writing.php' == $pagenow && apply_filters( 'dwpb_redirect_admin_options_writing', true ) ) {
 			$url = admin_url( '/options-general.php' );
 			$redirect_url = apply_filters( 'dwpb_redirect_options_writing', $url );
 		}
-	
-		// Redirect avilable tools page
-		if( 'tools.php' == $pagenow && apply_filters( 'dwpb_redirect_admin_options_writing', true ) ) {
-			$url = admin_url( '/index.php' );
-			$redirect_url = apply_filters( 'dwpb_redirect_options_writing', $url );
+
+		// Redirect available tools page
+		if( 'tools.php' == $pagenow && !isset( $_GET['page'] ) && apply_filters( 'dwpb_redirect_admin_options_writing', true ) ) {
+		 	$url = admin_url( '/index.php' );
+		 	$redirect_url = apply_filters( 'dwpb_redirect_options_writing', $url );
 		}
-		
+
 		// If we have a redirect url, do it
 		if( $redirect_url ) {
 			wp_redirect( esc_url_raw( $redirect_url ), 301 );
 			exit;
 		}
 	}
-	
+
 	/**
 	 * Remove blog-related admin bar links
 	 *
@@ -357,11 +357,11 @@ class Disable_Blog_Admin {
 	 */
 	public function remove_admin_bar_links() {
 		global $wp_admin_bar;
-	
+
 		// If only posts support comments, then remove comment from admin bar
 		if( ! dwpb_post_types_with_feature( 'comments' ) )
 		    $wp_admin_bar->remove_menu( 'comments' );
-	
+
 		// Remove New Post from Content
 		$wp_admin_bar->remove_node( 'new-post' );
 	}
@@ -370,27 +370,27 @@ class Disable_Blog_Admin {
 	 * Hide all comments from 'post' post type
 	 *
 	 * @uses dwpb_post_types_with_feature()
-	 * 
+	 *
 	 * @since 0.1.0
 	 *
 	 * @param  (wp_query object) $comments
 	 */
 	public function comment_filter( $comments ) {
 		global $pagenow;
-	
+
 		if( !isset( $pagenow ) )
 			return $comments;
-		
+
 		// Filter out comments from post
 		if( is_admin() && $pagenow == 'edit-comments.php' ) {
 			if( $post_types = dwpb_post_types_with_feature( 'comments' ) ) {
 				$comments->query_vars['post_type'] = $post_types;
 			}
 		}
-	
+
 		return $comments;
 	}
-	
+
 	/**
 	 * Remove post-related dashboard widgets
 	 *
@@ -399,36 +399,36 @@ class Disable_Blog_Admin {
 	 * @since 0.1.0
 	 */
 	function remove_dashboard_widgets() {
-		
+
 		// recent comments
 		if( apply_filters( 'dwpb_disable_dashboard_recent_comments', true ) && ! dwpb_post_types_with_feature( 'comments' ) )
 			remove_meta_box( 'dashboard_recent_comments', 'dashboard', 'normal' );
-	
+
 		// incoming links
 		if( apply_filters( 'dwpb_disable_dashboard_incoming_links', true ) )
 			remove_meta_box( 'dashboard_incoming_links', 'dashboard', 'normal' );
-	
+
 		// quick press
 		if( apply_filters( 'dwpb_disable_dashboard_quick_press', true ) )
 			remove_meta_box( 'dashboard_quick_press', 'dashboard', 'normal' );
-	
+
 		// recent drafts
 		if( apply_filters( 'dwpb_disable_dashboard_recent_drafts', true ) )
 			remove_meta_box( 'dashboard_recent_drafts', 'dashboard', 'normal' );
-	
+
 		// activity
 		if( apply_filters( 'dwpb_disable_dashboard_activity', true ) )
 			remove_meta_box( 'dashboard_activity', 'dashboard', 'normal' );
 	}
-	
+
 	/**
 	 * Set Page for Posts options: 'show_on_front', 'page_for_posts', 'page_on_front'
-	 * 
+	 *
 	 * If the 'show_on_front' option is set to 'posts', then set it to 'page'
 	 * and also set the page
-	 * 
+	 *
 	 * @since 0.2.0
-	 * 
+	 *
 	 */
 	public function reading_settings() {
 		if( 'posts' == get_option( 'show_on_front' ) ) {
@@ -437,24 +437,24 @@ class Disable_Blog_Admin {
 			update_option( 'page_on_front', apply_filters( 'dwpb_page_on_front', 1 ) );
 		}
 	}
-	
+
 	/**
 	 * Kill the Press This functionality
-	 * 
+	 *
 	 * @since 0.2.0
 	 */
 	public function disable_press_this() {
 		wp_die( '"Press This" functionality has been disabled.' );
 	}
-	
+
 	/**
 	 * Remove post related widgets
-	 * 
+	 *
 	 * @since 0.2.0
 	 * @since 0.4.0 simplified unregistering and added dwpb_unregister_widgets filter.
 	 */
 	public function remove_widgets() {
-		
+
 		// Unregister widgets that don't require a check
         $widgets = array(
 			'WP_Widget_Recent_Comments', // Recent Comments
@@ -471,33 +471,33 @@ class Disable_Blog_Admin {
 			if( apply_filters( "dwpb_unregister_widgets", true, $widget ) )
 	            unregister_widget( $widget );
         }
-	
+
 	}
-	
+
 	/**
 	 * Filter the widget removal & check for reasons to not remove specific widgets.
 	 *
 	 * @since 0.4.0
 	 *
-	 * @param boolean $boolean 
+	 * @param boolean $boolean
 	 * @param string $widget
 	 *
 	 * @return boolean
 	 */
 	public function filter_widget_removal( $boolean, $widget ) {
-		
+
 		// Remove Categories Widget
 		if( 'WP_Widget_Categories' == $widget && dwpb_post_types_with_tax( 'category' ) )
 			$boolean = false;
-	
+
 		// Remove Recent Comments Widget if posts are the only type with comments
 		if( 'WP_Widget_Recent_Comments' == $widget && dwpb_post_types_with_feature( 'comments' ) )
 			$boolean = false;
-	
+
 		// Remove Tag Cloud
 		if( 'WP_Widget_Tag_Cloud' == $widget && dwpb_post_types_with_tax( 'post_tag' ) )
 			$boolean = false;
-		
+
 		return $boolean;
 	}
 


### PR DESCRIPTION
The redirection rule for 'Available Tools' introduced in v0.4.0 returns
true for custom admin pages under `tools.php` via `add_submenu_page`, which
I don't think is desired behaviour (This change broke Migrate DB Pro and
and I expect other plugins as well.) This PR redirects away from
`tools.php` only if `$_GET['page']` is empty, which should maintain
the desired functionality without impacting other plugins.