### PR TITLE
Return comments count as array for WooCommerce (versions <= 2.6.2)

### DIFF
--- a/admin/class-disable-blog-admin.php
+++ b/admin/class-disable-blog-admin.php
@@ -74,6 +74,7 @@ class Disable_Blog_Admin {
 	 * Filter the comment counts to remove comments to 'post' post type.
 	 *
 	 * @since 0.4.0
+	 * @since 0.4.3 Moved everything into the post id check and reset the cache.
 	 *
 	 * @param object $comments
 	 * @param int $post_id
@@ -85,6 +86,12 @@ class Disable_Blog_Admin {
 		// if this is grabbing all the comments, filter out the 'post' comments.
 		if( 0 == $post_id ) {
 			$comments = $this->get_comment_counts();
+			
+			$comments['moderated'] = $comments['awaiting_moderation'];
+			unset( $comments['awaiting_moderation'] );
+			
+			$comments = (object) $comments;
+			wp_cache_set( "comments-0", $comments, 'counts' );
 		}
 
 		return $comments;
@@ -139,14 +146,13 @@ class Disable_Blog_Admin {
 	 * Retreive the comment counts without the 'post' comments.
 	 *
 	 * @since 0.4.0
+	 * @since 0.4.3 Removed Unused "count" function.
 	 *
 	 * @see get_comment_count()
 	 *
-	 * @param mixed $count Array or string of the specific count you're looking for, defaults to all.
-	 *
 	 * @return array $comment_counts
 	 */
-	public function get_comment_counts( $count = null ) {
+	public function get_comment_counts() {
 
 		global $wpdb;
 

--- a/admin/class-disable-blog-admin.php
+++ b/admin/class-disable-blog-admin.php
@@ -89,6 +89,28 @@ class Disable_Blog_Admin {
 
 		return $comments;
 	}
+	
+	/**
+	 * Turn the comments object back into an array if WooCommerce is active.
+	 *
+	 * This is only necessary for version of WooCommerce prior to 2.6.3, where it failed
+	 * to check/convert the $comment object into an array.
+	 *
+	 * @since 0.4.3
+	 *
+	 * @param object $comments
+	 * @param int $post_id
+	 *
+	 * @return array $comments
+	 */
+	public function filter_woocommerce_comment_count( $comments, $post_id ) {
+		
+		if( 0 == $post_id && class_exists( 'WC_Comments' ) && function_exists( 'WC' ) && version_compare( WC()->version, '2.6.2', '<=' ) ) {
+			$comments = (array) $comments;
+		}
+		
+		return $comments;
+	}
 
 	/**
 	 * Alter the comment counts on the admin comment table to remove comments associated with posts.

--- a/admin/class-disable-blog-admin.php
+++ b/admin/class-disable-blog-admin.php
@@ -78,17 +78,14 @@ class Disable_Blog_Admin {
 	 * @param object $comments
 	 * @param int $post_id
 	 *
-	 * @return object $comments
+	 * @return array $comments
 	 */
 	public function filter_wp_count_comments( $comments, $post_id ) {
 
 		// if this is grabbing all the comments, filter out the 'post' comments.
-		if( 0 == $post_id )
+		if( 0 == $post_id ) {
 			$comments = $this->get_comment_counts();
-
-		// If we filtered it above, it needs to be an object, not an array.
-		if( !empty( $comments ) )
-			$comments = (object) $comments;
+		}
 
 		return $comments;
 	}

--- a/disable-blog.php
+++ b/disable-blog.php
@@ -37,6 +37,25 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 /**
+ * The code that runs during plugin activation.
+ * This action is documented in includes/class-disable-blog-activator.php
+ */
+function activate_plugin_name() {
+	require_once plugin_dir_path( __FILE__ ) . 'includes/class-disable-blog-activator.php';
+	Disable_Blog_Activator::activate();
+}
+/**
+ * The code that runs during plugin deactivation.
+ * This action is documented in includes/class-disable-blog-deactivator.php
+ */
+function deactivate_plugin_name() {
+	require_once plugin_dir_path( __FILE__ ) . 'includes/class-disable-blog-deactivator.php';
+	Disable_Blog_Deactivator::deactivate();
+}
+register_activation_hook( __FILE__, 'activate_plugin_name' );
+register_deactivation_hook( __FILE__, 'deactivate_plugin_name' );
+
+/**
  * The core plugin class that is used to define internationalization,
  * admin-specific hooks, and public-facing site hooks.
  */

--- a/disable-blog.php
+++ b/disable-blog.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Disable Blog
  * Plugin URI:        https://wordpress.org/plugins/disable-blog/
  * Description:       A plugin to disable the blog functionality of WordPress (by hiding, removing, and redirecting).
- * Version:           0.4.2
+ * Version:           0.4.3
  * Author:            Joshua Nelson
  * Author URI:        http://joshuadnelson.com
  * License:           GPL-2.0+

--- a/includes/class-disable-blog-activator.php
+++ b/includes/class-disable-blog-activator.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Fired during plugin activation
+ *
+ * @link       https://github.com/joshuadavidnelson/disable-blog
+ * @since      0.4.3
+ *
+ * @package    Disable_Blog
+ * @subpackage Disable_Blog/includes
+ */
+
+/**
+ * Fired during plugin activation.
+ *
+ * This class defines all code necessary to run during the plugin's activation.
+ *
+ * @since      0.4.3
+ * @package    Disable_Blog
+ * @subpackage Disable_Blog/includes
+ * @author     Joshua Nelson <josh@joshuadnelson.com>
+ */
+class Disable_Blog_Activator {
+
+	/**
+	 * Clear the global comment count cache.
+	 *
+	 * @since    0.4.3
+	 */
+	public static function activate() {
+		wp_cache_delete( 'comments-0', 'counts' );
+		delete_transient( 'wc_count_comments' );
+	}
+
+}

--- a/includes/class-disable-blog-deactivator.php
+++ b/includes/class-disable-blog-deactivator.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Fired during plugin deactivation
+ *
+ * @link       https://github.com/joshuadavidnelson/disable-blog
+ * @since      0.4.3
+ *
+ * @package    Disable_Blog
+ * @subpackage Disable_Blog/includes
+ */
+
+/**
+ * Fired during plugin deactivation.
+ *
+ * This class defines all code necessary to run during the plugin's deactivation.
+ *
+ * @since      0.4.3
+ * @package    Disable_Blog
+ * @subpackage Disable_Blog/includes
+ * @author     Joshua Nelson <josh@joshuadnelson.com>
+ */
+class Disable_Blog_Deactivator {
+
+	/**
+	 * Clear the global comment cache.
+	 *
+	 * @since    0.4.3
+	 */
+	public static function deactivate() {
+		wp_cache_delete( 'comments-0', 'counts' );
+		delete_transient( 'wc_count_comments' );
+	}
+
+}

--- a/includes/class-disable-blog.php
+++ b/includes/class-disable-blog.php
@@ -249,6 +249,9 @@ class Disable_Blog {
 		// Filter wp_count_comments, which addresses comments in admin bar.
 		$this->loader->add_filter( 'wp_count_comments', $plugin_admin, 'filter_wp_count_comments', 10, 2 );
 		
+		// Convert the $comments object back into an array if older version of WooCommerce is active.
+		$this->loader->add_filter( 'wp_count_comments', $plugin_admin, 'filter_woocommerce_comment_count', 10, 2 );
+		
 		// Remove the X-Pingback HTTP header.
 		$this->loader->add_filter( 'wp_headers', $plugin_admin, 'filter_wp_headers', 10, 1 );
 		


### PR DESCRIPTION
Fixes conflicts with older (pre 2.6.3) versions of WooCommerce filtering the comment counts incorrectly, see #11. Also cleans up the comment count functions and clears the comment count cache on activation and deactivation of plugin.