### PR TITLE
Hide Settings > Writing for users with Disable Comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Changelog
 
+##### 0.4.4
+- Hide the Settings > Writing menu item, which shows up with Disable Comments enabled everywhere. Thanks to @dater for identifying.
+
 ##### 0.4.3
 - Fix fatal error conflict with WooCommerce versions older than 2.6.3 (props to @Mahjouba91 for the heads up), no returns an array of comments in the filter for those older WooCommerce versions.
 - Add de/activation hooks to clear comment caches

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ Disable Blog
 ======================
 
 **Requires at least:** 3.1.0
-**Tested up to:** 4.9.2
-**Stable version:** 0.4.3
+**Tested up to:** 4.9.8
+**Stable version:** 0.4.4
 **License:** GPLv2 or later
 
 ## Description

--- a/admin/css/disable-blog-admin.css
+++ b/admin/css/disable-blog-admin.css
@@ -24,3 +24,8 @@
 #front-static-pages ul {
  	margin: 0
 }
+
+/* Hide the menu link for options-writing.php the appears with Disable Comments enabled */
+#menu-settings a[href="options-writing.php"] {
+	display: none;
+}

--- a/disable-blog.php
+++ b/disable-blog.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Disable Blog
  * Plugin URI:        https://wordpress.org/plugins/disable-blog/
  * Description:       A plugin to disable the blog functionality of WordPress (by hiding, removing, and redirecting).
- * Version:           0.4.3
+ * Version:           0.4.4
  * Author:            Joshua Nelson
  * Author URI:        http://joshuadnelson.com
  * License:           GPL-2.0+

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: joshuadnelson
 Donate link: https://joshuadnelson.com/donate/
 Tags: remove blog, disable blog, disable settings, disable blogging, disable feeds, posts, feeds
 Requires at least: 3.1.0
-Tested up to: 4.9.2
-Stable tag: 0.4.3
+Tested up to: 4.9.8
+Stable tag: 0.4.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -48,6 +48,9 @@ e.g.
 2. **I want to delete my posts and comments.** Deactivate the plugin, delete your posts (which will delete related comments), and delete any tags or categories you might want to remove as well. Then reactivate the plugin to hide everything.
 
 == Changelog ==
+
+= 0.4.4 =
+* Hide the Settings > Writing menu item, which shows up with Disable Comments enabled everywhere. Thanks to @dater for identifying.
 
 = 0.4.3 =
 * Fix fatal error conflict with WooCommerce versions older than 2.6.3 (props to @Mahjouba91 for the heads up), no returns an array of comments in the filter for those older WooCommerce versions.
@@ -111,6 +114,9 @@ A bunch of stuff:
 * Hide other post-related reading options, except Search Engine Visibility
 
 == Upgrade Notice ==
+
+= 0.4.4 =
+* Hide the Settings > Writing menu item, which shows up with Disable Comments enabled everywhere. Thanks to @dater for identifying.
 
 = 0.4.3 =
 * Fixes compatibility issues with WooCommerce (versions 2.6.3 and older)


### PR DESCRIPTION
This hides the options-writing.php (Settings > Writing) menu from view, which re-appears if Disable Comments is active and enabled with Disable Blog. See: https://wordpress.org/support/topic/admin-menu-options-writing/