### PR TITLE
Configure TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: php
+
+php:
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
+
+env:
+  matrix:
+    - php: 5.3
+      dist: precise
+      script: find lib/ -type f -name '*.php' -print0 | xargs -0 -L1 -P4 -- php -l
+    - php: 5.6
+      script: find lib/ -type f -name '*.php' -print0 | xargs -0 -L1 -P4 -- php -l
+
+install:
+  - composer update --prefer-dist
+
+script:
+  - find lib/ -type f -name '*.php' -print0 | xargs -0 -L1 -P4 -- php -l
+  - vendor/bin/phpcs
+  - vendor/bin/phpstan analyse


### PR DESCRIPTION
Do we **really** support WordPress 3.1.0?? See https://wordpress.org/news/2010/07/eol-for-php4-and-mysql4/