### PR TITLE
0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Cleaned up the Reading settings, adding admin notices if front page is not set.
 - Add check for Multisite to avoid network page redirects. Closes #17, props to @Mactory.
 - Added Contributing and Code of Conduct documentation.
+- Check that `is_singular` works prior to running redirects to avoid non-object errors in feeds.
 
 ##### 0.4.6
 - Added check on disable feed functionality to confirm post type prior to disabling feed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Using GitHub actions publish on WP.org from github releases.
 - Cleaned up the Reading settings, adding admin notices if front page is not set.
 - Add check for Multisite to avoid network page redirects. Closes #17, props to @Mactory.
-- Added Constributing and Code of Contduct documentation.
+- Added Contributing and Code of Conduct documentation.
 
 ##### 0.4.6
 - Added check on disable feed functionality to confirm post type prior to disabling feed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Changelog
 
+##### 0.4.6
+- Added check on disable feed functionality to confirm post type prior to disabling feed.
+
 ##### 0.4.5
 - Remove the functionality hiding the Settings > Writing admin page, allow this option to be re-enabled via the older filter. This page used to be entirely related to posts, but is also used to select the editor type (Gutenberg vs Classic).
 - Correct misspelled dwpb_redirect_options_tools filter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Changelog
 
+##### 0.4.7
+- Using GitHub actions publish on WP.org from github releases.
+- Cleaned up the Reading settings, adding admin notices if front page is not set.
+- Add check for Multisite to avoid network page redirects. Closes #17, props to @Mactory.
+- Added Constributing and Code of Contduct documentation.
+
 ##### 0.4.6
 - Added check on disable feed functionality to confirm post type prior to disabling feed.
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ Disable Blog
 ======================
 
 **Requires at least:** 3.1.0
-**Tested up to:** 4.9.8
-**Stable version:** 0.4.4
+**Tested up to:** 5.1.1
+**Stable version:** 0.4.5
 **License:** GPLv2 or later
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@ Disable Blog
 ======================
 
 **Requires at least:** 3.1.0  
-**Tested up to:** 5.2.1  
-**Stable version:** 0.4.6  
+**Tested up to:** 5.4.1  
+**Stable version:** 0.4.7  
 **License:** GPLv2 or later
 
 ## Description
+
+WordPress, without the blog. Activate to disable the blog functions within WordPres, for a site without a blog.
+
 A plugin to disable the blog functionality of WordPress (by hiding, removing, and redirecting). Useful when you want a WordPress site to remain static and hide blog-related elements from admin users.
 
 Does the following:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ Disable Blog
 ======================
 
 **Requires at least:** 3.1.0
-**Tested up to:** 5.1.1
-**Stable version:** 0.4.5
+**Tested up to:** 5.2.1
+**Stable version:** 0.4.6
 **License:** GPLv2 or later
 
 ## Description

--- a/admin/css/disable-blog-admin.css
+++ b/admin/css/disable-blog-admin.css
@@ -2,11 +2,15 @@
  * All of the CSS for your admin-specific functionality should be
  * included in this file.
  */
-#dashboard_right_now .post-count,
-#dashboard_right_now .comment-count,
-.nav-menus-php label[for="add-post-hide"],
-.control-section.add-post,
-.welcome-icon.welcome-write-blog,
-.users-php .column-posts {
-    display: none;
-}
+ #dashboard_right_now .post-count,
+ #dashboard_right_now .comment-count,
+ .nav-menus-php label[for="add-post-hide"],
+ .control-section.add-post,
+ .welcome-icon.welcome-write-blog,
+ .users-php .column-posts,
+ .disabled-blog.options-reading-php #front-static-pages legend + p,
+ .disabled-blog.options-reading-php .form-table tr:nth-child(2),
+ .disabled-blog.options-reading-php .form-table tr:nth-child(3),
+ .disabled-blog.options-reading-php .form-table tr:nth-child(4) {
+     display: none;
+ }

--- a/admin/css/disable-blog-admin.css
+++ b/admin/css/disable-blog-admin.css
@@ -10,17 +10,3 @@
 .users-php .column-posts {
     display: none;
 }
-
-/* Hide blog options */
-.options-reading-php #front-static-pages p:first-of-type,
-.options-reading-php .form-table tr:nth-child(2),
-.options-reading-php .form-table tr:nth-child(3),
-.options-reading-php .form-table tr:nth-child(4),
-.options-reading-php #front-static-pages ul li:last-child,
-.options-reading-php #front-static-pages ul li:nth-child(2),
-.options-reading-php #front-static-pages input[name="show_on_front"] {
-	display: none;
-}
-#front-static-pages ul {
- 	margin: 0
-}

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,50 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+*   Using welcoming and inclusive language
+*   Being respectful of differing viewpoints and experiences
+*   Gracefully accepting constructive criticism
+*   Focusing on what is best for the community
+*   Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+*   The use of sexualized language or imagery and unwelcome sexual attention or advances
+*   Trolling, insulting/derogatory comments, and personal or political attacks
+*   Public or private harassment
+*   Publishing others' private information, such as a physical or electronic address, without explicit permission
+*   Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+This Code of Conduct also applies outside the project spaces when the Project Steward has a reasonable belief that an individual's behavior may have a negative impact on the project or its community.
+
+## Conflict Resolution
+
+We do not believe that all conflict is bad; healthy debate and disagreement often yield positive results. However, it is never okay to be disrespectful or to engage in behavior that violates the project’s code of conduct.
+
+If you see someone violating the code of conduct, you are encouraged to address the behavior directly with those involved. Many issues can be resolved quickly
+and easily, and this gives people more control over the outcome of their dispute. If you are unable to resolve the matter for any reason, or if the behavior is threatening or harassing, report it. We are dedicated to providing an environment where participants feel welcome and safe.
+
+Reports should be directed to Joshua Nelson, josh@joshuadnelson.com, the Project Steward(s) for the Disable WordPress Blog Plugin. It is the Project Steward’s duty to receive and address reported violations of the code of conduct. They will then work with a committee consisting of representatives from the Open Source Programs Office and the Google Open Source Strategy team. If for any reason you are uncomfortable reaching out the Project Steward, please email opensource@google.com.
+
+We will investigate every complaint, but you may not receive a direct response. We will use our discretion in determining when and how to follow up on reported incidents, which may range from not taking action to permanent expulsion from the project and project-sponsored spaces. We will notify the accused of the report and provide them an opportunity to discuss it before any action is taken. The identity of the reporter will be omitted from the details of the report supplied to the accused. In potentially harmful situations, such as ongoing harassment or threats to anyone's safety, we may take action without notice.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -32,18 +32,15 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 
 This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
 
-This Code of Conduct also applies outside the project spaces when the Project Steward has a reasonable belief that an individual's behavior may have a negative impact on the project or its community.
+This Code of Conduct also applies outside the project spaces when the Project Maintainer has a reasonable belief that an individual's behavior may have a negative impact on the project or its community.
 
 ## Conflict Resolution
 
 We do not believe that all conflict is bad; healthy debate and disagreement often yield positive results. However, it is never okay to be disrespectful or to engage in behavior that violates the project’s code of conduct.
 
-If you see someone violating the code of conduct, you are encouraged to address the behavior directly with those involved. Many issues can be resolved quickly
-and easily, and this gives people more control over the outcome of their dispute. If you are unable to resolve the matter for any reason, or if the behavior is threatening or harassing, report it. We are dedicated to providing an environment where participants feel welcome and safe.
+If you see someone violating the code of conduct, you are encouraged to address the behavior directly with those involved. Many issues can be resolved quickly and easily, and this gives people more control over the outcome of their dispute. If you are unable to resolve the matter for any reason, or if the behavior is threatening or harassing, report it. We are dedicated to providing an environment where participants feel welcome and safe.
 
-Reports should be directed to Joshua Nelson, josh@joshuadnelson.com, the Project Steward(s) for the Disable WordPress Blog Plugin. It is the Project Steward’s duty to receive and address reported violations of the code of conduct. They will then work with a committee consisting of representatives from the Open Source Programs Office and the Google Open Source Strategy team. If for any reason you are uncomfortable reaching out the Project Steward, please email opensource@google.com.
-
-We will investigate every complaint, but you may not receive a direct response. We will use our discretion in determining when and how to follow up on reported incidents, which may range from not taking action to permanent expulsion from the project and project-sponsored spaces. We will notify the accused of the report and provide them an opportunity to discuss it before any action is taken. The identity of the reporter will be omitted from the details of the report supplied to the accused. In potentially harmful situations, such as ongoing harassment or threats to anyone's safety, we may take action without notice.
+Reports should be directed to Joshua Nelson, josh@joshuadnelson.com, the Project Maintainer. 
 
 ## Attribution
 

--- a/contributing.md
+++ b/contributing.md
@@ -2,4 +2,4 @@ The `master` branch is reserved for releases and intended to be a mirror of the 
 
 The `develop` branch is the most current working branch.
 
-All pull requestes should be branches specific to a single issue or feature, directed to the `develop` branch. All improvements are merged into `develop` and then queued up for release before being merged into `master`.
+All pull requests should be made on a branch specific to a single issue or feature, directed to the `develop` branch. All improvements are merged into `develop` and then queued up for release before being merged into `master`.

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,5 @@
+The `master` branch is reserved for releases and intended to be a mirror of the official current release, or `trunk` on wp.org.
+
+The `develop` branch is the most current working branch.
+
+All pull requestes should be branches specific to a single issue or feature, directed to the `develop` branch. All improvements are merged into `develop` and then queued up for release before being merged into `master`.

--- a/disable-blog.php
+++ b/disable-blog.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Disable Blog
  * Plugin URI:        https://wordpress.org/plugins/disable-blog/
  * Description:       A plugin to disable the blog functionality of WordPress (by hiding, removing, and redirecting).
- * Version:           0.4.6
+ * Version:           0.4.7
  * Author:            Joshua Nelson
  * Author URI:        http://joshuadnelson.com
  * License:           GPL-2.0+

--- a/disable-blog.php
+++ b/disable-blog.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Disable Blog
  * Plugin URI:        https://wordpress.org/plugins/disable-blog/
  * Description:       A plugin to disable the blog functionality of WordPress (by hiding, removing, and redirecting).
- * Version:           0.4.4
+ * Version:           0.4.5
  * Author:            Joshua Nelson
  * Author URI:        http://joshuadnelson.com
  * License:           GPL-2.0+

--- a/disable-blog.php
+++ b/disable-blog.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Disable Blog
  * Plugin URI:        https://wordpress.org/plugins/disable-blog/
  * Description:       A plugin to disable the blog functionality of WordPress (by hiding, removing, and redirecting).
- * Version:           0.4.5
+ * Version:           0.4.6
  * Author:            Joshua Nelson
  * Author URI:        http://joshuadnelson.com
  * License:           GPL-2.0+

--- a/includes/class-disable-blog.php
+++ b/includes/class-disable-blog.php
@@ -263,10 +263,13 @@ class Disable_Blog {
 	
 		// Remove Dashboard Widgets
 		$this->loader->add_action( 'admin_init', $plugin_admin, 'remove_dashboard_widgets' );
-	
-		// Force Reading Settings
-		$this->loader->add_action( 'admin_init', $plugin_admin, 'reading_settings' );
-	
+
+		// Admin notices
+        $this->loader->add_action( 'admin_notices', $plugin_admin, 'admin_notices' );
+        
+        // Add a class to the admin body for the reading options page
+        $this->loader->add_filter( 'admin_body_class', $plugin_admin, 'admin_body_class', 10, 1 );
+
 		// Remove Post via Email Settings
 		add_filter( 'enable_post_by_email_configuration', '__return_false' );
 	

--- a/public/class-disable-blog-public.php
+++ b/public/class-disable-blog-public.php
@@ -63,46 +63,49 @@ class Disable_Blog_Public {
 	 * @link http://codex.wordpress.org/Plugin_API/Action_Reference/template_redirect
 	 */
 	public function redirect_posts() {
+
 		if( is_admin() || !get_option( 'page_on_front' ) )
 			return;
-		
+
 		// Get the front page id and url
 		$page_id = get_option( 'page_on_front' );
 		$url = get_permalink( $page_id );
-		
+
 		// Run the redirects
-		if( is_singular( 'post' ) ) {
-		
+		global $post;
+
+		if( $post instanceof WP_Post && is_singular( 'post' ) ) {
+
 			global $post;
 			$redirect_url = apply_filters( "dwpb_redirect_posts", $url, $post );
 			$redirect_url = apply_filters( "dwpb_redirect_post_{$post->ID}", $redirect_url, $post );
-		
+
 		} elseif( is_tag() && ! dwpb_post_types_with_tax( 'post_tag' ) ) {
-		
+
 			$redirect_url = apply_filters( 'dwpb_redirect_post_tag_archive', $url );
-		
+
 		} elseif( is_category() && ! dwpb_post_types_with_tax( 'category' ) ) {
-		
+
 			$redirect_url = apply_filters( 'dwpb_redirect_category_archive', $url );
-		
+
 		} elseif( is_post_type_archive( 'post' ) ) {
-		
+
 			$redirect_url = apply_filters( 'dwpb_redirect_post_archive', $url );
-		
+
 		} elseif( is_home() ) {
-			
+
 			$redirect_url = apply_filters( 'dwpb_redirect_blog_page', $url );
-		
+
 		} elseif( is_date() ) {
-		
+
 			$redirect_url = apply_filters( 'dwpb_redirect_date_archive', $url );
-		
+
 		} else {
-			
+
 			$redirect_url = false;
-				
+
 		}
-		
+
 		// Get the current url and compare to the redirect, if they are the same, bail to avoid a loop
 		// If there is no redirect url, then also bail.
 		$protocol = stripos($_SERVER['SERVER_PROTOCOL'],'https') === true ? 'https://' : 'http://';
@@ -111,23 +114,23 @@ class Disable_Blog_Public {
 			return;
 		}
 
-        /**
-         * Filter to toggle the plugin's front-end redirection.
-         *
-         * @since 0.2.0
-         * @since 0.4.0 added the current_url param.
-         *
-         * @param bool  $bool True to enable, false to disable.
-         * @param string $redirect_url The url being used for the redirect.
-         * @param string $current_url The current url.
-         */
+		/**
+		 * Filter to toggle the plugin's front-end redirection.
+		 *
+		 * @since 0.2.0
+		 * @since 0.4.0 added the current_url param.
+		 *
+		 * @param bool  $bool True to enable, false to disable.
+		 * @param string $redirect_url The url being used for the redirect.
+		 * @param string $current_url The current url.
+		 */
 		if ( apply_filters( 'dwpb_redirect_front_end', true, $redirect_url, $current_url ) ) {
 			wp_safe_redirect( esc_url( $redirect_url ), 301 );
 			exit();
-        }
-        
+		}
+
 	}
-	
+
 	/**
 	 * Remove post type from query array.
 	 *
@@ -144,32 +147,32 @@ class Disable_Blog_Public {
 	public function remove_post_from_array_in_query( $query, $array, $filter = '' ) {
 
 		if ( is_array( $array ) && in_array( 'post', $array, true ) ) {
-            unset( $array['post'] );
-            
-            /**
-             * If there is a filter name passed, then a filter is applied on the array and query.
-             * 
-             * Used for 'dwpb_search_post_types' and 'dwpb_author_post_types' filters.
-             * 
-             * @see Disable_Blog_Public->modify_query
-             * 
-             * @since 0.4.0
-             * 
-             * @param array $array
-             * @param object $query
-             */
+			unset( $array['post'] );
+
+			/**
+			 * If there is a filter name passed, then a filter is applied on the array and query.
+			 * 
+			 * Used for 'dwpb_search_post_types' and 'dwpb_author_post_types' filters.
+			 * 
+			 * @see Disable_Blog_Public->modify_query
+			 * 
+			 * @since 0.4.0
+			 * 
+			 * @param array $array
+			 * @param object $query
+			 */
 			$set_to = empty( $filter ) ? $array : apply_filters( $filter, $array, $query );
 			if ( ! empty( $set_to ) && method_exists( $query, 'set' ) ) {
 				$query->set( 'post_type', $set_to );
 				return true;
-            }
-            
+			}
+
 		} // end if
 
-        return false;
-        
+		return false;
+
 	}
-	
+
 	/**
 	 * Modify query.
 	 *
@@ -184,29 +187,29 @@ class Disable_Blog_Public {
 	 * @since 0.4.0 added remove_post_from_array_in_query function
 	 */
 	public function modify_query( $query ) {
-		
+
 		// Bail if we're in the admin or not on the main query
 		if( is_admin() || ! $query->is_main_query() )
 			return;
-		
+
 		// Remove 'post' post_type from search results, replace with page
 		if ( $query->is_search() ) {
 			$in_search_post_types = get_post_types( array(
-                'exclude_from_search' => false,
-            ) );
+				'exclude_from_search' => false,
+			) );
 			$this->remove_post_from_array_in_query( $query, $in_search_post_types, 'dwpb_search_post_types' );
 		}
-	
+
 		// Remove Posts from Author Page
 		if ( $query->is_author() ) {
 			$author_post_types = get_post_types( array(
-                'publicly_queryable'  => true,
-                'exclude_from_search' => false,
-            ) );
+				'publicly_queryable'  => true,
+				'exclude_from_search' => false,
+			) );
 			$this->remove_post_from_array_in_query( $query, $author_post_types, 'dwpb_author_post_types' );
 		}
 	}
-	
+
 	/**
 	 * Disable Blog feeds.
 	 *
@@ -214,82 +217,82 @@ class Disable_Blog_Public {
 	 * @since 0.4.0 add $is_comment_feed variable to feeds and check $is_comment_feed prior to redirect.
 	 */
 	public function disable_feed( $is_comment_feed ) {
-		
+
 		// If this is a comment feed and comments are supported by other post types, bail
 		if( $is_comment_feed && dwpb_post_types_with_feature( 'comments' ) )
 			return;
-		
+
 		// Option to override this via filter and check to confirm post type
-        global $post;
-        
-        /**
-         * Toggle the disable feed via this filter.
-         * 
-         * @since 0.4.0
-         * 
-         * @param bool $bool True to cancel the feed, assuming it's a post feed.
-         * @param object $post Global post object.
-         * @param bool $is_comment_feed True if the feed is a comment feed.
-         */
+		global $post;
+
+		/**
+		 * Toggle the disable feed via this filter.
+		 * 
+		 * @since 0.4.0
+		 * 
+		 * @param bool $bool True to cancel the feed, assuming it's a post feed.
+		 * @param object $post Global post object.
+		 * @param bool $is_comment_feed True if the feed is a comment feed.
+		 */
 		if ( apply_filters( 'dwpb_disable_feed', true, $post, $is_comment_feed ) && isset( $post->post_type ) && 'post' === $post->post_type ) {
 
-            /**
-             * Filter the feed redirect url.
-             * 
-             * @since 0.4.0
-             * 
-             * @param string $url The redirect url (defaults to homepage)
-             * @param bool $is_comment_feed True if the feed is a comment feed.
-             */
+			/**
+			 * Filter the feed redirect url.
+			 * 
+			 * @since 0.4.0
+			 * 
+			 * @param string $url The redirect url (defaults to homepage)
+			 * @param bool $is_comment_feed True if the feed is a comment feed.
+			 */
 			$redirect_url = apply_filters( 'dwpb_redirect_feeds', home_url(), $is_comment_feed );
 
-            /**
-             * Filter to toggle on a message instead of a redirect.
-             * 
-             * Defaults to false, so a redirect is the expacted default behavior.
-             * 
-             * @since 0.4.0
-             * 
-             * @param bool $bool True to use a message, false to redirect.
-             * @param object $post Global post object.
-             * @param bool $is_comment_feed True if the feed is a comment feed.
-             */
+			/**
+			 * Filter to toggle on a message instead of a redirect.
+			 * 
+			 * Defaults to false, so a redirect is the expacted default behavior.
+			 * 
+			 * @since 0.4.0
+			 * 
+			 * @param bool $bool True to use a message, false to redirect.
+			 * @param object $post Global post object.
+			 * @param bool $is_comment_feed True if the feed is a comment feed.
+			 */
 			if ( apply_filters( 'dwpb_feed_message', false, $post, $is_comment_feed ) ) {
-                
-                // translators: the placeholser is the URL of our website
-                $message = sprintf( __( 'No feed available, please visit our <a href="%s">homepage</a>!', 'disable-blog' ), esc_url_raw( $redirect_url ) );
-                
-                /**
-                 * Filter the feed die message.
-                 * 
-                 * If the `dwpb_feed_message` is set to true, use this filter to set a custom message.
-                 * 
-                 * @since 0.4.0
-                 * 
-                 * @param string $message
-                 */
-                $message = apply_filters( 'dwpb_feed_die_message', $message );
-                $allowed_html = array(
-                    'a' => array(
-                        'href' => array(),
-                        'name' => array(),
-                        'id'   => array(),
-                    )
-                );
-                $safe_message = wp_kses( $message, $allowed_html );
+
+				// translators: the placeholser is the URL of our website
+				$message = sprintf( __( 'No feed available, please visit our <a href="%s">homepage</a>!', 'disable-blog' ), esc_url_raw( $redirect_url ) );
+
+				/**
+				 * Filter the feed die message.
+				 * 
+				 * If the `dwpb_feed_message` is set to true, use this filter to set a custom message.
+				 * 
+				 * @since 0.4.0
+				 * 
+				 * @param string $message
+				 */
+				$message = apply_filters( 'dwpb_feed_die_message', $message );
+				$allowed_html = array(
+					'a' => array(
+						'href' => array(),
+						'name' => array(),
+						'id'   => array(),
+					)
+				);
+				$safe_message = wp_kses( $message, $allowed_html );
 				wp_die( $safe_message );
 
 			// Default option: redirect to homepage
 			} else {
 
 				wp_safe_redirect( esc_url_raw( $redirect_url ), 301 );
-                exit;
-                
+				exit;
+
 			}
-			
+
 		}
 	}
-	
+
 	/**
 	 * Turn off the feed link.
 	 *
@@ -317,14 +320,14 @@ class Disable_Blog_Public {
 	 * @return boolean
 	 */
 	public function feed_links_show_comments_feed( $boolean ) {
-		
+
 		// If 'post' type is the only type supporting comments, then disable the comment feed link
 		if( ! dwpb_post_types_with_feature( 'comments' ) )
 			$boolean = false;
-		
-		return $boolean;
-	}
 
+		return $boolean;
+
+	}
 
 	/**
 	 * Remove 'post' type from the REST API results
@@ -337,13 +340,13 @@ class Disable_Blog_Public {
 	 */
 	public function modify_rest_api() {
 
-        /**
-         * Filter to toggle the disable rest API.
-         * 
-         * @since 0.4.2
-         * 
-         * @param bool $bool True to modify API, false to cancel.
-         */
+		/**
+		 * Filter to toggle the disable rest API.
+		 * 
+		 * @since 0.4.2
+		 * 
+		 * @param bool $bool True to modify API, false to cancel.
+		 */
 		if ( true !== apply_filters( 'dwpb_disable_rest_api', true ) ) {
 			return false;
 		}

--- a/public/class-disable-blog-public.php
+++ b/public/class-disable-blog-public.php
@@ -188,7 +188,7 @@ class Disable_Blog_Public {
 		
 		// Option to override this via filter and check to confirm post type
 		global $post;
-		if( apply_filters( 'dwpb_disable_feed', true, $post, $is_comment_feed ) && $post->post_type == 'post' ) {
+		if( apply_filters( 'dwpb_disable_feed', true, $post, $is_comment_feed ) && isset( $post->post_type ) && $post->post_type == 'post' ) {
 			$redirect_url = apply_filters( 'dwpb_redirect_feeds', home_url(), $is_comment_feed );
 			
 			// Provide option to show a message with a link instead of redirect

--- a/public/class-disable-blog-public.php
+++ b/public/class-disable-blog-public.php
@@ -4,7 +4,7 @@
  * The public-facing functionality of the plugin.
  *
  * @link       https://github.com/joshuadavidnelson/disable-blog
- * @since      1.0.0
+ * @since      0.2.0
  *
  * @package    Disable_Blog
  * @subpackage Disable_Blog/public
@@ -25,7 +25,7 @@ class Disable_Blog_Public {
 	/**
 	 * The ID of this plugin.
 	 *
-	 * @since    1.0.0
+	 * @since    0.2.0
 	 * @access   private
 	 * @var      string    $plugin_name    The ID of this plugin.
 	 */
@@ -34,7 +34,7 @@ class Disable_Blog_Public {
 	/**
 	 * The version of this plugin.
 	 *
-	 * @since    1.0.0
+	 * @since    0.2.0
 	 * @access   private
 	 * @var      string    $version    The current version of this plugin.
 	 */
@@ -43,7 +43,7 @@ class Disable_Blog_Public {
 	/**
 	 * Initialize the class and set its properties.
 	 *
-	 * @since    1.0.0
+	 * @since    0.2.0
 	 * @param      string    $plugin_name       The name of the plugin.
 	 * @param      string    $version    The version of this plugin.
 	 */
@@ -107,13 +107,25 @@ class Disable_Blog_Public {
 		// If there is no redirect url, then also bail.
 		$protocol = stripos($_SERVER['SERVER_PROTOCOL'],'https') === true ? 'https://' : 'http://';
 		$curent_url = esc_url( $protocol . $_SERVER["HTTP_HOST"] . $_SERVER["REQUEST_URI"] );
-		if( $redirect_url == $curent_url || ! $redirect_url )
+		if( $redirect_url == $curent_url || ! $redirect_url ) {
 			return;
-		
-		if( apply_filters( 'dwpb_redirect_front_end', true, $redirect_url ) ) {
-			wp_redirect( esc_url( $redirect_url ), 301 );
-			exit();
 		}
+
+        /**
+         * Filter to toggle the plugin's front-end redirection.
+         *
+         * @since 0.2.0
+         * @since 0.4.0 added the current_url param.
+         *
+         * @param bool  $bool True to enable, false to disable.
+         * @param string $redirect_url The url being used for the redirect.
+         * @param string $current_url The current url.
+         */
+		if ( apply_filters( 'dwpb_redirect_front_end', true, $redirect_url, $current_url ) ) {
+			wp_safe_redirect( esc_url( $redirect_url ), 301 );
+			exit();
+        }
+        
 	}
 	
 	/**
@@ -130,16 +142,32 @@ class Disable_Blog_Public {
 	 * @return boolean
 	 */
 	public function remove_post_from_array_in_query( $query, $array, $filter = '' ) {
-		if( is_array( $array ) && in_array( 'post', $array ) ) {
-			unset( $array[ 'post' ] );
+
+		if ( is_array( $array ) && in_array( 'post', $array, true ) ) {
+            unset( $array['post'] );
+            
+            /**
+             * If there is a filter name passed, then a filter is applied on the array and query.
+             * 
+             * Used for 'dwpb_search_post_types' and 'dwpb_author_post_types' filters.
+             * 
+             * @see Disable_Blog_Public->modify_query
+             * 
+             * @since 0.4.0
+             * 
+             * @param array $array
+             * @param object $query
+             */
 			$set_to = empty( $filter ) ? $array : apply_filters( $filter, $array, $query );
-			if( ! empty( $set_to ) && method_exists( $query, 'set' ) ) {
+			if ( ! empty( $set_to ) && method_exists( $query, 'set' ) ) {
 				$query->set( 'post_type', $set_to );
 				return true;
-			}
-		}
-		
-		return false;
+            }
+            
+		} // end if
+
+        return false;
+        
 	}
 	
 	/**
@@ -162,14 +190,19 @@ class Disable_Blog_Public {
 			return;
 		
 		// Remove 'post' post_type from search results, replace with page
-		if( $query->is_search() ) {
-			$in_search_post_types = get_post_types( array( 'exclude_from_search' => false ) );
+		if ( $query->is_search() ) {
+			$in_search_post_types = get_post_types( array(
+                'exclude_from_search' => false,
+            ) );
 			$this->remove_post_from_array_in_query( $query, $in_search_post_types, 'dwpb_search_post_types' );
 		}
 	
 		// Remove Posts from Author Page
-		if( $query->is_author() ) {
-			$author_post_types = get_post_types( array( 'publicly_queryable' => true, 'exclude_from_search' => false ) );
+		if ( $query->is_author() ) {
+			$author_post_types = get_post_types( array(
+                'publicly_queryable'  => true,
+                'exclude_from_search' => false,
+            ) );
 			$this->remove_post_from_array_in_query( $query, $author_post_types, 'dwpb_author_post_types' );
 		}
 	}
@@ -187,20 +220,71 @@ class Disable_Blog_Public {
 			return;
 		
 		// Option to override this via filter and check to confirm post type
-		global $post;
-		if( apply_filters( 'dwpb_disable_feed', true, $post, $is_comment_feed ) && isset( $post->post_type ) && $post->post_type == 'post' ) {
+        global $post;
+        
+        /**
+         * Toggle the disable feed via this filter.
+         * 
+         * @since 0.4.0
+         * 
+         * @param bool $bool True to cancel the feed, assuming it's a post feed.
+         * @param object $post Global post object.
+         * @param bool $is_comment_feed True if the feed is a comment feed.
+         */
+		if ( apply_filters( 'dwpb_disable_feed', true, $post, $is_comment_feed ) && isset( $post->post_type ) && 'post' === $post->post_type ) {
+
+            /**
+             * Filter the feed redirect url.
+             * 
+             * @since 0.4.0
+             * 
+             * @param string $url The redirect url (defaults to homepage)
+             * @param bool $is_comment_feed True if the feed is a comment feed.
+             */
 			$redirect_url = apply_filters( 'dwpb_redirect_feeds', home_url(), $is_comment_feed );
-			
-			// Provide option to show a message with a link instead of redirect
-			if( apply_filters( 'dwpb_feed_message', false, $post, $is_comment_feed ) ) {
-				$message = sprintf( 'No feed available, please visit our <a href="%s">homepage</a>!', esc_url_raw( $redirect_url ), 'disable-blog' );
-				$message = apply_filters( 'dwpb_feed_die_message', $message );
-				wp_die( $message );
-				
+
+            /**
+             * Filter to toggle on a message instead of a redirect.
+             * 
+             * Defaults to false, so a redirect is the expacted default behavior.
+             * 
+             * @since 0.4.0
+             * 
+             * @param bool $bool True to use a message, false to redirect.
+             * @param object $post Global post object.
+             * @param bool $is_comment_feed True if the feed is a comment feed.
+             */
+			if ( apply_filters( 'dwpb_feed_message', false, $post, $is_comment_feed ) ) {
+                
+                // translators: the placeholser is the URL of our website
+                $message = sprintf( __( 'No feed available, please visit our <a href="%s">homepage</a>!', 'disable-blog' ), esc_url_raw( $redirect_url ) );
+                
+                /**
+                 * Filter the feed die message.
+                 * 
+                 * If the `dwpb_feed_message` is set to true, use this filter to set a custom message.
+                 * 
+                 * @since 0.4.0
+                 * 
+                 * @param string $message
+                 */
+                $message = apply_filters( 'dwpb_feed_die_message', $message );
+                $allowed_html = array(
+                    'a' => array(
+                        'href' => array(),
+                        'name' => array(),
+                        'id'   => array(),
+                    )
+                );
+                $safe_message = wp_kses( $message, $allowed_html );
+				wp_die( $safe_message );
+
 			// Default option: redirect to homepage
 			} else {
-				wp_redirect( esc_url_raw( $redirect_url ), 301 );
-				exit;
+
+				wp_safe_redirect( esc_url_raw( $redirect_url ), 301 );
+                exit;
+                
 			}
 			
 		}
@@ -252,9 +336,18 @@ class Disable_Blog_Public {
 	 * @return boolean
 	 */
 	public function modify_rest_api() {
-		if( true !== apply_filters( 'dwpb_disable_rest_api', true ) )
-			return;
-		
+
+        /**
+         * Filter to toggle the disable rest API.
+         * 
+         * @since 0.4.2
+         * 
+         * @param bool $bool True to modify API, false to cancel.
+         */
+		if ( true !== apply_filters( 'dwpb_disable_rest_api', true ) ) {
+			return false;
+		}
+
 		global $wp_post_types;
 		$post_type_name = 'post';
 		

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: joshuadnelson
 Donate link: https://joshuadnelson.com/donate/
 Tags: remove blog, disable blog, disable settings, disable blogging, disable feeds, posts, feeds
 Requires at least: 3.1.0
-Tested up to: 4.9.8
+Tested up to: 5.1.1
 Stable tag: 0.4.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -59,6 +59,7 @@ Deactivate the plugin, delete your posts (which will delete related comments), a
 * Cleaned up the Reading settings, adding admin notices if front page is not set.
 * Add check for Multisite to avoid network page redirects. Closes #17, props to @Mactory.
 * Added Contributing and Code of Conduct documentation.
+* Check that `is_singular` works prior to running redirects to avoid non-object errors in feeds.
 
 = 0.4.6 =
 * Added check on disable feed functionality to confirm post type prior to disabling feed. 
@@ -138,6 +139,7 @@ A bunch of stuff:
 * Cleaned up the Reading settings, adding admin notices if front page is not set.
 * Add check for Multisite to avoid network page redirects. Closes #17, props to @Mactory.
 * Added Contributing and Code of Conduct documentation.
+* Check that `is_singular` works prior to running redirects to avoid non-object errors in feeds.
 
 = 0.4.6 =
 Added check on disable feed functionality to confirm post type prior to disabling feed.

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: joshuadnelson
 Donate link: https://joshuadnelson.com/donate/
 Tags: remove blog, disable blog, disable settings, disable blogging, disable feeds, posts, feeds
 Requires at least: 3.1.0
-Tested up to: 5.1.1
-Stable tag: 0.4.5
+Tested up to: 5.2.1
+Stable tag: 0.4.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -47,6 +47,9 @@ e.g.
 2. **I want to delete my posts and comments.** Deactivate the plugin, delete your posts (which will delete related comments), and delete any tags or categories you might want to remove as well. Then reactivate the plugin to hide everything.
 
 == Changelog ==
+
+= 0.4.6 =
+* Added check on disable feed functionality to confirm post type prior to disabling feed. 
 
 = 0.4.5 =
 * Remove the functionality hiding the Settings > Writing admin page, allow this option to be re-enabled via the older filter. This page used to be entirely related to posts, but is also used to select the editor type (Gutenberg vs Classic).
@@ -117,6 +120,9 @@ A bunch of stuff:
 * Hide other post-related reading options, except Search Engine Visibility
 
 == Upgrade Notice ==
+
+= 0.4.6 =
+Added check on disable feed functionality to confirm post type prior to disabling feed.
 
 = 0.4.5 =
 * Remove the functionality hiding the Settings > Writing admin page, allow this option to be re-enabled via the older filter. This page used to be entirely related to posts, but is also used to select the editor type (Gutenberg vs Classic).

--- a/readme.txt
+++ b/readme.txt
@@ -3,20 +3,22 @@ Contributors: joshuadnelson
 Donate link: https://joshuadnelson.com/donate/
 Tags: remove blog, disable blog, disable settings, disable blogging, disable feeds, posts, feeds
 Requires at least: 3.1.0
-Tested up to: 5.2.1
-Stable tag: 0.4.6
+Tested up to: 5.4.1
+Stable tag: 0.4.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-A plugin to disable the blog functionality of WordPress (by hiding, removing, and redirecting).
+All the power of WordPress, but without a blog.
 
 == Description ==
 
-This plugin to disables the blog functionality of WordPress, mostly by hiding admin pages and settings and redirecting pages on both the front-end and admin side. This can be useful when you want a WordPress site to remain static and hide blog-related elements from admin users to avoid confusion.
+Free your WordPress site from the blog! Maintain a static website without "posts."
 
-**Important**: If Settings > Reading > "Front Page Displays" is not set to show on a page, then this plugin will update it to that option, but **you still need to select a page to act as the front page**. Not doing so will mean that your post page can still be visible on the front-end of the site.
+This plugin to disables the "blog" functions of WordPress - mostly by hiding admin pages/settings and redirecting urls on both the front-end and admin portions of your site.
 
-**Comments**: Comments remain enabled, unless the 'post' type is the only type supporting comments (pages also typical support comments so they don't disappear in most cases). If you're looking to disable them completely, check out the [Disable Comments](https://wordpress.org/plugins/disable-comments/) plugin (by others).
+**Important**: If Settings > Reading > "Front Page Displays" is not set to show on a page, then this plugin will not function correctly. **You need to select a page to act as the home page**. Not doing so will mean that your post page can still be visible on the front-end of the site. Note that it's not required, but recommended you select a page for the  "posts page" setting, this page will be automatically redirected to the static "home page."
+
+**Comments**: Comments remain enabled, unless the 'post' type is the only type supporting comments (pages also support comments by default, so the comments section won't disappear in most cases). If you're looking to disable comments completely, check out the [Disable Comments](https://wordpress.org/plugins/disable-comments/) plugin.
 
 **Categories & Tags**: These are hidden and redirected, unless they are supported by a custom post type.
 
@@ -51,6 +53,12 @@ This could be done, but other post types (like Pages) may have comment support. 
 Deactivate the plugin, delete your posts (which will delete related comments), and delete any tags or categories you might want to remove as well. Then reactivate the plugin to hide everything.
 
 == Changelog ==
+
+= 0.4.7 =
+* Using GitHub actions publish on WP.org from github releases.
+* Cleaned up the Reading settings, adding admin notices if front page is not set.
+* Add check for Multisite to avoid network page redirects. Closes #17, props to @Mactory.
+* Added Constributing and Code of Contduct documentation.
 
 = 0.4.6 =
 * Added check on disable feed functionality to confirm post type prior to disabling feed. 
@@ -124,6 +132,12 @@ A bunch of stuff:
 * Hide other post-related reading options, except Search Engine Visibility
 
 == Upgrade Notice ==
+
+= 0.4.7 =
+* Using GitHub actions publish on WP.org from github releases.
+* Cleaned up the Reading settings, adding admin notices if front page is not set.
+* Add check for Multisite to avoid network page redirects. Closes #17, props to @Mactory.
+* Added Constributing and Code of Contduct documentation.
 
 = 0.4.6 =
 Added check on disable feed functionality to confirm post type prior to disabling feed.

--- a/readme.txt
+++ b/readme.txt
@@ -58,7 +58,7 @@ Deactivate the plugin, delete your posts (which will delete related comments), a
 * Using GitHub actions publish on WP.org from github releases.
 * Cleaned up the Reading settings, adding admin notices if front page is not set.
 * Add check for Multisite to avoid network page redirects. Closes #17, props to @Mactory.
-* Added Constributing and Code of Contduct documentation.
+* Added Contributing and Code of Conduct documentation.
 
 = 0.4.6 =
 * Added check on disable feed functionality to confirm post type prior to disabling feed. 
@@ -137,7 +137,7 @@ A bunch of stuff:
 * Using GitHub actions publish on WP.org from github releases.
 * Cleaned up the Reading settings, adding admin notices if front page is not set.
 * Add check for Multisite to avoid network page redirects. Closes #17, props to @Mactory.
-* Added Constributing and Code of Contduct documentation.
+* Added Contributing and Code of Conduct documentation.
 
 = 0.4.6 =
 Added check on disable feed functionality to confirm post type prior to disabling feed.


### PR DESCRIPTION
Prepped for version 0.4.7 release:
* Using GitHub actions publish on WP.org from github releases.
* Cleaned up the Reading settings, adding admin notices if front page is not set.
* Add check for Multisite to avoid network page redirects. Closes #17, props to @Mactory.
* Added Contributing and Code of Conduct documentation.
* Check that `is_singular` works prior to running redirects to avoid non-object errors in feeds, Closes #22.