### PR TITLE
Hide Posts, Categories, and Tags in Appearance > Menus

### DIFF
--- a/admin/class-disable-blog-admin.php
+++ b/admin/class-disable-blog-admin.php
@@ -437,7 +437,20 @@ class Disable_Blog_Admin {
 			update_option( 'page_on_front', apply_filters( 'dwpb_page_on_front', 1 ) );
 		}
 	}
-	
+
+	/**
+	 * Hide Posts, Categories, and Tags metabox in Appearance > Menus
+	 *
+	 * @since 0.5.0
+	 */
+	public function filter_nav_menu_meta_boxes( $object ) {
+		if ( is_object( $object ) && in_array( $object->name, array( 'post', 'category', 'post_tag' ), true ) ) {
+			return false;
+		}
+
+		return $object;
+	}
+
 	/**
 	 * Kill the Press This functionality
 	 * 

--- a/includes/class-disable-blog.php
+++ b/includes/class-disable-blog.php
@@ -260,7 +260,10 @@ class Disable_Blog {
 	
 		// Force Reading Settings
 		$this->loader->add_action( 'admin_init', $plugin_admin, 'reading_settings' );
-	
+
+		// Hide Posts, Categories, and Tags in Appearance > Menus
+		$this->loader->add_action( 'nav_menu_meta_box_object', $plugin_admin, 'filter_nav_menu_meta_boxes', 10, 1 );
+
 		// Remove Post via Email Settings
 		add_filter( 'enable_post_by_email_configuration', '__return_false' );
 	


### PR DESCRIPTION
See #8.

The [nav_menu_meta_box_object](https://developer.wordpress.org/reference/hooks/nav_menu_meta_box_object/) filter is available since WordPress 3.0, so this snippet should work with all supported WP versions (3.1 up).

I'm actually using slightly modern version of this snippet on my website, but hopefully this one does its job as well.