### PR TITLE
Fix 0.4.9 custom post type archive redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Changelog
 
+##### 0.4.10
+- Fix a bug from v0.4.9 that caused redirects on custom post type archives, correcting the `modify_query` function to only remove posts from built-in taxonomy archives, as that was the original intent.
+
 ##### 0.4.9
 - **Notice:** We've added the minimum PHP version requirement of 5.3, which was not explicitly set before now.
 - **Big change:** the plugin now changes the `post_type` arguments for posts so they are no longer public and removes all post_type support parameters. This disables the post-related admin redirects, as WordPress will now show users an error page stating "Sorry, you are not allowed to edit posts in this post type." It also pulls posts out of a lot of other locations (menus, etc) and is a much more efficient method of "disabling" the post type. This method is also used on built-in taxonomies, unless another post type supports them. **This change may impact other plugins or themes, be sure to back up your site and, if you can, test these changes prior to updating the plugin on a production site.**

--- a/disable-blog.php
+++ b/disable-blog.php
@@ -15,7 +15,7 @@
  * Plugin Name: Disable Blog
  * Plugin URI:  https://wordpress.org/plugins/disable-blog/
  * Description: Go blog-less with WordPress. This plugin disables all blog-related functionality (by hiding, removing, and redirecting).
- * Version:     0.4.9
+ * Version:     0.4.10
  * Author:      Joshua Nelson
  * Author URI:  http://joshuadnelson.com
  * License:     GPL-2.0+

--- a/includes/class-disable-blog-admin.php
+++ b/includes/class-disable-blog-admin.php
@@ -91,6 +91,7 @@ class Disable_Blog_Admin {
 
 			// remove supports.
 			$wp_post_types['post']->supports = array();
+
 		}
 
 	}

--- a/includes/class-disable-blog.php
+++ b/includes/class-disable-blog.php
@@ -76,7 +76,7 @@ class Disable_Blog {
 	public function __construct() {
 
 		$this->plugin_name = 'disable-blog';
-		$this->version     = '0.4.9';
+		$this->version     = '0.4.10';
 
 		do_action( 'dwpb_init' );
 

--- a/includes/class-disable-blog.php
+++ b/includes/class-disable-blog.php
@@ -98,6 +98,11 @@ class Disable_Blog {
 	 */
 	private static function upgrade_check() {
 
+		// let's only run these checks on the admin page load.
+		if ( ! is_admin() ) {
+			return;
+		}
+
 		// Get the current version option.
 		$current_version = get_option( 'dwpb_version', false );
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: remove blog, disable blog, disable settings, disable blogging, disable fee
 Requires at least: 3.1.0
 Requires PHP: 5.3
 Tested up to: 5.5.1
-Stable tag: 0.4.9
+Stable tag: 0.4.10
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -61,6 +61,9 @@ There are numerous filters available to change the way this plugin works. Refer 
 
 == Changelog ==
 
+= 0.4.10 =
+- Fix a bug from v0.4.9 that caused redirects on custom post type archives, correcting the `modify_query` function to only remove posts from built-in taxonomy archives, as that was the original intent.
+
 = 0.4.9 =
 - **Notice:** We've added the minimum PHP version requirement of 5.3, which was not explicitly set before now.
 - **Big change:** the plugin now changes the `post_type` arguments for posts so they are no longer public and removes all post_type support parameters. This disables the post-related admin redirects, as WordPress will now show users an error page stating "Sorry, you are not allowed to edit posts in this post type." It also pulls posts out of a lot of other locations (menus, etc) and is a much more efficient method of "disabling" the post type. This method is also used on built-in taxonomies, unless another post type supports them. **This change may impact other plugins or themes, be sure to back up your site and, if you can, test these changes prior to updating the plugin on a production site.**
@@ -172,6 +175,9 @@ A bunch of stuff:
 * Hide other post-related reading options, except Search Engine Visibility
 
 == Upgrade Notice ==
+
+= 0.4.10 =
+- Fix a bug from v0.4.9 that caused redirects on custom post type archives.
 
 = 0.4.9 =
 - **Notice:** We've added the minimum PHP version requirement of 5.3, which was not explicitly set before now.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,4 +6,4 @@
  * @package Disable_Blog
  */
 
-define( 'DWPB_VERSION', '0.4.9' );
+define( 'DWPB_VERSION', '0.4.10' );


### PR DESCRIPTION
Fix a bug from v0.4.9 that caused redirects on custom post type archives, correcting the `modify_query` function to only remove posts from built-in taxonomy archives, as that was the original intent.