### PR TITLE
v0.4.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Disable Blog
 ======================
 
-[![WordPress Plugin Version](https://img.shields.io/wordpress/plugin/v/disable-blog)](https://wordpress.org/plugins/disable-blog/)
+[![WordPress Plugin Version](https://img.shields.io/wordpress/plugin/v/disable-blog)](https://wordpress.org/plugins/disable-blog/) ![Downloads](https://img.shields.io/wordpress/plugin/dt/disable-blog.svg) ![Rating](https://img.shields.io/wordpress/plugin/r/disable-blog.svg)
 
 **Requires at least:** 3.1.0
 **Tested up to:** 5.5.1
@@ -18,12 +18,9 @@ Does the following:
 - Turns the `post` type into a non-public type, with support for zero post type features. Any attempts to edit or view posts within the admin screen will be met with a WordPress error page.
 
 - Front-end:
-	- Remove the Feed links from the header.
-	- Removes the feed link from front end (for WP >= 4.4.0), removes comment feed link if 'post' is the only post type supporting comments.
+	- Disables the post feed and remoives the feed links from the header (for WP >= 4.4.0) and disables the comment feed/removes comment feed link if 'post' is the only post type supporting comments (note that the default condition pages and attachments support comments).
 	- Removes posts from all archive pages.
-	- Disables the Feed for Posts.
-	- Remove 'post' post type from XML sitemaps and built-in taxonomies from XML sitemaps, if not being used by a custom post type (WP Version 5.5).
-	- Disable comments feed only if 'post' is only type shown.
+	- Remove 'post' post type from XML sitemaps and categories/tags from XML sitemaps, if not being used by a custom post type (WP Version 5.5).
 	- Disables the REST API for 'post' post type, as well as tags & categories (if not used by another custom post type).
 	- Disables XMLRPC for posts, as well as tags & categories (if not used by another custom post type).
 	- Redirects (301):
@@ -34,17 +31,16 @@ Does the following:
 - Admin side:
 	- Redirects tag and category pages to dashboard, unless used by a custom post type.
 	- If comments are not supported by other post types (by default comments are supported by pages and attachments), it will hide the menu links for and redirect discussion options page and 'Comments' admin page to the dashboard.
-	- Filters out the 'post' post type fromm 'Comments' admin page.
+	- Filters out the 'post' post type from 'Comments' admin page.
 	- Alters the comment count to remove any comments associated with 'post' post type.
 	- Optionally remove/redirect the Settings > Writting page via `dwpb_redirect_admin_options_writing` filter (default is false).
-	- Removes Available Tools from admin menu and redirects page (houses Press This and Category/Tag converter).
+	- Removes Available Tools from admin menu and redirects page to the dashboard (this admin page contains Press This and Category/Tag converter, both are no longer neededd without a blog).
 	- Removes Post from '+New' admin bar menu.
 	- Removes 'Posts' Admin Menu.
 	- Removes post-related dashboard widgets.
 	- Hides number of posts and comment count on Activity dashboard widget.
 	- Removes Post Related Widgets.
 	- Hide options in Reading Settings page related to posts (shows front page and search engine options).
-	- Places "Pages" above "Media" in admin menu and removes divider below dashboard.
 	- Removes 'Post' options on 'Menus' admin page.
 	- Filters 'post' post type out of main query.
 	- Disables "Press This" functionality.

--- a/includes/class-disable-blog-admin.php
+++ b/includes/class-disable-blog-admin.php
@@ -983,4 +983,23 @@ class Disable_Blog_Admin {
 
 	}
 
+	/**
+	 * Filters the default post display states used in the posts list table.
+	 *
+	 * @since 0.4.11
+	 *
+	 * @param string[] $post_states An array of post display states.
+	 * @param WP_Post  $post        The current post object.
+	 * @return array
+	 */
+	public function page_post_states( $post_states, $post ) {
+
+		if ( $this->has_front_page() && isset( $post->ID ) && absint( get_option( 'page_for_posts' ) ) === $post->ID ) {
+			// translators: This string is used to indicate that the blog page is redirected to the homepage.
+			$post_states['dwpb-redirected'] = __( 'Redirected to the homepage', 'disable-blog' );
+		}
+
+		return $post_states;
+	}
+
 }

--- a/includes/class-disable-blog-admin.php
+++ b/includes/class-disable-blog-admin.php
@@ -659,7 +659,7 @@ class Disable_Blog_Admin {
 			// translators: Prompt to configure the site for static homepage and posts page.
 			$message = __( 'Disable Blog is not fully active until a static page is selected for the site\'s homepage.', 'disable-blog' ) . $message_link;
 
-			printf( '<div class="%s"><p>%s</p></div>', 'notice notice-error', esc_attr( $message ) );
+			printf( '<div class="%s"><p>%s</p></div>', 'notice notice-error', wp_kses_post( $message ) );
 
 			// If we have a front page set, but no posts page or they are the same,.
 			// Then let the user know the expected behavior of these two.

--- a/includes/class-disable-blog-admin.php
+++ b/includes/class-disable-blog-admin.php
@@ -1002,4 +1002,22 @@ class Disable_Blog_Admin {
 		return $post_states;
 	}
 
+	/**
+	 * Removes the Site Health check for the post REST API.
+	 *
+	 * @uses dwpb_get_test_rest_availability()
+	 * @since 0.4.11
+	 * @param array $tests the tests, of course.
+	 * @return void
+	 */
+	public function site_status_tests( $tests ) {
+
+		if ( isset( $tests['direct']['rest_availability'] ) ) {
+			$tests['direct']['rest_availability']['test'] = 'dwpb_get_test_rest_availability';
+		}
+
+		return $tests;
+
+	}
+
 }

--- a/includes/class-disable-blog-admin.php
+++ b/includes/class-disable-blog-admin.php
@@ -187,6 +187,78 @@ class Disable_Blog_Admin {
 		$redirect_url = false;
 
 		/**
+		 * Redirect Edit Single Post to Dashboard.
+		 *
+		 * @since 0.4.0
+		 *
+		 * @param bool $bool True to redirect the edit-tags.php page, default is true.
+		 */
+		// @codingStandardsIgnoreStart - phpcs wants to sanitize this, but it's not necessary.
+		if ( apply_filters( 'dwpb_redirect_admin_edit_single_post', true )
+			&& $this->is_admin_page( 'post' )
+			&& ( isset( $_GET['post'] ) && 'post' == get_post_type( $_GET['post'] ) ) ) {
+			// @codingStandardsIgnoreEnd
+
+			/**
+			 * The redirect url used at the single post edit screen.
+			 *
+			 * @since 0.4.0
+			 *
+			 * @param string $url the url to redirct to, defaults to dashboard.
+			 */
+			$redirect_url = apply_filters( 'dwpb_redirect_single_post_edit', admin_url( '/index.php' ) );
+
+		}
+
+		/**
+		 * Redirect Edit Posts Screen to Edit Page.
+		 *
+		 * @since 0.4.0
+		 *
+		 * @param bool $bool True to redirect the edit-tags.php page, default is true.
+		 */
+		// @codingStandardsIgnoreStart - phpcs wants to sanitize this, but it's not necessary.
+		if ( apply_filters( 'dwpb_redirect_admin_edit_post', true )
+			&& $this->is_admin_page( 'edit' )
+			&& ( !isset( $_GET['post_type'] ) || isset( $_GET['post_type'] ) && $_GET['post_type'] == 'post' ) ) {
+			// @codingStandardsIgnoreEnd
+
+			/**
+			 * The redirect url used at the edit-tags.php and term.php pages.
+			 *
+			 * @since 0.4.0
+			 *
+			 * @param string $url the url to redirct to, defaults to dashboard.
+			 */
+			$redirect_url = apply_filters( 'dwpb_redirect_edit', admin_url( '/edit.php?post_type=page' ) );
+
+		}
+
+		/**
+		 * Redirect New Post to New Page.
+		 *
+		 * @since 0.4.0
+		 *
+		 * @param bool $bool True to redirect the edit-tags.php page, default is true.
+		 */
+		// @codingStandardsIgnoreStart - phpcs wants to sanitize this, but it's not necessary.
+		if ( apply_filters( 'dwpb_redirect_admin_post_new', true )
+			&& $this->is_admin_page( 'post-new' )
+			&& ( ! isset( $_GET['post_type'] ) || isset( $_GET['post_type'] ) && $_GET['post_type'] == 'post' ) ) {
+			// @codingStandardsIgnoreEnd
+
+			/**
+			 * The redirect url used at the edit-tags.php and term.php pages.
+			 *
+			 * @since 0.4.0
+			 *
+			 * @param string $url the url to redirct to, defaults to dashboard.
+			 */
+			$redirect_url = apply_filters( 'dwpb_redirect_post_new', admin_url( '/post-new.php?post_type=page' ) );
+
+		}
+
+		/**
 		 * Redirect admin page at edit tags screen.
 		 *
 		 * If this is either the edit-tags page or term page and the taxonomy is

--- a/includes/class-disable-blog.php
+++ b/includes/class-disable-blog.php
@@ -299,6 +299,9 @@ class Disable_Blog {
 		// Filter removal of widgets for some checks.
 		$this->loader->add_filter( 'dwpb_unregister_widgets', $plugin_admin, 'filter_widget_removal', 10, 2 );
 
+		// Custom Post State for the Blog Page redirect.
+		$this->loader->add_filter( 'display_post_states', $plugin_admin, 'page_post_states', 10, 2 );
+
 	}
 
 	/**

--- a/includes/class-disable-blog.php
+++ b/includes/class-disable-blog.php
@@ -307,6 +307,9 @@ class Disable_Blog {
 		// Custom Post State for the Blog Page redirect.
 		$this->loader->add_filter( 'display_post_states', $plugin_admin, 'page_post_states', 10, 2 );
 
+		// Remove REST API site health check related to posts.
+		$this->loader->add_filter( 'site_status_tests', $plugin_admin, 'site_status_tests', 10, 1 );
+
 	}
 
 	/**

--- a/includes/class-disable-blog.php
+++ b/includes/class-disable-blog.php
@@ -198,6 +198,11 @@ class Disable_Blog {
 		 */
 		require_once $includes_dir . '/class-disable-blog-public.php';
 
+		/**
+		 * Deprecated filters/hooks/etc.
+		 */
+		require_once $includes_dir . '/deprecated.php';
+
 		$this->loader = new Disable_Blog_Loader();
 
 	}

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Deprecated filters.
+ *
+ * Filters here for backwards compatibillity, being phased out of use.
+ *
+ * @link       https://github.com/joshuadavidnelson/disable-blog
+ * @since      0.4.11
+ * @package    Disable_Blog
+ * @subpackage Disable_Blog/includes
+ */
+
+add_filter( 'dwpb_redirect_admin_post', 'deprecated_redirect_admin_post_filter', 9, 1 );
+/**
+ * Original filter to toggle the admin post.php screen redirect.
+ *
+ * @since 0.4.11
+ * @param bool $bool true to redirect, false to not.
+ * @return bool
+ */
+function deprecated_redirect_admin_post_filter( $bool ) {
+
+	return apply_filters_deprecated( 'dwpb_redirect_admin_edit_single_post', array( $bool ), '0.4.11', 'dwpb_redirect_admin_post', 'This filter will be removed in version 0.5.0' );
+
+}
+
+add_filter( 'dwpb_redirect_post', 'deprecated_redirect_post_filter', 9, 1 );
+/**
+ * Original filter for the admin redirect url.
+ *
+ * @since 0.4.11
+ * @param string $url the redirect's destination url.
+ * @return string
+ */
+function deprecated_redirect_post_filter( $url ) {
+
+	return apply_filters_deprecated( 'dwpb_redirect_single_post_edit', array( $url ), '0.4.11', 'dwpb_redirect_post', 'This filter will be removed in version 0.5.0' );
+
+}
+
+add_filter( 'dwpb_redirect_admin_edit', 'deprecated_redirect_admin_edit_filter', 9, 1 );
+/**
+ * Original filter for toggling the admin edit.php redirect.
+ *
+ * @since 0.4.11
+ * @param bool $bool true to redirect, false to not.
+ * @return bool
+ */
+function deprecated_redirect_admin_edit_filter( $bool ) {
+
+	return apply_filters_deprecated( 'dwpb_redirect_admin_edit_post', array( $bool ), '0.4.11', 'dwpb_redirect_admin_edit', 'This filter will be removed in version 0.5.0' );
+
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -135,3 +135,113 @@ function dwpb_post_types_with_tax( $taxonomy, $args = array(), $output = 'names'
 	}
 
 }
+
+/**
+ * Replaces the core REST Availability Site Health check.
+ *
+ * Used by the site_status_tests filter in class-disable-blog-admin.php.
+ *
+ * Copied directly from https://developer.wordpress.org/reference/classes/wp_site_health/get_test_rest_availability/ but with the 'post' type updated to 'page' in the rest url.
+ *
+ * @see https://make.wordpress.org/core/2019/04/25/site-health-check-in-5-2/
+ * @since 0.4.11
+ * @return void
+ */
+function dwpb_get_test_rest_availability() {
+
+	$result = array(
+		'label'       => __( 'The REST API is available' ),
+		'status'      => 'good',
+		'badge'       => array(
+			'label' => __( 'Performance' ),
+			'color' => 'blue',
+		),
+		'description' => sprintf(
+			'<p>%s</p>',
+			__( 'The REST API is one way WordPress, and other applications, communicate with the server. One example is the block editor screen, which relies on this to display, and save, your posts and pages.' )
+		),
+		'actions'     => '',
+		'test'        => 'rest_availability',
+	);
+
+	$cookies = wp_unslash( $_COOKIE );
+	$timeout = 10;
+	$headers = array(
+		'Cache-Control' => 'no-cache',
+		'X-WP-Nonce'    => wp_create_nonce( 'wp_rest' ),
+	);
+	/** This filter is documented in wp-includes/class-wp-http-streams.php */
+	$sslverify = apply_filters( 'https_local_ssl_verify', false );
+
+	// Include Basic auth in loopback requests.
+	if ( isset( $_SERVER['PHP_AUTH_USER'] ) && isset( $_SERVER['PHP_AUTH_PW'] ) ) {
+		$headers['Authorization'] = 'Basic ' . base64_encode( wp_unslash( $_SERVER['PHP_AUTH_USER'] ) . ':' . wp_unslash( $_SERVER['PHP_AUTH_PW'] ) );
+	}
+
+	// -- here's the money, change this ti 'page' from 'post'.
+	$url = rest_url( 'wp/v2/types/page' );
+
+	// The context for this is editing with the new block editor.
+	$url = add_query_arg(
+		array(
+			'context' => 'edit',
+		),
+		$url
+	);
+
+	$r = wp_remote_get( $url, compact( 'cookies', 'headers', 'timeout', 'sslverify' ) );
+
+	if ( is_wp_error( $r ) ) {
+		$result['status'] = 'critical';
+
+		$result['label'] = __( 'The REST API encountered an error' );
+
+		$result['description'] .= sprintf(
+			'<p>%s</p>',
+			sprintf(
+				'%s<br>%s',
+				__( 'The REST API request failed due to an error.' ),
+				sprintf(
+					/* translators: 1: The WordPress error message. 2: The WordPress error code. */
+					__( 'Error: %1$s (%2$s)' ),
+					$r->get_error_message(),
+					$r->get_error_code()
+				)
+			)
+		);
+	} elseif ( 200 !== wp_remote_retrieve_response_code( $r ) ) {
+		$result['status'] = 'recommended';
+
+		$result['label'] = __( 'The REST API encountered an unexpected result' );
+
+		$result['description'] .= sprintf(
+			'<p>%s</p>',
+			sprintf(
+				/* translators: 1: The HTTP error code. 2: The HTTP error message. */
+				__( 'The REST API call gave the following unexpected result: (%1$d) %2$s.' ),
+				wp_remote_retrieve_response_code( $r ),
+				esc_html( wp_remote_retrieve_body( $r ) )
+			)
+		);
+	} else {
+		$json = json_decode( wp_remote_retrieve_body( $r ), true );
+
+		if ( false !== $json && ! isset( $json['capabilities'] ) ) {
+			$result['status'] = 'recommended';
+
+			$result['label'] = __( 'The REST API did not behave correctly' );
+
+			$result['description'] .= sprintf(
+				'<p>%s</p>',
+				sprintf(
+					/* translators: %s: The name of the query parameter being tested. */
+					__( 'The REST API did not process the %s query parameter correctly.' ),
+					'<code>context</code>'
+				)
+			);
+		}
+	}
+
+	return $result;
+
+}

--- a/readme.txt
+++ b/readme.txt
@@ -13,9 +13,42 @@ All the power of WordPress, but without a blog.
 
 == Description ==
 
-Free your WordPress site from the blog! Maintain a static website without "posts." Go blog-less with WordPress.
+Free your WordPress site from posts! Maintain a static website, a blog-less WordPress.
 
-This plugin disables all blog-related functionality, mostly by hiding admin pages/settings and redirecting urls on both the front-end and admin portions of your site.
+Disable Blog is a comprehensive plugin for to disable blogging functionality on your site. You'll be free to use pages and custom post types without the burden of a blog.
+
+The blog is "disabled" mostly by hiding blog-related admin pages/settings and redirecting urls on both the front-end and admin portions of your site. Specifically does the following:
+
+- Turns the `post` type into a non-public type, with support for zero post type features. Any attempts to edit or view posts within the admin screen will be met with a WordPress error page.
+
+- Front-end:
+	- Disables the post feed and remoives the feed links from the header (for WP >= 4.4.0) and disables the comment feed/removes comment feed link if 'post' is the only post type supporting comments (note that the default condition pages and attachments support comments).
+	- Removes posts from all archive pages.
+	- Remove 'post' post type from XML sitemaps and categories/tags from XML sitemaps, if not being used by a custom post type (WP Version 5.5).
+	- Disables the REST API for 'post' post type, as well as tags & categories (if not used by another custom post type).
+	- Disables XMLRPC for posts, as well as tags & categories (if not used by another custom post type).
+	- Redirects (301):
+		- All Single Posts & Post Archive urls to the homepage (requires a 'page' as your homepage in Settings > Reading)
+		- The blog page to the homepage.
+		- All Tag & Category archives to home page, unless they are supported by a custom post type.
+
+- Admin side:
+	- Redirects tag and category pages to dashboard, unless used by a custom post type.
+	- If comments are not supported by other post types (by default comments are supported by pages and attachments), it will hide the menu links for and redirect discussion options page and 'Comments' admin page to the dashboard.
+	- Filters out the 'post' post type from 'Comments' admin page.
+	- Alters the comment count to remove any comments associated with 'post' post type.
+	- Optionally remove/redirect the Settings > Writting page via `dwpb_redirect_admin_options_writing` filter (default is false).
+	- Removes Available Tools from admin menu and redirects page to the dashboard (this admin page contains Press This and Category/Tag converter, both are no longer neededd without a blog).
+	- Removes Post from '+New' admin bar menu.
+	- Removes 'Posts' Admin Menu.
+	- Removes post-related dashboard widgets.
+	- Hides number of posts and comment count on Activity dashboard widget.
+	- Removes Post Related Widgets.
+	- Hide options in Reading Settings page related to posts (shows front page and search engine options).
+	- Removes 'Post' options on 'Menus' admin page.
+	- Filters 'post' post type out of main query.
+	- Disables "Press This" functionality.
+	- Disables post by email configuration.
 
 **Important**: If Settings > Reading > "Front Page Displays" is not set to show on a page, then this plugin will not function correctly. **You need to select a page to act as the home page**. Not doing so will mean that your post page can still be visible on the front-end of the site. Note that it's not required, but recommended you select a page for the  "posts page" setting, this page will be automatically redirected to the static "home page."
 
@@ -32,7 +65,7 @@ If you have any posts, comments, categories, and/or tags, delete them prior to a
 **Support**: This plugin is maintained for free but **please reach out** and I will assist you as soon as possible. You can visit the [support forums](https://wordpress.org/support/plugin/disable-blog) or the [issue](https://github.com/joshuadavidnelson/disable-blog/issues) section of the [GitHub repository](https://github.com/joshuadavidnelson/disable-blog).
 
 = View on GitHub & Contribute =
-[View this plugin on GitHub](https://github.com/joshuadavidnelson/disable-blog) to see a comprehensive list of this plugin's functionality and the To-Do list of items yet to be included, as well as log any issues (or visit the WP support forums linked above).
+[View this plugin on GitHub](https://github.com/joshuadavidnelson/disable-blog) to contribute as well as log any issues (or visit the WP [support forums](https://wordpress.org/support/plugin/disable-blog)).
 
 Please feel free to contribute!
 


### PR DESCRIPTION
- Bring back some admin page redirects to account for use cases where direct access to `post.php`, `post-new.php`, etc occur. Closes #45.
- Dry out the admin redirect code, updating a few redirect-specific admin filters to a common format. Note that the following filters are now deprecated, replaced by new filters:
	- `dwpb_redirect_admin_edit_post` has been replaced by `dwpb_redirect_admin_edit`.
	- `dwpb_redirect_single_post_edit` has been replaced by `dwpb_redirect_post`.
	- `dwpb_redirect_admin_edit_single_post` has been replaced by `dwpb_redirect_admin_post`.
- Replace the REST API site health check (which usesthe `post` type with a matching function to queries the `page` type instead, this was throwing an error with the `post` type no longer in the REST endpoints. Closes #46.
- Fix issue with Reading Settings link in admin notice outputting raw HTML instead of a link. Closes #47.
- Bump minimum PHP to 5.6.
- Tested up to WP Core version 5.6.
- Updated minimum WP Core version to 4.0.