### PR TITLE
v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Changelog
 
+#### 0.5.3
+- Fix typeof typo in disable-blog-customizer.js from 0.5.2 updates for #59.
+- Fix uninstall error to allow for the plugin to be deleted.
+
 #### 0.5.2
 - Test up to WP 6.1.1
 - Increase minimum PHP to v7.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 ### Changelog
 
 #### 0.5.3
-- Fix typeof typo in disable-blog-customizer.js from 0.5.2 updates for #59.
-- Fix uninstall error to allow for the plugin to be deleted.
+- Fix `typeof` typo in `disable-blog-customizer.js` from 0.5.2 updates for #59.
+- Fix uninstall error to allow for the plugin to be deleted correctly.
+- Only fire comment related admin functions if comments are supported.
+- Limit the `get_comment_count` function to query only post types supporting comments. This allows for the post types to be modified via the `dwpb_post_types_supporting_comments` filter and avoids large queries on post types that aren't relevant (e.g. shop_order in WooCommerce). Closes #65
+- Add caching to the `dwpb_post_types_with_feature` function.
+- Create a plugin integration framework - simple class with "plugin active" checks and related integration functions, including the preexisting WooCommerce (version <= 2.6.2) comment count integration.
+- Add a Disable Comments integration, utilizing the `dwpb_post_types_supporting_comments` to turn off all Disable Blog comment-related functions if Disable Comments is active.
 
 #### 0.5.2
 - Test up to WP 6.1.1

--- a/assets/js/disable-blog-customizer.js
+++ b/assets/js/disable-blog-customizer.js
@@ -4,7 +4,7 @@
 	wp.customize.bind( 'ready', function() {
 
 		// Replace the default text in the homepage settings with the new version.
-		if ( typeof dwpbCustomizer.homepageSettingsText !== 'undefined' && wp.customize.section("static_front_page") !== 'undefined' ) {
+		if ( typeof dwpbCustomizer.homepageSettingsText !== 'undefined' && typeof wp.customize.section("static_front_page") !== 'undefined' ) {
 			wp.customize.section("static_front_page").container.find(".customize-section-description")[0].innerText = dwpbCustomizer.homepageSettingsText;
 		} // end if
 

--- a/disable-blog.php
+++ b/disable-blog.php
@@ -16,7 +16,7 @@
  * Plugin URI:  https://wordpress.org/plugins/disable-blog/
  * Description: Go blog-less with WordPress. This plugin disables all blog-related functionality (by hiding, removing, and redirecting).
  * Version:     0.5.2
- * Author:      Joshua Nelson
+ * Author:      Joshua David Nelson
  * Author URI:  http://joshuadnelson.com
  * License:     GPL-2.0+
  * License URI: http://www.gnu.org/licenses/gpl-2.0.txt

--- a/disable-blog.php
+++ b/disable-blog.php
@@ -15,7 +15,7 @@
  * Plugin Name: Disable Blog
  * Plugin URI:  https://wordpress.org/plugins/disable-blog/
  * Description: Go blog-less with WordPress. This plugin disables all blog-related functionality (by hiding, removing, and redirecting).
- * Version:     0.5.2
+ * Version:     0.5.3
  * Author:      Joshua David Nelson
  * Author URI:  http://joshuadnelson.com
  * License:     GPL-2.0+
@@ -59,7 +59,7 @@ register_deactivation_hook( __FILE__, 'deactivate_disable_blog' );
 define( 'DWPB_DIR', dirname( __FILE__ ) );
 define( 'DWPB_URL', plugins_url( '/', __FILE__ ) );
 define( 'DWPB_PLUGIN_NAME', 'disable-blog' );
-define( 'DWPB_VERSION', '0.5.2' );
+define( 'DWPB_VERSION', '0.5.3' );
 
 /**
  * The core plugin class that is used to define everything.

--- a/includes/class-disable-blog-admin.php
+++ b/includes/class-disable-blog-admin.php
@@ -900,27 +900,6 @@ class Disable_Blog_Admin {
 	}
 
 	/**
-	 * Turn the comments object back into an array if WooCommerce is active.
-	 *
-	 * This is only necessary for version of WooCommerce prior to 2.6.3, where it failed
-	 * to check/convert the $comment object into an array.
-	 *
-	 * @since 0.4.3
-	 * @param object $comments the array of comments.
-	 * @param int    $post_id  the post id.
-	 * @return array
-	 */
-	public function filter_woocommerce_comment_count( $comments, $post_id ) {
-
-		if ( 0 === $post_id && class_exists( 'WC_Comments' ) && function_exists( 'WC' ) && version_compare( WC()->version, '2.6.2', '<=' ) ) {
-			$comments = (array) $comments;
-		}
-
-		return $comments;
-
-	}
-
-	/**
 	 * Alter the comment counts on the admin comment table to remove comments associated with posts.
 	 *
 	 * @since 0.4.0

--- a/includes/class-disable-blog-admin.php
+++ b/includes/class-disable-blog-admin.php
@@ -952,7 +952,7 @@ class Disable_Blog_Admin {
 		// Get the post types that support comments.
 		$supported_post_types = dwpb_post_types_with_feature( 'comments' );
 
-		// Return an empty array of counts if there are no post types that support comments.
+		// Return an array of empty counts if there are no post types that support comments.
 		if ( empty( $supported_post_types ) || ! is_array( $supported_post_types ) ) {
 			return $comment_count;
 		}

--- a/includes/class-disable-blog-admin.php
+++ b/includes/class-disable-blog-admin.php
@@ -958,7 +958,10 @@ class Disable_Blog_Admin {
 		}
 
 		// Sanitizing the post type strings.
-		$in_post_types = implode( "','", array_map( 'esc_sql', $supported_post_types ) );
+		$sanitized_post_types = (array) array_map( 'esc_sql', $supported_post_types );
+
+		// Implode the post types into a string for the query.
+		$in_post_types = implode( "','", $sanitized_post_types );
 
 		// Grab the comments that are not associated with supported post types only.
 		// @codingStandardsIgnoreStart -- The get_results function doesn't need a wpdb->prepare here because $in_post_types is sanitized above.

--- a/includes/class-disable-blog-admin.php
+++ b/includes/class-disable-blog-admin.php
@@ -963,7 +963,7 @@ class Disable_Blog_Admin {
 		// Implode the post types into a string for the query.
 		$in_post_types = implode( "','", $sanitized_post_types );
 
-		// Grab the comments that are not associated with supported post types only.
+		// Grab the comments that are associated with supported post types only.
 		// @codingStandardsIgnoreStart -- The get_results function doesn't need a wpdb->prepare here because $in_post_types is sanitized above.
 		$totals = (array) $wpdb->get_results(
 			"SELECT comment_approved, COUNT( * ) AS total

--- a/includes/class-disable-blog-admin.php
+++ b/includes/class-disable-blog-admin.php
@@ -852,7 +852,7 @@ class Disable_Blog_Admin {
 	 *
 	 * @since 0.4.8
 	 * @param string $page the page slug.
-	 * @return boolean
+	 * @return bool
 	 */
 	public function is_admin_page( $page ) {
 

--- a/includes/class-disable-blog-admin.php
+++ b/includes/class-disable-blog-admin.php
@@ -961,7 +961,7 @@ class Disable_Blog_Admin {
 		$sanitized_post_types = (array) array_map( 'esc_sql', $supported_post_types );
 
 		// Implode the post types into a string for the query.
-		$in_post_types = implode( "','", $sanitized_post_types );
+		$in_post_types = implode( "','", $sanitized_post_types ); // phpcs:ignore - implode function updated in PHP 7.4 to follow 'string, array' order, phpstan throws and error saying it's wrong, but this is correct for supported PHP versions of this plugin.
 
 		// Grab the comments that are not associated with supported post types only.
 		// @codingStandardsIgnoreStart -- The get_results function doesn't need a wpdb->prepare here because $in_post_types is sanitized above.

--- a/includes/class-disable-blog-admin.php
+++ b/includes/class-disable-blog-admin.php
@@ -961,7 +961,7 @@ class Disable_Blog_Admin {
 		$sanitized_post_types = (array) array_map( 'esc_sql', $supported_post_types );
 
 		// Implode the post types into a string for the query.
-		$in_post_types = implode( "','", $sanitized_post_types ); // phpcs:ignore - implode function updated in PHP 7.4 to follow 'string, array' order, phpstan throws and error saying it's wrong, but this is correct for supported PHP versions of this plugin.
+		$in_post_types = implode( "','", $sanitized_post_types );
 
 		// Grab the comments that are not associated with supported post types only.
 		// @codingStandardsIgnoreStart -- The get_results function doesn't need a wpdb->prepare here because $in_post_types is sanitized above.

--- a/includes/class-disable-blog-integrations.php
+++ b/includes/class-disable-blog-integrations.php
@@ -29,14 +29,6 @@ class Disable_Blog_Integrations {
 	private $version;
 
 	/**
-	 * Object with common utility functions.
-	 *
-	 * @access private
-	 * @var    object
-	 */
-	private $functions;
-
-	/**
 	 * Initialize the class and set its properties.
 	 *
 	 * @param string $plugin_name The name of the plugin.
@@ -46,7 +38,6 @@ class Disable_Blog_Integrations {
 
 		$this->plugin_name = $plugin_name;
 		$this->version     = $version;
-		$this->functions   = new Disable_Blog_Functions();
 
 	}
 

--- a/includes/class-disable-blog-integrations.php
+++ b/includes/class-disable-blog-integrations.php
@@ -44,7 +44,10 @@ class Disable_Blog_Integrations {
 	/**
 	 * Check if the plugin is active.
 	 *
-	 * @param string $plugin
+	 * A wrapper function of is_plugin_active to call wp-admin/includes/plugin.php as needed.
+	 *
+	 * @see https://developer.wordpress.org/reference/functions/is_plugin_active/
+	 * @param string $plugin the plugin path.
 	 * @return bool
 	 */
 	public function is_plugin_active( $plugin ) {

--- a/includes/class-disable-blog-integrations.php
+++ b/includes/class-disable-blog-integrations.php
@@ -109,7 +109,7 @@ class Disable_Blog_Integrations {
 	 */
 	public function filter_woocommerce_comment_count( $comments, $post_id ) {
 
-		if ( 0 === $post_id && version_compare( WC()->version, '2.6.2', '<=' ) ) {
+		if ( 0 === $post_id && function_exists( 'WC' ) && version_compare( WC()->version, '2.6.2', '<=' ) ) {
 			$comments = (array) $comments;
 		}
 

--- a/includes/class-disable-blog-integrations.php
+++ b/includes/class-disable-blog-integrations.php
@@ -3,18 +3,22 @@
  * Integrations with other plugins.
  *
  * @link       https://github.com/joshuadavidnelson/disable-blog
+ * @since      0.5.3
  * @package    Disable_Blog
  * @subpackage Disable_Blog_Integrations
  */
 
 /**
  * Integrations with other plugins.
+ *
+ * @since 0.5.3
  */
 class Disable_Blog_Integrations {
 
 	/**
 	 * The ID of this plugin.
 	 *
+	 * @since  0.5.3
 	 * @access private
 	 * @var    string $plugin_name The ID of this plugin.
 	 */
@@ -23,6 +27,7 @@ class Disable_Blog_Integrations {
 	/**
 	 * The version of this plugin.
 	 *
+	 * @since  0.5.3
 	 * @access private
 	 * @var    string $version The current version of this plugin.
 	 */
@@ -31,6 +36,7 @@ class Disable_Blog_Integrations {
 	/**
 	 * Initialize the class and set its properties.
 	 *
+	 * @since 0.5.3
 	 * @param string $plugin_name The name of the plugin.
 	 * @param string $version     The version of this plugin.
 	 */
@@ -46,6 +52,7 @@ class Disable_Blog_Integrations {
 	 *
 	 * A wrapper function of is_plugin_active to call wp-admin/includes/plugin.php as needed.
 	 *
+	 * @since 0.5.3
 	 * @see https://developer.wordpress.org/reference/functions/is_plugin_active/
 	 * @param string $plugin the plugin path.
 	 * @return bool
@@ -69,6 +76,7 @@ class Disable_Blog_Integrations {
 	/**
 	 * Check if the Disable Comments plugin is active.
 	 *
+	 * @since 0.5.3
 	 * @return bool
 	 */
 	public function is_disable_comments_active() {
@@ -85,7 +93,7 @@ class Disable_Blog_Integrations {
 	/**
 	 * Check if WooCommerce is active.
 	 *
-	 * @since x.x.x
+	 * @since 0.5.3
 	 * @return bool
 	 */
 	public function is_woocommerce_active() {
@@ -106,6 +114,7 @@ class Disable_Blog_Integrations {
 	 * to check/convert the $comment object into an array.
 	 *
 	 * @since 0.4.3
+	 * @since 0.5.3 Moved to the Disable_Blog_Integrations class.
 	 * @param object $comments the array of comments.
 	 * @param int    $post_id  the post id.
 	 * @return array

--- a/includes/class-disable-blog-integrations.php
+++ b/includes/class-disable-blog-integrations.php
@@ -88,4 +88,42 @@ class Disable_Blog_Integrations {
 
 	}
 
+	/**
+	 * Check if WooCommerce is active.
+	 *
+	 * @since x.x.x
+	 * @return bool
+	 */
+	public function is_woocommerce_active() {
+
+		// Check if the Disable Comments plugin is active.
+		if ( $this->is_plugin_active( 'woocommerce/woocommerce.php' ) || function_exists( 'WC' ) ) {
+			return true;
+		}
+
+		return false;
+
+	}
+
+	/**
+	 * Turn the comments object back into an array if WooCommerce is active.
+	 *
+	 * This is only necessary for version of WooCommerce prior to 2.6.3, where it failed
+	 * to check/convert the $comment object into an array.
+	 *
+	 * @since 0.4.3
+	 * @param object $comments the array of comments.
+	 * @param int    $post_id  the post id.
+	 * @return array
+	 */
+	public function filter_woocommerce_comment_count( $comments, $post_id ) {
+
+		if ( 0 === $post_id && version_compare( WC()->version, '2.6.2', '<=' ) ) {
+			$comments = (array) $comments;
+		}
+
+		return $comments;
+
+	}
+
 }

--- a/includes/class-disable-blog-integrations.php
+++ b/includes/class-disable-blog-integrations.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Integrations with other plugins.
+ *
+ * @link       https://github.com/joshuadavidnelson/disable-blog
+ * @package    Disable_Blog
+ * @subpackage Disable_Blog_Integrations
+ */
+
+/**
+ * Integrations with other plugins.
+ */
+class Disable_Blog_Integrations {
+
+	/**
+	 * The ID of this plugin.
+	 *
+	 * @access private
+	 * @var    string $plugin_name The ID of this plugin.
+	 */
+	private $plugin_name;
+
+	/**
+	 * The version of this plugin.
+	 *
+	 * @access private
+	 * @var    string $version The current version of this plugin.
+	 */
+	private $version;
+
+	/**
+	 * Object with common utility functions.
+	 *
+	 * @access private
+	 * @var    object
+	 */
+	private $functions;
+
+	/**
+	 * Initialize the class and set its properties.
+	 *
+	 * @param string $plugin_name The name of the plugin.
+	 * @param string $version     The version of this plugin.
+	 */
+	public function __construct( $plugin_name, $version ) {
+
+		$this->plugin_name = $plugin_name;
+		$this->version     = $version;
+		$this->functions   = new Disable_Blog_Functions();
+
+	}
+
+	/**
+	 * Check if the plugin is active.
+	 *
+	 * @param string $plugin
+	 * @return bool
+	 */
+	public function is_plugin_active( $plugin ) {
+
+		// Check if the is_plugin_active function is available.
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			include_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		// Check if the the plugin is active.
+		if ( is_plugin_active( $plugin ) ) {
+			return true;
+		}
+
+		return false;
+
+	}
+
+}

--- a/includes/class-disable-blog-integrations.php
+++ b/includes/class-disable-blog-integrations.php
@@ -72,4 +72,20 @@ class Disable_Blog_Integrations {
 
 	}
 
+	/**
+	 * Check if the Disable Comments plugin is active.
+	 *
+	 * @return bool
+	 */
+	public function is_disable_comments_active() {
+
+		// Check if the Disable Comments plugin is active.
+		if ( $this->is_plugin_active( 'disable-comments/disable-comments.php' ) || class_exists( 'Disable_Comments' ) ) {
+			return true;
+		}
+
+		return false;
+
+	}
+
 }

--- a/includes/class-disable-blog.php
+++ b/includes/class-disable-blog.php
@@ -126,6 +126,7 @@ class Disable_Blog {
 	 * with WordPress.
 	 *
 	 * @since 0.4.0
+	 * @since 0.5.3 Added Integrations class.
 	 * @access private
 	 */
 	private function load_dependencies() {
@@ -184,6 +185,7 @@ class Disable_Blog {
 	 * of the plugin.
 	 *
 	 * @since 0.4.0
+	 * @since 0.5.3 Separated comment functions to run only if comments are supported.
 	 * @access private
 	 */
 	private function define_admin_hooks() {
@@ -341,6 +343,7 @@ class Disable_Blog {
 	/**
 	 * Integrate with other plugins.
 	 *
+	 * @since 0.5.3
 	 * @return void
 	 */
 	public function plugin_integrations() {

--- a/includes/class-disable-blog.php
+++ b/includes/class-disable-blog.php
@@ -347,6 +347,15 @@ class Disable_Blog {
 
 		$plugin_integrations = new Disable_Blog_Integrations( $this->get_plugin_name(), $this->get_version() );
 
+		// Disable Comments.
+		if ( $plugin_integrations->is_disable_comments_active() ) {
+
+			// If Disabled Comments is active, return false for post types supporting comments,
+			// and functionality in Disable Blog related to comments will be turned off,
+			// the assumption being that the Disable Comments plugin is handling it.
+			add_filter( 'dwpb_post_types_supporting_comments', '__return_false' );
+		}
+
 	}
 
 	/**

--- a/includes/class-disable-blog.php
+++ b/includes/class-disable-blog.php
@@ -356,6 +356,13 @@ class Disable_Blog {
 			add_filter( 'dwpb_post_types_supporting_comments', '__return_false' );
 		}
 
+		// WooCommerce.
+		if ( $plugin_integrations->is_woocommerce_active() && dwpb_post_types_with_feature( 'comments' ) ) {
+
+			// Convert the $comments object back into an array if older version of WooCommerce is active.
+			$this->loader->add_filter( 'wp_count_comments', $plugin_integrations, 'filter_woocommerce_comment_count', 15, 2 );
+		}
+
 	}
 
 	/**

--- a/includes/class-disable-blog.php
+++ b/includes/class-disable-blog.php
@@ -209,33 +209,14 @@ class Disable_Blog {
 		// Redirect Blog-related Admin Pages.
 		$this->loader->add_action( 'current_screen', $plugin_admin, 'redirect_admin_pages' );
 
-		// Filter comment counts in admin table.
-		$this->loader->add_filter( 'views_edit-comments', $plugin_admin, 'filter_admin_table_comment_count', 20, 1 );
-
-		// Filter post open status for comments and pings.
-		$this->loader->add_action( 'comments_open', $plugin_admin, 'filter_comment_status', 20, 2 );
+		// Filter post open status for pings.
 		$this->loader->add_action( 'pings_open', $plugin_admin, 'filter_comment_status', 20, 2 );
-
-		// Filter wp_count_comments, which addresses comments in admin bar.
-		$this->loader->add_filter( 'wp_count_comments', $plugin_admin, 'filter_wp_count_comments', 10, 2 );
-
-		// Convert the $comments object back into an array if older version of WooCommerce is active.
-		$this->loader->add_filter( 'wp_count_comments', $plugin_admin, 'filter_woocommerce_comment_count', 10, 2 );
 
 		// Remove Admin Bar Links.
 		$this->loader->add_action( 'wp_before_admin_bar_render', $plugin_admin, 'remove_admin_bar_links' );
 
-		// Filter Comments off Admin Page.
-		$this->loader->add_action( 'pre_get_comments', $plugin_admin, 'comment_filter', 10, 1 );
-
-		// Clear comments from 'post' post type.
-		$this->loader->add_filter( 'comments_array', $plugin_admin, 'filter_existing_comments', 20, 2 );
-
 		// Disable Update Services configruation, no pingbacks.
 		add_filter( 'enable_update_services_configuration', '__return_false' );
-
-		// Clear comments from 'post' post type.
-		$this->loader->add_filter( 'comments_array', $plugin_admin, 'filter_existing_comments', 20, 2 );
 
 		// Remove Dashboard Widgets.
 		$this->loader->add_action( 'admin_init', $plugin_admin, 'remove_dashboard_widgets' );
@@ -284,6 +265,26 @@ class Disable_Blog {
 
 		// Remove and update available permalink structure tags.
 		$this->loader->add_filter( 'available_permalink_structure_tags', $plugin_admin, 'available_permalink_structure_tags', 10, 1 );
+
+		// Only run comment related functions if comments are supported.
+		if ( dwpb_post_types_with_feature( 'comments' ) ) {
+
+			// Filter comment counts in admin table.
+			$this->loader->add_filter( 'views_edit-comments', $plugin_admin, 'filter_admin_table_comment_count', 20, 1 );
+
+			// Filter post open status for comments.
+			$this->loader->add_action( 'comments_open', $plugin_admin, 'filter_comment_status', 20, 2 );
+
+			// Filter wp_count_comments, which addresses comments in admin bar.
+			$this->loader->add_filter( 'wp_count_comments', $plugin_admin, 'filter_wp_count_comments', 10, 2 );
+
+			// Filter Comments off Admin Page.
+			$this->loader->add_action( 'pre_get_comments', $plugin_admin, 'comment_filter', 10, 1 );
+
+			// Clear comments from 'post' post type.
+			$this->loader->add_filter( 'comments_array', $plugin_admin, 'filter_existing_comments', 20, 2 );
+
+		}
 
 	}
 

--- a/includes/class-disable-blog.php
+++ b/includes/class-disable-blog.php
@@ -75,6 +75,7 @@ class Disable_Blog {
 		$this->upgrade_check();
 		$this->load_dependencies();
 		$this->set_locale();
+		$this->plugin_integrations();
 		$this->define_admin_hooks();
 		$this->define_public_hooks();
 
@@ -153,6 +154,7 @@ class Disable_Blog {
 			'Disable_Blog_Functions',
 			'Disable_Blog_Admin',
 			'Disable_Blog_Public',
+			'Disable_Blog_Integrations',
 		);
 		foreach ( $classes as $class ) {
 			$this->loader->autoLoader( $class );
@@ -333,6 +335,17 @@ class Disable_Blog {
 
 		// Conditionally remove author sitemaps, if author archives are not being supported.
 		$this->loader->add_filter( 'wp_sitemaps_add_provider', $plugin_public, 'wp_author_sitemaps', 100, 2 );
+
+	}
+
+	/**
+	 * Integrate with other plugins.
+	 *
+	 * @return void
+	 */
+	public function plugin_integrations() {
+
+		$plugin_integrations = new Disable_Blog_Integrations( $this->get_plugin_name(), $this->get_version() );
 
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -20,6 +20,7 @@
  * @since 0.1.0
  * @since 0.4.0 pulled out of class, unique function.
  * @since 0.5.0 added $args parameter for passing specific arguments to get_post_types.
+ * @since 0.5.3 added caching.
  * @see register_post_types(), get_post_types(), get_object_taxonomies()
  * @param string $feature the feature in question.
  * @param array  $args    the arguments passed to get_post_types.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -20,7 +20,6 @@ parameters:
         - '#^Property Disable_Blog_Public::\$version is never read, only written\.#'
         - '#^Property Disable_Blog_Integrations::\$plugin_name is never read, only written\.#'
         - '#^Property Disable_Blog_Integrations::\$version is never read, only written\.#'
-        # Implode is correctly used in get_comments_count, updated in PHP 7.4 to follow 'string, array' order, phpstan throws and error saying it's wrong, but this is correct for supported PHP versions of this plugin.
-        - '#^Parameter \#2 $array of function implode expects array\<string\>,
-         array\<array\|string\> given\.#'
+        # Implode is correctly used in get_comments_count for supported PHP versions of this plugin.
+        - '#^Parameter \#2 $array of function implode expects array\<string\>, array\<array\|string\> given\.#'
         - '#^Constant DWPB_URL not found\.#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -18,4 +18,6 @@ parameters:
         # errors we don't care about.
         - '#^Property Disable_Blog_Public::\$plugin_name is never read, only written\.#'
         - '#^Property Disable_Blog_Public::\$version is never read, only written\.#'
+        - '#^Property Disable_Blog_Integrations::$plugin_name is never read, only written\.#'
+        - '#^Property Disable_Blog_Integrations::$version is never read, only written\.#'
         - '#^Constant DWPB_URL not found\.#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -18,6 +18,6 @@ parameters:
         # errors we don't care about.
         - '#^Property Disable_Blog_Public::\$plugin_name is never read, only written\.#'
         - '#^Property Disable_Blog_Public::\$version is never read, only written\.#'
-        - '#^Property Disable_Blog_Integrations::$plugin_name is never read, only written\.#'
-        - '#^Property Disable_Blog_Integrations::$version is never read, only written\.#'
+        - '#^Property Disable_Blog_Integrations::\$plugin_name is never read, only written\.#'
+        - '#^Property Disable_Blog_Integrations::\$version is never read, only written\.#'
         - '#^Constant DWPB_URL not found\.#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -20,4 +20,7 @@ parameters:
         - '#^Property Disable_Blog_Public::\$version is never read, only written\.#'
         - '#^Property Disable_Blog_Integrations::\$plugin_name is never read, only written\.#'
         - '#^Property Disable_Blog_Integrations::\$version is never read, only written\.#'
+        # Implode is correctly used in get_comments_count, updated in PHP 7.4 to follow 'string, array' order, phpstan throws and error saying it's wrong, but this is correct for supported PHP versions of this plugin.
+        - '#^Parameter \#2 $array of function implode expects array\<string\>,
+         array\<array\|string\> given\.#'
         - '#^Constant DWPB_URL not found\.#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -21,5 +21,5 @@ parameters:
         - '#^Property Disable_Blog_Integrations::\$plugin_name is never read, only written\.#'
         - '#^Property Disable_Blog_Integrations::\$version is never read, only written\.#'
         # Implode is correctly used in get_comments_count for supported PHP versions of this plugin.
-        - '#^Parameter \#2 $array of function implode expects array\<string\>, array\<array\|string\> given\.#'
+        - '#^Parameter \#2 \$array of function implode expects array\<string\>, array\<array\|string\> given\.#'
         - '#^Constant DWPB_URL not found\.#'

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: remove blog, disable blog, disable settings, disable blogging, disable fee
 Requires at least: 4.0
 Requires PHP: 7.4
 Tested up to: 6.1.1
-Stable tag: 0.5.2
+Stable tag: 0.5.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -86,6 +86,10 @@ There are numerous filters available to change the way this plugin works. Refer 
 
 
 == Changelog ==
+
+= 0.5.3 =
+- Fix typeof typo in disable-blog-customizer.js from 0.5.2 updates for #59.
+- Fix uninstall error to allow for the plugin to be deleted.
 
 = 0.5.2 =
 - Test up to WP 6.1.1
@@ -279,12 +283,16 @@ A bunch of stuff:
 
 == Upgrade Notice ==
 
+= 0.5.3 =
+- Fix typeof typo in disable-blog-customizer.js from 0.5.2 updates for #59.
+- Fix uninstall error to allow for the plugin to be deleted.
+
 = 0.5.2 =
 - Tested up to WP 6.1.1
 - Increase minimum PHP to v7.4
 - Test to PHP 8.1
 - Update Github Actions to current versions.
-- Fix some bugs, few plugin changelog for specifics.
+- Fix some bugs, view the plugin's `changelog.md` for specifics.
 
 = 0.5.1 =
 - Update to documentation, readmes, and doc blocks.

--- a/readme.txt
+++ b/readme.txt
@@ -88,8 +88,13 @@ There are numerous filters available to change the way this plugin works. Refer 
 == Changelog ==
 
 = 0.5.3 =
-- Fix typeof typo in disable-blog-customizer.js from 0.5.2 updates for #59.
-- Fix uninstall error to allow for the plugin to be deleted.
+- Fix `typeof` typo in `disable-blog-customizer.js` from 0.5.2 updates.
+- Fix uninstall error to allow for the plugin to be deleted correctly.
+- Only fire comment related admin functions if comments are supported.
+- Limit the `get_comment_count` function to query only post types supporting comments. This allows for the post types to be modified via the `dwpb_post_types_supporting_comments` filter and avoids large queries on post types that aren't relevant (e.g. shop_order in WooCommerce).
+- Add caching to the `dwpb_post_types_with_feature` function.
+- Create a plugin integration framework - simple class with "plugin active" checks and related integration functions, including the preexisting WooCommerce (version <= 2.6.2) comment count integration.
+- Add a Disable Comments integration, utilizing the `dwpb_post_types_supporting_comments` to turn off all Disable Blog comment-related functions if Disable Comments is active.
 
 = 0.5.2 =
 - Test up to WP 6.1.1
@@ -284,11 +289,13 @@ A bunch of stuff:
 == Upgrade Notice ==
 
 = 0.5.3 =
-- Fix typeof typo in disable-blog-customizer.js from 0.5.2 updates for #59.
-- Fix uninstall error to allow for the plugin to be deleted.
+- Fix `typeof` typo in `disable-blog-customizer.js` from 0.5.2 updates.
+- Fix uninstall error to allow for the plugin to be deleted correctly.
+- Improve comment functions & caching of comment counts.
+- Create a plugin integration framework for integrations with WooCommerce and Disable Comment plugins.
 
 = 0.5.2 =
-- Tested up to WP 6.1.1
+- Tested up to WordPress v6.1.1
 - Increase minimum PHP to v7.4
 - Test to PHP 8.1
 - Update Github Actions to current versions.

--- a/uninstall.php
+++ b/uninstall.php
@@ -33,7 +33,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' )
 		|| empty( $_REQUEST )
 		|| ! isset( $_REQUEST['plugin'] )
 		|| ! isset( $_REQUEST['action'] )
-		|| 'plugin-name/plugin-name.php' !== $_REQUEST['plugin']
+		|| strpos( $_REQUEST['plugin'], 'disable-blog.php' ) === false
 		|| 'delete-plugin' !== $_REQUEST['action']
 		|| ! check_ajax_referer( 'updates', '_ajax_nonce' )
 		|| ! current_user_can( 'activate_plugins' )


### PR DESCRIPTION
- Fix `typeof` typo in `disable-blog-customizer.js` from 0.5.2 updates for #59.
- Fix uninstall error to allow for the plugin to be deleted correctly.
- Only fire comment related admin functions if comments are supported.
- Limit the `get_comment_count` function to query only post types supporting comments. This allows for the post types to be modified via the `dwpb_post_types_supporting_comments` filter and avoids large queries on post types that aren't relevant (e.g. shop_order in WooCommerce). Closes #65
- Add caching to the `dwpb_post_types_with_feature` function.
- Create a plugin integration framework - simple class with "plugin active" checks and related integration functions, including the preexisting WooCommerce (version <= 2.6.2) comment count integration.
- Add a Disable Comments integration, utilizing the `dwpb_post_types_supporting_comments` to turn off all Disable Blog comment-related functions if Disable Comments is active.