### PR TITLE
Fix typos including a bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@
 - In order to account for multiple subpages of a common parent page being removed the `dwpb_menu_subpages_to_remove` param has been updated to support an array of subpages in the format of `$remove_subpages['parent-page-slug.php'] = array( 'subpage-1.php', 'subpage-2.php' );`, though it still supports subpages as strings for backwards compatibility. Fixes bugs were `options-writing.php` and `options-discussion.php` were conflicting.
 
 **Improvements/Updates**
-- Update admin filters to a common format and removing redundent filters. Filter changes include:
+- Update admin filters to a common format and removing redundant filters. Filter changes include:
 	- New filter: `dwpb_redirect_admin_url` filters the final url used in admin redirects.
 	- `dwpb_redirect_admin` only accepts 1 parameter, the previous version accepted 3 (dropping `$redirect_url` & `$current_url`).
 	- `dwpb_redirect_admin_edit_post` is now `dwpb_redirect_admin_edit`.
@@ -69,7 +69,7 @@
 	- `dwpb_redirect_edit_tax` has been removed. Use `dwpb_redirect_admin_edit_tags` or `dwpb_redirect_admin_term` instead, depending on the context.
 	- `dwpb_redirect_edit_comments` has been removed. use `dwpb_redirect_admin_edit_comments` instead.
 	- `dwpb_redirect_options_discussion` has been removed. Use `dwpb_redirect_admin_options_discussion` instead.
-	- The filter `dwpb_redirect_admin_options_writing` that would pass a boolean to toggle off the options writing page has been remaned `dwpb_remove_options_writing` and must be passed with `true` in order to have the page redirect _and_ the admin menu item removed. By default the value filtered is false and the options Writing page does not go away, as numerous other plugins use this page for non-blog related settings. Now `dwpb_redirect_admin_options_writing` is used to filter the redirect url itself, replacing the previously named `dwpb_redirect_options_writing` filter.  
+	- The filter `dwpb_redirect_admin_options_writing` that would pass a boolean to toggle off the options writing page has been remained `dwpb_remove_options_writing` and must be passed with `true` in order to have the page redirect _and_ the admin menu item removed. By default the value filtered is false and the options Writing page does not go away, as numerous other plugins use this page for non-blog related settings. Now `dwpb_redirect_admin_options_writing` is used to filter the redirect url itself, replacing the previously named `dwpb_redirect_options_writing` filter.  
 	- `dwpb_redirect_options_tools` has been removed. Use `dwpb_redirect_admin_options_tools` instead.
 	- New filter: `dwpb_disabled_xmlpc_methods` (see above).
 	- New filter: `dwpb_author_archive_post_types` (see above).

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Activating Disable Blog does the following:
 - Turns the `post` type into a non-public content type, with support for zero post type features. Any attempts to edit or view posts within the admin screen will be met with a WordPress error page or be redirect to the homepage.
 
 - Front-end:
-	- Disables the post feed and remoives the feed links from the header (for WP >= 4.4.0) and disables the comment feed/removes comment feed link if 'post' is the only post type supporting comments (note that the default condition pages and attachments support comments).
+	- Disables the post feed and removes the feed links from the header (for WP >= 4.4.0) and disables the comment feed/removes comment feed link if 'post' is the only post type supporting comments (note that the default condition pages and attachments support comments).
 	- Removes posts from all archive pages.
 	- Remove 'post' post type from XML sitemaps and categories/tags from XML sitemaps, if not being used by a custom post type (WP Version 5.5).
 	- Disables the REST API for 'post' post type, as well as tags & categories (if not used by another custom post type).
@@ -59,7 +59,7 @@ Activating Disable Blog does the following:
 	- If comments are not supported by other post types (by default comments are supported by pages and attachments), it will hide the menu links for and redirect discussion options page and 'Comments' admin page to the dashboard.
 	- Filters out the 'post' post type from 'Comments' admin page.
 	- Alters the comment count to remove any comments associated with 'post' post type.
-	- Optionally remove/redirect the Settings > Writting page via `dwpb_remove_options_writing` filter (default is false).
+	- Optionally remove/redirect the Settings > Writing page via `dwpb_remove_options_writing` filter (default is false).
 	- Removes Available Tools from admin menu and redirects page to the dashboard (this admin page contains Press This and Category/Tag converter, both are no longer neededd without a blog).
 	- Removes Post from '+New' admin bar menu.
 	- Removes 'Posts' Admin Menu.

--- a/includes/class-disable-blog-activator.php
+++ b/includes/class-disable-blog-activator.php
@@ -116,7 +116,7 @@ class Disable_Blog_Activator {
 	/**
 	 * Validate the Request data.
 	 *
-	 * Validates the $_REQUESTed data is matching this plugin and action.
+	 * Validates the data in $_REQUEST is matching this plugin and action.
 	 *
 	 * @since 0.5.1
 	 * @param string $plugin The Plugin folder/name.php.

--- a/includes/class-disable-blog-admin.php
+++ b/includes/class-disable-blog-admin.php
@@ -104,7 +104,7 @@ class Disable_Blog_Admin {
 			$arguments_to_remove = array(
 				'has_archive',
 				'public',
-				'publicaly_queryable',
+				'publicly_queryable',
 				'rewrite',
 				'query_var',
 				'show_ui',
@@ -167,7 +167,7 @@ class Disable_Blog_Admin {
 					$arguments_to_remove = array(
 						'has_archive',
 						'public',
-						'publicaly_queryable',
+						'publicly_queryable',
 						'query_var',
 						'show_ui',
 						'show_tagcloud',
@@ -511,7 +511,7 @@ class Disable_Blog_Admin {
 		 * Admin subpages to be removed.
 		 *
 		 * @since 0.4.0
-		 * @since 0.5.0 in order to account for mulitple subpages with a common parent
+		 * @since 0.5.0 in order to account for multiple subpages with a common parent
 		 *               the `subpages` are now in arrays
 		 * @param array $remove_subpages Array of page => subpages where subpages is an array of strings.
 		 */
@@ -644,7 +644,7 @@ class Disable_Blog_Admin {
 			/**
 			 * Filter to change the dashboard widgets beinre removed.
 			 *
-			 * Filter name baed on the name of the widget above,
+			 * Filter name based on the name of the widget above,
 			 * For instance: `dwpb_disable_dashboard_quick_press` for the Quick Press widget.
 			 *
 			 * @since 0.4.1
@@ -765,7 +765,7 @@ class Disable_Blog_Admin {
 		foreach ( $widgets as $widget ) {
 
 			/**
-			 * The ability to stop the widget unregsiter.
+			 * The ability to stop the widget unregister.
 			 *
 			 * @since 0.4.0
 			 *
@@ -925,7 +925,7 @@ class Disable_Blog_Admin {
 	}
 
 	/**
-	 * Retreive the comment counts without the 'post' comments.
+	 * Retrieve the comment counts without the 'post' comments.
 	 *
 	 * @since 0.4.0
 	 * @since 0.4.3 Removed Unused "count" function.
@@ -1273,7 +1273,7 @@ class Disable_Blog_Admin {
 		$post_types = $this->user_column_post_types();
 		foreach ( $post_types as $post_type ) {
 			/**
-			 * Create a new column for 'pages' similar to the orginal 'post' column.
+			 * Create a new column for 'pages' similar to the original 'post' column.
 			 *
 			 * @since 0.5.0
 			 * @param bool $bool True to remove the column, defaults to true.
@@ -1356,7 +1356,7 @@ class Disable_Blog_Admin {
 		// Include any post types using author archives.
 		$post_types = $this->functions->author_archive_post_types();
 
-		// The author_archive_post_type function returns false if empy, but we need an array.
+		// The author_archive_post_type function returns false if empty, but we need an array.
 		$post_types = empty( $post_types ) ? array() : $post_types;
 
 		// Also include pages, which is not in the author archive by default,

--- a/includes/class-disable-blog-deactivator.php
+++ b/includes/class-disable-blog-deactivator.php
@@ -116,7 +116,7 @@ class Disable_Blog_Deactivator {
 	/**
 	 * Validate the Request data.
 	 *
-	 * Validates the $_REQUESTed data is matching this plugin and action.
+	 * Validates the data in $_REQUEST is matching this plugin and action.
 	 *
 	 * @since 0.5.1
 	 * @param string $plugin The Plugin folder/name.php.

--- a/includes/class-disable-blog-functions.php
+++ b/includes/class-disable-blog-functions.php
@@ -45,7 +45,7 @@ class Disable_Blog_Functions {
 		/**
 		 * Should we pass url query string in the redirect?
 		 *
-		 * Deault is false.
+		 * Default is false.
 		 *
 		 * @since 0.5.0
 		 * @param bool $bool true to allow query strings on redirect.

--- a/includes/class-disable-blog.php
+++ b/includes/class-disable-blog.php
@@ -219,7 +219,7 @@ class Disable_Blog {
 		// Remove Admin Bar Links.
 		$this->loader->add_action( 'wp_before_admin_bar_render', $plugin_admin, 'remove_admin_bar_links' );
 
-		// Disable Update Services configruation, no pingbacks.
+		// Disable Update Services configuration, no pingbacks.
 		add_filter( 'enable_update_services_configuration', '__return_false' );
 
 		// Remove Dashboard Widgets.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -65,7 +65,7 @@ function dwpb_post_types_with_feature( $feature, $args = array() ) {
 	 * be disabled and the options-discussion.php admin page redirected.
 	 *
 	 * @since 0.4.0
-	 * @since 0.5.0 Added the $args paramenter.
+	 * @since 0.5.0 Added the $args parameter.
 	 * @param array|bool $post_types_with_feature an array of post types support this feature or false if none.
 	 * @param array      $args                    the arguments passed to get_post_types.
 	 * @return array|bool A list of post type names that support the featured or false if nothing found.
@@ -136,7 +136,7 @@ function dwpb_post_types_with_tax( $taxonomy, $args = array(), $output = 'names'
 	 *
 	 * @since 0.4.0
 	 * @param mixed         $null                Null for no override, otherwise pass an array of post type slugs.
-	 * @param string|object $taxonomy            The curent taxonomy slug.
+	 * @param string|object $taxonomy            The current taxonomy slug.
 	 * @param array|bool    $post_types_with_tax An array of post types use this taxonomy or false if none.
 	 * @param array         $args                An array of key => value arguments to match against the post type objects. Default empty array.
 	 * @param string        $output              The type of output to return, either 'names' or 'objects'.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -19,7 +19,6 @@ parameters:
         - '#^Property Disable_Blog_Public::\$plugin_name is never read, only written\.#'
         - '#^Property Disable_Blog_Public::\$version is never read, only written\.#'
         - '#^Property Disable_Blog_Integrations::\$plugin_name is never read, only written\.#'
-        - '#^Property Disable_Blog_Integrations::\$version is never read, only written\.#'
         # Implode is correctly used in get_comments_count for supported PHP versions of this plugin.
         - '#^Parameter \#2 \$array of function implode expects array\<string\>, array\<array\|string\> given\.#'
         - '#^Constant DWPB_URL not found\.#'

--- a/readme.txt
+++ b/readme.txt
@@ -147,7 +147,7 @@ There are numerous filters available to change the way this plugin works. Refer 
 
 **Improvements/Updates**
 
-- Update admin filters to a common format and removing redundent filters. Filter changes include:
+- Update admin filters to a common format and removing redundant filters. Filter changes include:
 	- New filter: `dwpb_redirect_admin_url` filters the final url used in admin redirects.
 	- `dwpb_redirect_admin` only accepts 1 parameter, the previous version accepted 3 (dropping `$redirect_url` & `$current_url`).
 	- `dwpb_redirect_admin_edit_post` is now `dwpb_redirect_admin_edit`.
@@ -156,7 +156,7 @@ There are numerous filters available to change the way this plugin works. Refer 
 	- `dwpb_redirect_edit_tax` has been removed. Use `dwpb_redirect_admin_edit_tags` or `dwpb_redirect_admin_term` instead, depending on the context.
 	- `dwpb_redirect_edit_comments` has been removed. use `dwpb_redirect_admin_edit_comments` instead.
 	- `dwpb_redirect_options_discussion` has been removed. Use `dwpb_redirect_admin_options_discussion` instead.
-	- The filter `dwpb_redirect_admin_options_writing` that would pass a boolean to toggle off the options writing page has been remaned `dwpb_remove_options_writing` and must be passed with `true` in order to have the page redirect _and_ the admin menu item removed. By default the value filtered is false and the options Writing page does not go away, as numerous other plugins use this page for non-blog related settings. Now `dwpb_redirect_admin_options_writing` is used to filter the redirect url itself, replacing the previously named `dwpb_redirect_options_writing` filter.
+	- The filter `dwpb_redirect_admin_options_writing` that would pass a boolean to toggle off the options writing page has been remained `dwpb_remove_options_writing` and must be passed with `true` in order to have the page redirect _and_ the admin menu item removed. By default the value filtered is false and the options Writing page does not go away, as numerous other plugins use this page for non-blog related settings. Now `dwpb_redirect_admin_options_writing` is used to filter the redirect url itself, replacing the previously named `dwpb_redirect_options_writing` filter.
 	- `dwpb_redirect_options_tools` has been removed. Use `dwpb_redirect_admin_options_tools` instead.
 	- New filter: `dwpb_disabled_xmlpc_methods` (see above).
 	- New filter: `dwpb_author_archive_post_types` (see above).

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Bootsrap file for tests.
+ * Bootstrap file for tests.
  *
  * @since 0.4.9
  * @package Disable_Blog


### PR DESCRIPTION
Found some misspellings.

The bug is in the word https://github.com/search?q=repo%3AWordPress%2FWordPress%20publicly_queryable&type=code
