### PR TITLE
Add GitBook documentation site

### DIFF
--- a/.dev/specs/2026-08-05-gitbook-docs-design.md
+++ b/.dev/specs/2026-08-05-gitbook-docs-design.md
@@ -2,6 +2,7 @@
 
 **Date:** 2026-08-05
 **Status:** Approved
+**Documents plugin version:** 0.5.6
 
 ## Goal
 
@@ -12,16 +13,28 @@ uninstall, and extend the plugin.
 The docs will publish at `docs.disable.blog`. Until that is live, all internal links are
 relative so they resolve correctly on GitHub.
 
+## Version and branch
+
+This branch is based on `stable` (0.5.5), but the docs describe **0.5.6**, which is in
+development on `e2e/playwright`. 0.5.6 changes the public filter surface enough that
+documenting 0.5.5 would be wrong on release day.
+
+Every source detail is read from `e2e/playwright`, not from the checked-out `stable`
+tree.
+
+Only new files are added, so nothing conflicts with the 0.5.6 work in flight.
+
 ## Writing rules
 
 These apply to every page.
 
 - No em dashes.
 - Brief, plainly readable by end users. Short declarative sentences, second person.
-- Document the plugin's current released state. Include version nuance only when it
-  changes what a user sees or does, written as a "Changed in X.Y.Z" callout.
-- No references to intermediate work, branches, or internal process. If it does not
+- Document the plugin's released behavior. Include version nuance only when it changes
+  what a user sees or does, written as a "Changed in X.Y.Z" callout.
+- Do not document bugs, known issues, or anything about work in progress. If it does not
   impact a user on a release branch, it does not go in.
+- No references to branches, refactors, or internal process.
 
 Match the conventions in the archived-post-status `docs/` folder:
 `{% hint style="warning" %}` for cautions, `{% code overflow="wrap" %}` for shell and PHP
@@ -65,15 +78,15 @@ structure:
 
 ## Files modified
 
-**`README.md`.** Keeps the badges, description, static front page warning, support,
-contributing, and local development sections. The "How does this plugin work?" list and
-the FAQ section are replaced by a Documentation section linking into `docs/` with
-relative paths.
+None. `README.md`, `readme.txt`, and `.distignore` are left untouched so the 0.5.6 work
+in flight can absorb those edits.
 
-**`.distignore`.** Add `/docs/` and `.gitbook.yaml` so neither ships in the
-WordPress.org plugin ZIP. The current file excludes neither.
+Two follow-ups are handed back rather than done here:
 
-**`readme.txt`.** Untouched. The WordPress.org readme stays self-contained.
+1. `.distignore` needs `/docs/` and `.gitbook.yaml` added, or the docs ship inside the
+   WordPress.org plugin ZIP. The current file excludes neither.
+2. `README.md` can drop its "How does this plugin work?" list and FAQ in favor of links
+   into `docs/`, once the docs are live.
 
 ## Table of contents
 
@@ -123,10 +136,11 @@ comment handling, dashboard widgets, Reading and Writing settings, the user tabl
 to Pages column swap, taxonomy count corrections, and the Site Health REST check
 replacement.
 
-The admin redirect table lists only the screens that actually redirect in 0.5.5:
-`post.php`, `edit.php`, `post-new.php`, `edit-tags.php`, `edit-comments.php`,
-`options-discussion.php`, and `options-writing.php`. Tools is described as removed from
-the menu, not redirected.
+The admin redirect table lists all nine screens that redirect: `post.php`, `edit.php`,
+`post-new.php`, `term.php`, `edit-tags.php`, `edit-comments.php`,
+`options-discussion.php`, `options-writing.php`, and `tools.php`.
+
+Dashboard widgets removed are Quick Press and Activity.
 
 **Your Content & Data.** Nothing is deleted. Posts, categories, tags, and comments stay
 in the database but become inaccessible while the plugin is active. Explains how to
@@ -150,7 +164,7 @@ entries grouped by area: Redirects, Front-End, Admin, and Post Types & Taxonomie
 entry gives a description, Since version, parameters, return value, and a runnable
 example.
 
-Covers 25 named filters:
+Covers 26 named filters:
 
 `dwpb_pass_query_string_on_redirect`, `dwpb_allowed_query_vars`,
 `dwpb_redirect_status_code`, `dwpb_redirect_front_end`, `dwpb_front_end_redirect_url`,
@@ -159,40 +173,39 @@ Covers 25 named filters:
 `dwpb_disable_author_archives`, `dwpb_author_archive_post_types`,
 `dwpb_tag_post_types`, `dwpb_category_post_types`, `dwpb_taxonomy_support`,
 `dwpb_disabled_xmlrpc_methods`, `dwpb_remove_pingback_header`,
-`dwpb_disable_user_sitemap`, `dwpb_menu_pages_to_remove`,
-`dwpb_menu_subpages_to_remove`, `dwpb_remove_options_writing`,
-`dwpb_unregister_widgets`, `dwpb_admin_user_post_types`, and
-`dpwb_disable_user_post_column`.
+`dwpb_disable_user_sitemap`, `dwpb_disable_removed_sitemaps`,
+`dwpb_menu_pages_to_remove`, `dwpb_menu_subpages_to_remove`,
+`dwpb_remove_options_writing`, `dwpb_unregister_widgets`,
+`dwpb_admin_user_post_types`, and `dwpb_disable_user_post_column`.
 
-Plus the six front-end redirect filters built from the page being viewed:
+Plus the six front-end redirect filters, named for the page being viewed:
 `dwpb_redirect_post`, `dwpb_redirect_post_tag_archive`,
 `dwpb_redirect_category_archive`, `dwpb_redirect_blog_page`,
 `dwpb_redirect_date_archive`, and `dwpb_redirect_author_archive`.
 
-Plus the seven admin redirect filters that fire: `dwpb_redirect_admin_post`,
+Plus the nine admin redirect filters: `dwpb_redirect_admin_post`,
 `dwpb_redirect_admin_edit`, `dwpb_redirect_admin_post_new`,
-`dwpb_redirect_admin_edit_tags`, `dwpb_redirect_admin_edit_comments`,
-`dwpb_redirect_admin_options_discussion`, and `dwpb_redirect_admin_options_writing`.
+`dwpb_redirect_admin_term`, `dwpb_redirect_admin_edit_tags`,
+`dwpb_redirect_admin_edit_comments`, `dwpb_redirect_admin_options_discussion`,
+`dwpb_redirect_admin_options_writing`, and `dwpb_redirect_admin_tools`.
 
 Plus three dynamic filters: `dwpb_post_types_supporting_{$feature}`,
-`dwpb_disable_{$metabox_id}` (the four dashboard widgets are `dashboard_quick_press`,
-`dashboard_recent_drafts`, `dashboard_incoming_links`, and `dashboard_activity`), and
-`dpwb_create_user_{$post_type}_column`.
+`dwpb_disable_{$metabox_id}` (valid IDs are `dashboard_quick_press` and
+`dashboard_activity`), and `dwpb_create_user_{$post_type}_column`.
 
 Plus the `dwpb_init` action.
 
-Two filters are misspelled in the source, using `dpwb` rather than `dwpb`:
-`dpwb_disable_user_post_column` and `dpwb_create_user_{$post_type}_column`. Document
-them exactly as they are, with a short note, since renaming them would break sites.
+A short Deprecated section at the end covers the three filters renamed in 0.5.6. Each
+still works through `apply_filters_deprecated()`, and each entry names its replacement:
+
+| Deprecated | Use instead |
+| --- | --- |
+| `dwpb_redirect_admin_options_tools` | `dwpb_redirect_admin_tools` |
+| `dpwb_disable_user_post_column` | `dwpb_disable_user_post_column` |
+| `dpwb_create_user_{$post_type}_column` | `dwpb_create_user_{$post_type}_column` |
 
 Do not document `https_local_ssl_verify`. That is a WordPress core filter the plugin
 re-applies inside its Site Health check, not a plugin filter.
-
-Do not document `dwpb_redirect_admin_term` or `dwpb_redirect_admin_tools`. Neither
-fires in 0.5.5, so neither belongs in the docs until the underlying issue is resolved.
-For the same reason, the Admin Changes page must not claim that the Tools screen
-redirects to the dashboard. It is removed from the menu, which is what the docs should
-say.
 
 **PHP Functions.** `dwpb_post_types_with_feature()` and `dwpb_post_types_with_tax()`.
 Signature, parameters, return value, examples, and the caching behavior.
@@ -209,21 +222,18 @@ add your own integration.
 ### Changelog
 
 A GitBook GitHub code-block embed pointing at `CHANGELOG.md` on the `stable` branch, the
-same pattern archived-post-status uses.
+same pattern archived-post-status uses. It picks up 0.5.6 automatically once that
+release merges.
 
 ## Accuracy
 
 Every filter entry takes its Since version, default value, and parameter list from the
-source rather than from inference. Where a docblock disagrees with the code, the code
-wins. Every code example is written to run as given.
-
-The docs describe what 0.5.5 actually does, which in two places differs from what
-`README.md` currently claims. The Tools screen redirect is the known case. Any other
-mismatch found while writing is resolved in favor of the code, and noted here.
+0.5.6 source rather than from inference. Where a docblock disagrees with the code, the
+code wins. Every code example is written to run as given.
 
 ## Out of scope
 
 - Screenshots. The pages are structured so images can be added later without rewriting.
   `docs/.gitbook/assets/` is created empty and ready.
-- Changes to `readme.txt`.
+- Any edit to `README.md`, `readme.txt`, or `.distignore`.
 - Any change to plugin behavior.

--- a/.dev/specs/2026-08-05-gitbook-docs-design.md
+++ b/.dev/specs/2026-08-05-gitbook-docs-design.md
@@ -1,0 +1,229 @@
+# GitBook Documentation Site Design
+
+**Date:** 2026-08-05
+**Status:** Approved
+
+## Goal
+
+Publish a GitBook documentation site for Disable Blog from a `/docs/` folder, matching
+the setup already used by archived-post-status. The site covers how to install, use,
+uninstall, and extend the plugin.
+
+The docs will publish at `docs.disable.blog`. Until that is live, all internal links are
+relative so they resolve correctly on GitHub.
+
+## Writing rules
+
+These apply to every page.
+
+- No em dashes.
+- Brief, plainly readable by end users. Short declarative sentences, second person.
+- Document the plugin's current released state. Include version nuance only when it
+  changes what a user sees or does, written as a "Changed in X.Y.Z" callout.
+- No references to intermediate work, branches, or internal process. If it does not
+  impact a user on a release branch, it does not go in.
+
+Match the conventions in the archived-post-status `docs/` folder:
+`{% hint style="warning" %}` for cautions, `{% code overflow="wrap" %}` for shell and PHP
+snippets, `<details>`/`<summary>` for FAQ entries, and the phrase "Add this to your
+theme's `functions.php` file or as an [MU plugin](...)" when introducing a filter
+example.
+
+## Files created
+
+```
+.gitbook.yaml                          repo root, points GitBook at ./docs/
+docs/
+├── README.md                          landing page
+├── SUMMARY.md                         table of contents
+├── changelog.md                       GitHub code-block embed of CHANGELOG.md
+├── .gitbook/assets/                   empty, ready for future screenshots
+├── usage/
+│   ├── install-and-activate.md
+│   ├── setting-up.md
+│   ├── front-end-changes.md
+│   ├── admin-changes.md
+│   ├── your-content-and-data.md
+│   ├── deactivate-and-uninstall.md
+│   └── frequently-asked-questions.md
+└── extending-the-plugin/
+    ├── hooks-filters-and-actions.md
+    ├── functions.md
+    ├── common-customizations.md
+    └── plugin-integrations.md
+```
+
+`.gitbook.yaml` is written as clean YAML:
+
+```yaml
+root: ./docs/
+
+structure:
+  readme: README.md
+  summary: SUMMARY.md
+```
+
+## Files modified
+
+**`README.md`.** Keeps the badges, description, static front page warning, support,
+contributing, and local development sections. The "How does this plugin work?" list and
+the FAQ section are replaced by a Documentation section linking into `docs/` with
+relative paths.
+
+**`.distignore`.** Add `/docs/` and `.gitbook.yaml` so neither ships in the
+WordPress.org plugin ZIP. The current file excludes neither.
+
+**`readme.txt`.** Untouched. The WordPress.org readme stays self-contained.
+
+## Table of contents
+
+```markdown
+# Table of contents
+
+* [Disable Blog](README.md)
+
+## ⭐ Usage
+
+* [Install & Activate](usage/install-and-activate.md)
+* [Setting Up Your Site](usage/setting-up.md)
+* [Front-End Changes](usage/front-end-changes.md)
+* [Admin Changes](usage/admin-changes.md)
+* [Your Content & Data](usage/your-content-and-data.md)
+* [Deactivate & Uninstall](usage/deactivate-and-uninstall.md)
+* [Frequently Asked Questions](usage/frequently-asked-questions.md)
+
+## 🔌 Extending the Plugin
+
+* [Hooks, Filters, and Actions](extending-the-plugin/hooks-filters-and-actions.md)
+* [PHP Functions](extending-the-plugin/functions.md)
+* [Common Customizations](extending-the-plugin/common-customizations.md)
+* [Plugin Integrations](extending-the-plugin/plugin-integrations.md)
+
+***
+
+* [Changelog](changelog.md)
+```
+
+## Page contents
+
+### Usage
+
+**Install & Activate.** Plugins screen, FTP, WP-CLI, and Composer via wpackagist.
+
+**Setting Up Your Site.** The static front page requirement, why it matters, and what
+does not work without it. Covers the optional posts page and its redirect. Opens with a
+warning hint, since this is the single most common source of support questions.
+
+**Front-End Changes.** What visitors no longer see. Feeds and feed links, posts removed
+from archives, sitemap changes, REST API and XML-RPC restrictions, author archive
+behavior, and the full list of 301 redirects.
+
+**Admin Changes.** What disappears from wp-admin. Menu removals, admin redirects,
+comment handling, dashboard widgets, Reading and Writing settings, the user table Posts
+to Pages column swap, taxonomy count corrections, and the Site Health REST check
+replacement.
+
+The admin redirect table lists only the screens that actually redirect in 0.5.5:
+`post.php`, `edit.php`, `post-new.php`, `edit-tags.php`, `edit-comments.php`,
+`options-discussion.php`, and `options-writing.php`. Tools is described as removed from
+the menu, not redirected.
+
+**Your Content & Data.** Nothing is deleted. Posts, categories, tags, and comments stay
+in the database but become inaccessible while the plugin is active. Explains how to
+actually delete that content, and what the plugin itself stores (`dwpb_version` and
+`dwpb_previous_version`).
+
+**Deactivate & Uninstall.** Deactivating from the Plugins screen, with WP-CLI, and
+removing via Composer. What uninstall deletes. Notes the multisite behavior, including
+that networks of 5000 or more sites skip the per-site option cleanup.
+
+**Frequently Asked Questions.** Collapsible `<details>` entries. Carries over the four
+existing FAQs (disabling comments, deleting posts and comments, disabling author
+archives, changing plugin behavior) and adds ones the code answers: custom post types
+using categories or tags, Query Loop block behavior, where redirects point, and
+multisite.
+
+### Extending the Plugin
+
+**Hooks, Filters, and Actions.** The complete reference. An index at the top, then
+entries grouped by area: Redirects, Front-End, Admin, and Post Types & Taxonomies. Each
+entry gives a description, Since version, parameters, return value, and a runnable
+example.
+
+Covers 25 named filters:
+
+`dwpb_pass_query_string_on_redirect`, `dwpb_allowed_query_vars`,
+`dwpb_redirect_status_code`, `dwpb_redirect_front_end`, `dwpb_front_end_redirect_url`,
+`dwpb_redirect_admin`, `dwpb_admin_redirect_url`, `dwpb_disable_feed`,
+`dwpb_redirect_feeds`, `dwpb_feed_message`, `dwpb_feed_die_message`,
+`dwpb_disable_author_archives`, `dwpb_author_archive_post_types`,
+`dwpb_tag_post_types`, `dwpb_category_post_types`, `dwpb_taxonomy_support`,
+`dwpb_disabled_xmlrpc_methods`, `dwpb_remove_pingback_header`,
+`dwpb_disable_user_sitemap`, `dwpb_menu_pages_to_remove`,
+`dwpb_menu_subpages_to_remove`, `dwpb_remove_options_writing`,
+`dwpb_unregister_widgets`, `dwpb_admin_user_post_types`, and
+`dpwb_disable_user_post_column`.
+
+Plus the six front-end redirect filters built from the page being viewed:
+`dwpb_redirect_post`, `dwpb_redirect_post_tag_archive`,
+`dwpb_redirect_category_archive`, `dwpb_redirect_blog_page`,
+`dwpb_redirect_date_archive`, and `dwpb_redirect_author_archive`.
+
+Plus the seven admin redirect filters that fire: `dwpb_redirect_admin_post`,
+`dwpb_redirect_admin_edit`, `dwpb_redirect_admin_post_new`,
+`dwpb_redirect_admin_edit_tags`, `dwpb_redirect_admin_edit_comments`,
+`dwpb_redirect_admin_options_discussion`, and `dwpb_redirect_admin_options_writing`.
+
+Plus three dynamic filters: `dwpb_post_types_supporting_{$feature}`,
+`dwpb_disable_{$metabox_id}` (the four dashboard widgets are `dashboard_quick_press`,
+`dashboard_recent_drafts`, `dashboard_incoming_links`, and `dashboard_activity`), and
+`dpwb_create_user_{$post_type}_column`.
+
+Plus the `dwpb_init` action.
+
+Two filters are misspelled in the source, using `dpwb` rather than `dwpb`:
+`dpwb_disable_user_post_column` and `dpwb_create_user_{$post_type}_column`. Document
+them exactly as they are, with a short note, since renaming them would break sites.
+
+Do not document `https_local_ssl_verify`. That is a WordPress core filter the plugin
+re-applies inside its Site Health check, not a plugin filter.
+
+Do not document `dwpb_redirect_admin_term` or `dwpb_redirect_admin_tools`. Neither
+fires in 0.5.5, so neither belongs in the docs until the underlying issue is resolved.
+For the same reason, the Admin Changes page must not claim that the Tools screen
+redirects to the dashboard. It is removed from the menu, which is what the docs should
+say.
+
+**PHP Functions.** `dwpb_post_types_with_feature()` and `dwpb_post_types_with_tax()`.
+Signature, parameters, return value, examples, and the caching behavior.
+
+**Common Customizations.** Task-oriented recipes: disable author archives, keep tags and
+categories working for a custom post type, change redirect targets and the status code,
+keep Settings > Writing available, preserve a feed, allow query variables through
+redirects, and add custom post types to author archives.
+
+**Plugin Integrations.** How Disable Blog behaves alongside Disable Comments and
+WooCommerce, followed by a section on how `Disable_Blog_Integrations` works and how to
+add your own integration.
+
+### Changelog
+
+A GitBook GitHub code-block embed pointing at `CHANGELOG.md` on the `stable` branch, the
+same pattern archived-post-status uses.
+
+## Accuracy
+
+Every filter entry takes its Since version, default value, and parameter list from the
+source rather than from inference. Where a docblock disagrees with the code, the code
+wins. Every code example is written to run as given.
+
+The docs describe what 0.5.5 actually does, which in two places differs from what
+`README.md` currently claims. The Tools screen redirect is the known case. Any other
+mismatch found while writing is resolved in favor of the code, and noted here.
+
+## Out of scope
+
+- Screenshots. The pages are structured so images can be added later without rewriting.
+  `docs/.gitbook/assets/` is created empty and ready.
+- Changes to `readme.txt`.
+- Any change to plugin behavior.

--- a/.distignore
+++ b/.distignore
@@ -3,6 +3,9 @@
 /.wordpress-org
 /vendor/
 /tests/
+/docs/
+/.dev/
+.gitbook.yaml
 .editorconfig
 .gitignore
 .distignore

--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,5 @@
+root: ./docs/
+
+structure:
+  readme: README.md
+  summary: SUMMARY.md

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ All the power of WordPress, without a blog.
 
 Disable Blog is a comprehensive plugin to disable the built-in blogging functionality on your site. You'll be free to use pages and custom post types without the burden of a blog.
 
-The blog is "disabled" when the plugin is activated, which removes support for the core 'post' type, hides blog-related admin pages/settings, and redirects urls on both the public and admin portions of the site. Refer to [below](#how-does-this-plugin-work) for a detailed functionality list.
+The blog is "disabled" when the plugin is activated, which removes support for the core 'post' type, hides blog-related admin pages/settings, and redirects urls on both the public and admin portions of the site. See [Front-End Changes](docs/usage/front-end-changes.md) and [Admin Changes](docs/usage/admin-changes.md) for the detailed functionality list.
 
 ### Important: Set a front page
 
@@ -34,65 +34,24 @@ If you have content and wish to remove it, either delete that content prior to a
 
 Comments remain enabled, unless the 'post' type is the only type supporting comments (pages also support comments by default, so the comments section won't disappear in most cases). If you're looking to disable comments completely, check out the [Disable Comments](https://wordpress.org/plugins/disable-comments/) plugin.
 
-### How does this plugin work?
+## Documentation
 
-Activating Disable Blog does the following:
+Full documentation lives in [docs/](docs/README.md).
 
-- Turns the `post` type into a non-public content type, with support for zero post type features. Any attempts to edit or view posts within the admin screen will be met with a WordPress error page or be redirect to the homepage.
+- [Install & Activate](docs/usage/install-and-activate.md)
+- [Setting Up Your Site](docs/usage/setting-up.md)
+- [Front-End Changes](docs/usage/front-end-changes.md)
+- [Admin Changes](docs/usage/admin-changes.md)
+- [Your Content & Data](docs/usage/your-content-and-data.md)
+- [Deactivate & Uninstall](docs/usage/deactivate-and-uninstall.md)
+- [Frequently Asked Questions](docs/usage/frequently-asked-questions.md)
 
-- Front-end:
-	- Disables the post feed and removes the feed links from the header (for WP >= 4.4.0) and disables the comment feed/removes comment feed link if 'post' is the only post type supporting comments (note that the default condition pages and attachments support comments).
-	- Removes posts from all archive pages.
-	- Remove 'post' post type from XML sitemaps and categories/tags from XML sitemaps, if not being used by a custom post type (WP Version 5.5).
-	- Disables the REST API for 'post' post type, as well as tags & categories (if not used by another custom post type).
-	- Disables XMLRPC for posts, as well as tags & categories (if not used by another custom post type).
-	- Disable author archives (redirect to homepage) via `dwpb_disable_author_archives` filter. Add the following to your theme functions.php file or a custom plugin file: `add_filter( 'dwpb_disable_author_archives', '__return_true' );` The plugin by default does not disable author archives because numerous other plugins use author archives for other purposes. (A future settings page will provide more flexibility here). Change the url being used in the redirect with the `dwpb_redirect_author_archive` filter.
-	- Removes post sitemaps and, if not supported via the `dwpb_disable_author_archive` filter, removes user sitemaps. User sitemaps can be toggled back on via that filter or directly passing `false` to the `dwpb_disable_user_sitemap` filter.
-	- Redirects (301):
-		- All Single Posts & Post Archive urls to the homepage (requires a 'page' as your homepage in Settings > Reading)
-		- The blog page to the homepage.
-		- All Tag & Category archives to home page, unless they are supported by a custom post type.
-		- Date archives to the homepage.
-		- Author archives are not redirected by default, but can per the above mentioned `dwpb_disable_author_archives` filter.
+Extending the plugin:
 
-- Admin side:
-	- Redirects tag and category pages to dashboard, unless used by a custom post type.
-	- Redirects post related screens (`post.php`, `post-new.php`, etc) to the `page` version of the same page.
-	- If comments are not supported by other post types (by default comments are supported by pages and attachments), it will hide the menu links for and redirect discussion options page and 'Comments' admin page to the dashboard.
-	- Filters out the 'post' post type from 'Comments' admin page.
-	- Alters the comment count to remove any comments associated with 'post' post type.
-	- Optionally remove/redirect the Settings > Writing page via `dwpb_remove_options_writing` filter (default is false).
-	- Removes Available Tools from admin menu and redirects page to the dashboard (this admin page contains Press This and Category/Tag converter, both are no longer neededd without a blog).
-	- Removes Post from '+New' admin bar menu.
-	- Removes 'Posts' Admin Menu.
-	- Removes post-related dashboard widgets.
-	- Hides number of posts and comment count on Activity dashboard widget.
-	- Removes Post Related Widgets.
-	- Hide options in Reading Settings page related to posts (shows front page and search engine options), as well as matching section in Cusomizer > Homepage Settings view.
-	- Removes 'Post' options on 'Menus' admin page.
-	- Filters 'post' post type out of main query.
-	- Disables "Press This" functionality.
-	- Disables post by email configuration.
-	- Hides Category and Tag permalink base options, if they are not supported by a custom post type.
-	- Hides "Toggle Comments" link on Welcome screen if comments are only supported for posts.
-	- Hides default category and default post format on Writing Options screen.
-	- Replace the REST API availability site health check with a duplicate function that uses the `page` type instead of the `post` type (avoids false positive error in Site Health).
-	- Replaces the "Posts" column in the user table with "Pages," linked to pages by that author.
-	- Remove the "view" link to author archives in the user screen if author archives are not supported.
-	- Updates the post tag and category "count" columns to correctly show the number of posts by post type, for use with custom post types supporting built-in taxonomies.
-
-**Note that this plugin will not delete anything - existing posts, comments, categories and tags will remain in your database.** 
-
-If Settings > Reading > Front Page Displays is not set to show on a page, then some aspects of the plugin won't work, be sure to set your front page to a static page.
-
-## FAQ
-
-1. Can I Disable Comments?
- - Other post types (like Pages) may have comment support and other great plugins exist that can disable comments, so this feature was not part of the initial development of this plugin. A future release will include options to disable comments, but until then if you would like to disable comments, try the [Disable Comments](https://wordpress.org/plugins/disable-comments/) plugin.
-2. I want to delete my posts and comments
- - Deactivate the plugin, delete your posts (which will delete related comments), and delete any tags or categories you might want to remove as well. Then reactivate the Disable Blog to hide everything again.
-3. How can I disable author archives?
- - If you're not using the built-in WP author archives for other purposes (example url: `example.com/author/author-name`) and would like to disable them entirely, add the following to your theme functions.php file or a custom plugin file: `add_filter( 'dwpb_disable_author_archives', '__return_true' );`. If author archives are not disabled, the plugin adds functionality to support custom post types on author archives by passing an array of post type slugs to `dwpb_author_archive_post_types` filter - however, theme support is usually needed to disable custom content types correctly.
+- [Hooks, Filters, and Actions](docs/extending-the-plugin/hooks-filters-and-actions.md)
+- [PHP Functions](docs/extending-the-plugin/functions.md)
+- [Common Customizations](docs/extending-the-plugin/common-customizations.md)
+- [Plugin Integrations](docs/extending-the-plugin/plugin-integrations.md)
 
 ## Support
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,23 @@
+---
+description: Turn off the blog in WordPress with the Disable Blog plugin
+---
+
+# Disable Blog
+
+[![WordPress Plugin Version](https://img.shields.io/wordpress/plugin/v/disable-blog)](https://wordpress.org/plugins/disable-blog/) ![Downloads](https://img.shields.io/wordpress/plugin/dt/disable-blog.svg) ![Rating](https://img.shields.io/wordpress/plugin/r/disable-blog.svg) [![WP compatibility](https://plugintests.com/plugins/wporg/disable-blog/wp-badge.svg)](https://plugintests.com/plugins/wporg/disable-blog/latest) [![PHP compatibility](https://plugintests.com/plugins/wporg/disable-blog/php-badge.svg)](https://plugintests.com/plugins/wporg/disable-blog/latest)
+
+View on: [Github](https://github.com/joshuadavidnelson/disable-blog/) & [WordPress.org](https://wordpress.org/plugins/disable-blog/)
+
+## All the power of WordPress, without a blog
+
+WordPress ships as a blogging platform, but most sites built with it are not blogs. Disable Blog removes the blog instead of asking you to work around it.
+
+Once the plugin is active, posts go away, along with their feeds, archives, and admin screens. Categories and tags go too, unless another post type is using them. Pages and custom post types keep working exactly as they did before, comments included.
+
+This plugin is for site owners and developers who use WordPress as a CMS rather than a blogging platform, and who want the blogging parts gone rather than hidden by a theme.
+
+{% hint style="warning" %}
+Disable Blog requires a static front page. If Settings > Reading is not set to show a page on the front end, parts of the site will not work correctly. See [Setting Up Your Site](usage/setting-up.md) before you activate.
+{% endhint %}
+
+Dive into the following pages to install, set up, and extend the plugin.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ description: Turn off the blog in WordPress with the Disable Blog plugin
 
 [![WordPress Plugin Version](https://img.shields.io/wordpress/plugin/v/disable-blog)](https://wordpress.org/plugins/disable-blog/) ![Downloads](https://img.shields.io/wordpress/plugin/dt/disable-blog.svg) ![Rating](https://img.shields.io/wordpress/plugin/r/disable-blog.svg) [![WP compatibility](https://plugintests.com/plugins/wporg/disable-blog/wp-badge.svg)](https://plugintests.com/plugins/wporg/disable-blog/latest) [![PHP compatibility](https://plugintests.com/plugins/wporg/disable-blog/php-badge.svg)](https://plugintests.com/plugins/wporg/disable-blog/latest)
 
-View on: [Github](https://github.com/joshuadavidnelson/disable-blog/) & [WordPress.org](https://wordpress.org/plugins/disable-blog/)
+View on: [GitHub](https://github.com/joshuadavidnelson/disable-blog/) & [WordPress.org](https://wordpress.org/plugins/disable-blog/)
 
 ## All the power of WordPress, without a blog
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,24 @@
+# Table of contents
+
+* [Disable Blog](README.md)
+
+## ⭐ Usage
+
+* [Install & Activate](usage/install-and-activate.md)
+* [Setting Up Your Site](usage/setting-up.md)
+* [Front-End Changes](usage/front-end-changes.md)
+* [Admin Changes](usage/admin-changes.md)
+* [Your Content & Data](usage/your-content-and-data.md)
+* [Deactivate & Uninstall](usage/deactivate-and-uninstall.md)
+* [Frequently Asked Questions](usage/frequently-asked-questions.md)
+
+## 🔌 Extending the Plugin
+
+* [Hooks, Filters, and Actions](extending-the-plugin/hooks-filters-and-actions.md)
+* [PHP Functions](extending-the-plugin/functions.md)
+* [Common Customizations](extending-the-plugin/common-customizations.md)
+* [Plugin Integrations](extending-the-plugin/plugin-integrations.md)
+
+***
+
+* [Changelog](changelog.md)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,3 @@
+# Changelog
+
+{% @github-files/github-code-block url="https://github.com/joshuadavidnelson/disable-blog/blob/stable/CHANGELOG.md" %}

--- a/docs/extending-the-plugin/common-customizations.md
+++ b/docs/extending-the-plugin/common-customizations.md
@@ -1,0 +1,200 @@
+# Common Customizations
+
+These are the most common adjustments people make to Disable Blog. For the complete list of filters and actions the plugin offers, see [Hooks, Filters, and Actions](hooks-filters-and-actions.md).
+
+Add this to your theme's `functions.php` file or as an [MU plugin](https://wordpress.org/documentation/article/must-use-plugins/). Give each function below a unique name if you use more than one on the same site.
+
+### Disable author archives
+
+Author archives are left alone by default. Themes and plugins commonly repurpose the author archive as a profile page, so the plugin will not touch it unless you say so.
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_disable_author_archives', '__return_true' );
+```
+{% endcode %}
+
+{% hint style="info" %}
+Turning this on also removes the users sitemap.
+{% endhint %}
+
+### Keep categories or tags working for a custom post type
+
+If a custom post type is genuinely registered with the `category` or `post_tag` taxonomy, this already works with no code. The plugin checks WordPress's own registration data to see what uses each taxonomy, and keeps that taxonomy's admin screens and archives active as soon as anything other than `post` is using it.
+
+Use `dwpb_taxonomy_support` only to override that detection, for example if a post type uses the taxonomy in a way the plugin's check cannot see.
+
+{% code overflow="wrap" %}
+```php
+function my_dwpb_taxonomy_support( $override, $taxonomy, $post_types, $args, $output ) {
+    if ( 'post_tag' === $taxonomy ) {
+        return array( 'book' );
+    }
+
+    return $override;
+}
+add_filter( 'dwpb_taxonomy_support', 'my_dwpb_taxonomy_support', 10, 5 );
+```
+{% endcode %}
+
+| # | Parameter | What it is |
+| --- | --- | --- |
+| 1 | `$override` | `null` by default. Return anything else and that value short-circuits the result. |
+| 2 | `$taxonomy` | The taxonomy slug or object being checked. |
+| 3 | `$post_types` | Every registered post type matching `$args`, not just the ones already using the taxonomy. |
+| 4 | `$args` | The arguments used to fetch that list of post types. |
+| 5 | `$output` | `'names'` or `'objects'`. |
+
+Returning `$override` unchanged, as the example does for any taxonomy other than `post_tag`, leaves the plugin's own detection in place.
+
+### Change where redirects send people
+
+`dwpb_front_end_redirect_url` changes the destination for every front-end redirect at once. It fires after any page-specific filter and receives that filter's result, so if you hook it, your return value is what the plugin actually redirects to, regardless of page type.
+
+{% code overflow="wrap" %}
+```php
+function my_dwpb_front_end_redirect_url( $redirect_url ) {
+    return home_url( '/welcome/' );
+}
+add_filter( 'dwpb_front_end_redirect_url', 'my_dwpb_front_end_redirect_url' );
+```
+{% endcode %}
+
+To change just one kind of page instead, use its own filter. Single posts use `dwpb_redirect_post`, and tag archives, category archives, the blog page, date archives, and author archives each have a matching filter of their own. See [Hooks, Filters, and Actions](hooks-filters-and-actions.md) for the full list.
+
+{% code overflow="wrap" %}
+```php
+function my_dwpb_redirect_post( $redirect_url ) {
+    return home_url( '/blog-has-moved/' );
+}
+add_filter( 'dwpb_redirect_post', 'my_dwpb_redirect_post' );
+```
+{% endcode %}
+
+### Change the redirect status code
+
+{% code overflow="wrap" %}
+```php
+function my_dwpb_redirect_status_code( $status_code, $current_url, $redirect_url ) {
+    return 302;
+}
+add_filter( 'dwpb_redirect_status_code', 'my_dwpb_redirect_status_code', 10, 3 );
+```
+{% endcode %}
+
+{% hint style="warning" %}
+The returned value must be a number from 300 to 399. Anything outside that range, including 200, is ignored and the plugin falls back to 301.
+{% endhint %}
+
+### Turn off redirects entirely
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_redirect_front_end', '__return_false' );
+add_filter( 'dwpb_redirect_admin', '__return_false' );
+```
+{% endcode %}
+
+{% hint style="info" %}
+Redirects are one layer of the plugin, not the whole plugin. Turning both of these off only stops the forwarding. The `post` type itself is still non-public, excluded from search, left out of the REST API, and hidden from the admin menu, none of that depends on the redirect filters.
+{% endhint %}
+
+### Remove the Settings > Writing screen
+
+This is off by default because other plugins commonly add their own fields to that screen.
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_remove_options_writing', '__return_true' );
+```
+{% endcode %}
+
+Turning it on removes Settings > Writing from the admin menu and redirects any direct visit to it.
+
+### Keep a feed alive
+
+Add this to your theme's `functions.php` file or as an [MU plugin](https://wordpress.org/documentation/article/must-use-plugins/):
+
+{% code overflow="wrap" %}
+```php
+function my_dwpb_keep_comment_feed_alive( $disable, $post, $is_comment_feed ) {
+    if ( $is_comment_feed ) {
+        return false;
+    }
+
+    return $disable;
+}
+add_filter( 'dwpb_disable_feed', 'my_dwpb_keep_comment_feed_alive', 10, 3 );
+```
+{% endcode %}
+
+`$disable` arrives as `true`, meaning the plugin is about to shut the feed off. Return `false` to let that one through. `$post` is the global post object, and `$is_comment_feed` tells you whether the request is a comment feed rather than the main content feed. The example above keeps comment feeds working and leaves everything else disabled. Flip the condition to keep the main feed instead and disable comment feeds.
+
+### Show a message instead of redirecting a feed
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_feed_message', '__return_true' );
+
+function my_dwpb_feed_die_message( $message ) {
+    return 'This site does not publish a feed. Visit <a href="' . esc_url( home_url() ) . '">the homepage</a> for the latest updates.';
+}
+add_filter( 'dwpb_feed_die_message', 'my_dwpb_feed_die_message' );
+```
+{% endcode %}
+
+`dwpb_feed_message` defaults to false, so a disabled feed redirects to the homepage. Returning true stops the redirect and shows a message built with `dwpb_feed_die_message` instead. Only `<a>` tags survive in that message, everything else is stripped.
+
+### Let query strings through a redirect
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_pass_query_string_on_redirect', '__return_true' );
+
+function my_dwpb_allowed_query_vars( $allowed_query_vars ) {
+    $allowed_query_vars[] = 'utm_source';
+    $allowed_query_vars[] = 'utm_campaign';
+
+    return $allowed_query_vars;
+}
+add_filter( 'dwpb_allowed_query_vars', 'my_dwpb_allowed_query_vars' );
+```
+{% endcode %}
+
+{% hint style="warning" %}
+Both filters are needed together. `dwpb_pass_query_string_on_redirect` only switches on the mechanism that looks at the current query string, it does not decide what gets kept. `dwpb_allowed_query_vars` decides that, and it defaults to an empty array. With no keys on that list, turning on `dwpb_pass_query_string_on_redirect` by itself carries nothing over, because there is nothing allowed to copy yet.
+{% endhint %}
+
+### Add custom post types to author archives
+
+By default only `post` entries show on an author archive. Add this to your theme's `functions.php` file or as an [MU plugin](https://wordpress.org/documentation/article/must-use-plugins/):
+
+{% code overflow="wrap" %}
+```php
+function my_dwpb_author_archive_post_types( $post_types ) {
+    $post_types[] = 'post';
+    $post_types[] = 'book';
+
+    return $post_types;
+}
+add_filter( 'dwpb_author_archive_post_types', 'my_dwpb_author_archive_post_types' );
+```
+{% endcode %}
+
+{% hint style="warning" %}
+`$post_types` arrives empty, and whatever you return replaces the list used on author archives rather than adding to it. If you want ordinary posts to keep appearing, include `post` yourself as shown above. Leave it out and only `book` entries will show.
+{% endhint %}
+
+This filter also decides whether the users sitemap appears. Left untouched, the users sitemap is left out. Add any post type here and the users sitemap turns on as a side effect.
+
+### Keep a dashboard widget
+
+The plugin removes two dashboard widgets by default: Quick Press and Activity. Keep one by returning false from its own filter.
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_disable_dashboard_quick_press', '__return_false' );
+```
+{% endcode %}
+
+Use `dwpb_disable_dashboard_activity` for the Activity widget the same way.

--- a/docs/extending-the-plugin/functions.md
+++ b/docs/extending-the-plugin/functions.md
@@ -1,0 +1,113 @@
+# PHP Functions
+
+Disable Blog exposes two helper functions, both defined in `functions.php`. Each
+answers the same underlying question: which post types, other than `post`, support a
+given feature or taxonomy. The plugin uses them internally to decide what to redirect,
+hide, or leave alone, and you can call them from your own code for the same purpose.
+
+{% hint style="warning" %}
+Always [check that a plugin function exists](https://www.php.net/manual/en/function.function-exists.php)
+before calling it, in case the plugin is ever deactivated.
+{% endhint %}
+
+### `dwpb_post_types_with_feature( string $feature, array $args = array() ): array|bool`
+
+Get the post types, other than `post`, that support a given feature, the same string
+you would pass to `post_type_supports()`, for example `'comments'`, `'excerpt'`, or
+`'thumbnail'`.
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `$feature` | none, required | The feature to check for. |
+| `$args` | `array()` | Arguments passed to `get_post_types()` to narrow which post types get checked. |
+
+Returns an array of post type slugs that support `$feature`. The `post` post type is
+always excluded from the result, even though it supports most features by default.
+Returns `false` if `$feature` is empty or not a string, and also if no post type other
+than `post` supports it.
+
+{% hint style="warning" %}
+This returns `false`, not an empty array, when nothing matches. Check the result with
+`if ( $post_types )` before looping over it.
+{% endhint %}
+
+Results are cached per `$feature`, in the `post-types-by-feature` cache group, under
+the key `post-types-supporting-{$feature}`. The `$args` you pass are not part of the
+cache key, so two calls with the same `$feature` but different `$args` share whichever
+result was cached first. A feature that nothing supports is recomputed on every call
+rather than served from cache, since a cached `false` is indistinguishable from an
+empty cache.
+
+Before returning, the result passes through
+[`dwpb_post_types_supporting_{$feature}`](hooks-filters-and-actions.md), with
+`{$feature}` replaced by the feature you passed in, for example
+`dwpb_post_types_supporting_comments`. This runs on every call, cached or not. Disable
+Blog's own Disable Comments integration uses this filter to turn off its comment
+handling; see [Plugin Integrations](plugin-integrations.md). Full filter parameters are
+on the [Hooks, Filters, and Actions](hooks-filters-and-actions.md) page.
+
+Add this to your theme's `functions.php` file or as an [MU plugin](https://wordpress.org/documentation/article/must-use-plugins/):
+
+{% code overflow="wrap" %}
+```php
+function my_dwpb_list_comment_post_types() {
+    $post_types = dwpb_post_types_with_feature( 'comments' );
+
+    if ( $post_types ) {
+        foreach ( $post_types as $post_type ) {
+            // Runs once for every non-'post' post type that still supports comments.
+        }
+    } else {
+        // Nothing but 'post' supports comments, or nothing does.
+    }
+}
+// Priority 20 so custom post types have already been registered.
+add_action( 'init', 'my_dwpb_list_comment_post_types', 20 );
+```
+{% endcode %}
+
+### `dwpb_post_types_with_tax( string|object $taxonomy, array $args = array(), string $output = 'names' ): array|bool`
+
+Get the post types, other than `post`, that use a given taxonomy. Disable Blog calls
+this to check whether any custom post type still uses the built-in `category` or
+`post_tag` taxonomies, since if nothing but `post` does, it turns off the related
+archives, redirects, and sitemap entries for that taxonomy.
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `$taxonomy` | none, required | A taxonomy slug or a taxonomy object. Only the slug is used either way. |
+| `$args` | `array()` | Arguments passed to `get_post_types()` to narrow which post types get checked. |
+| `$output` | `'names'` | `'names'` returns an array of post type slugs, `'objects'` returns post type objects. |
+
+Returns an array of post type names or objects (matching `$output`) that use
+`$taxonomy`. The `post` post type is always excluded from the result. Returns `false`
+if `$taxonomy` is empty, and also if no post type other than `post` uses it.
+
+{% hint style="warning" %}
+Like `dwpb_post_types_with_feature()`, this returns `false`, not an empty array, when
+nothing matches. Check the result before looping over it.
+{% endhint %}
+
+Before returning, the function runs
+[`dwpb_taxonomy_support`](hooks-filters-and-actions.md). Return anything other than
+`null` from this filter and that value becomes the function's return value instead,
+short-circuiting the `false`-when-empty fallback described above. Full filter
+parameters are on the [Hooks, Filters, and Actions](hooks-filters-and-actions.md) page.
+
+Add this to your theme's `functions.php` file or as an [MU plugin](https://wordpress.org/documentation/article/must-use-plugins/):
+
+{% code overflow="wrap" %}
+```php
+function my_dwpb_list_category_post_types() {
+    $post_types = dwpb_post_types_with_tax( 'category' );
+
+    if ( $post_types ) {
+        // At least one custom post type still uses categories.
+    } else {
+        // Only 'post' used categories, so Disable Blog treats it as unused.
+    }
+}
+// Priority 20 so custom post types have already been registered.
+add_action( 'init', 'my_dwpb_list_category_post_types', 20 );
+```
+{% endcode %}

--- a/docs/extending-the-plugin/hooks-filters-and-actions.md
+++ b/docs/extending-the-plugin/hooks-filters-and-actions.md
@@ -1,0 +1,901 @@
+# Hooks, Filters, and Actions
+
+Disable Blog has no settings page. Every behavior it controls, from redirects to
+dashboard widgets, is adjustable through a filter or action instead. This page is the
+complete reference: every filter and action the plugin fires, with its parameters,
+defaults, and a working example.
+
+{% hint style="info" %}
+Add any of the examples below to your theme's `functions.php` file or as an [MU plugin](https://wordpress.org/documentation/article/must-use-plugins/).
+{% endhint %}
+
+### Index
+
+**Redirects**
+
+[`dwpb_redirect_front_end`](#dwpb_redirect_front_end), [`dwpb_front_end_redirect_url`](#dwpb_front_end_redirect_url), [`dwpb_redirect_admin`](#dwpb_redirect_admin), [`dwpb_admin_redirect_url`](#dwpb_admin_redirect_url), [`dwpb_redirect_status_code`](#dwpb_redirect_status_code), [`dwpb_pass_query_string_on_redirect`](#dwpb_pass_query_string_on_redirect), [`dwpb_allowed_query_vars`](#dwpb_allowed_query_vars), [front-end page redirects](#front-end-page-redirects) (6 filters), [admin screen redirects](#admin-screen-redirects) (9 filters).
+
+**Front-End**
+
+[`dwpb_disable_feed`](#dwpb_disable_feed), [`dwpb_redirect_feeds`](#dwpb_redirect_feeds), [`dwpb_feed_message`](#dwpb_feed_message), [`dwpb_feed_die_message`](#dwpb_feed_die_message), [`dwpb_disabled_xmlrpc_methods`](#dwpb_disabled_xmlrpc_methods), [`dwpb_remove_pingback_header`](#dwpb_remove_pingback_header), [`dwpb_disable_user_sitemap`](#dwpb_disable_user_sitemap), [`dwpb_disable_removed_sitemaps`](#dwpb_disable_removed_sitemaps).
+
+**Admin**
+
+[`dwpb_menu_pages_to_remove`](#dwpb_menu_pages_to_remove), [`dwpb_menu_subpages_to_remove`](#dwpb_menu_subpages_to_remove), [`dwpb_remove_options_writing`](#dwpb_remove_options_writing), [`dwpb_unregister_widgets`](#dwpb_unregister_widgets), [`dwpb_disable_{$metabox_id}`](#dwpb_disable_metabox_id), [`dwpb_admin_user_post_types`](#dwpb_admin_user_post_types), [`dwpb_disable_user_post_column`](#dwpb_disable_user_post_column), [`dwpb_create_user_{$post_type}_column`](#dwpb_create_user_post_type_column).
+
+**Post Types & Taxonomies**
+
+[`dwpb_post_types_supporting_{$feature}`](#dwpb_post_types_supporting_feature), [`dwpb_taxonomy_support`](#dwpb_taxonomy_support), [`dwpb_tag_post_types`](#dwpb_tag_post_types), [`dwpb_category_post_types`](#dwpb_category_post_types), [`dwpb_disable_author_archives`](#dwpb_disable_author_archives), [`dwpb_author_archive_post_types`](#dwpb_author_archive_post_types).
+
+**Actions**
+
+[`dwpb_init`](#dwpb_init).
+
+**Deprecated**
+
+[`dwpb_redirect_admin_options_tools`](#deprecated), [`dpwb_disable_user_post_column`](#deprecated), [`dpwb_create_user_{$post_type}_column`](#deprecated).
+
+### Redirects
+
+Disable Blog redirects front-end pages and admin screens that no longer apply once the
+blog is disabled. These filters control where those redirects go, whether they happen at
+all, and how the destination URL is built.
+
+#### **`dwpb_redirect_front_end`**
+
+Toggles all front-end redirects at once. Return `false` to stop the plugin from
+redirecting single posts, archives, and the other pages listed under
+[Front-end page redirects](#front-end-page-redirects).
+
+**Since:** 0.2.0
+
+**Parameters:**
+
+* `bool $bool` - True to redirect, false to leave the page alone (default: `true`)
+
+**Returns:** `bool`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+// Turn off every front-end redirect.
+add_filter( 'dwpb_redirect_front_end', '__return_false' );
+```
+{% endcode %}
+
+#### **`dwpb_front_end_redirect_url`**
+
+Overrides the destination URL for every front-end redirect at once. It fires after the
+page-specific filter (for example `dwpb_redirect_post`) has already run, and receives
+that filter's result, so whatever it returns is where the plugin actually sends the
+visitor.
+
+**Since:** 0.5.0
+
+**Parameters:**
+
+* `string $redirect_url` - The URL to redirect to (default: the result of the page-specific redirect filter, which itself defaults to the site's front page URL)
+
+**Returns:** `string`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_front_end_redirect_url', function( $redirect_url ) {
+    return home_url( '/site-notice/' );
+} );
+```
+{% endcode %}
+
+#### Front-end page redirects
+
+Six filters share one pattern: each is named `dwpb_redirect_<page>`, takes the site's
+front page URL as its only parameter, and returns the URL to redirect to. Only the first
+matching page below fires on a given request.
+
+| Filter | Page | Redirects when |
+| --- | --- | --- |
+| `dwpb_redirect_post` | Single posts | Always |
+| `dwpb_redirect_post_tag_archive` | Tag archives | No other post type uses the `post_tag` taxonomy |
+| `dwpb_redirect_category_archive` | Category archives | No other post type uses the `category` taxonomy |
+| `dwpb_redirect_blog_page` | Posts page | A Posts page is set in Reading Settings |
+| `dwpb_redirect_date_archive` | Date archives | Always |
+| `dwpb_redirect_author_archive` | Author archives | The `dwpb_disable_author_archives` filter is set to `true`. Off by default |
+
+**Since:** 0.4.0
+
+**Parameters:**
+
+* `string $url` - The URL to redirect to (default: the site's front page URL)
+
+**Returns:** `string`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+// Send single posts to a custom page instead of the homepage.
+add_filter( 'dwpb_redirect_post', function( $url ) {
+    return home_url( '/no-more-blog/' );
+} );
+```
+{% endcode %}
+
+#### **`dwpb_redirect_admin`**
+
+Toggles all admin redirects at once. Return `false` to stop the plugin from redirecting
+`post.php`, `edit.php`, and the other screens listed under
+[Admin screen redirects](#admin-screen-redirects).
+
+**Since:** 0.4.0
+
+**Parameters:**
+
+* `bool $bool` - True to redirect, false to leave the screen alone (default: `true`)
+* `string $redirect_url` - The URL the plugin is about to redirect to
+
+**Returns:** `bool`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+// Turn off every admin redirect.
+add_filter( 'dwpb_redirect_admin', '__return_false' );
+```
+{% endcode %}
+
+#### **`dwpb_admin_redirect_url`**
+
+Overrides the destination URL for every admin redirect at once. It runs on every admin
+page load, not only the nine screens below, receiving whatever the page-specific filter
+produced, or `false` if none of them matched. A callback that unconditionally returns a
+URL redirects every admin screen, so check `$redirect_url` before replacing it.
+
+**Since:** 0.5.0
+
+**Parameters:**
+
+* `string|false $redirect_url` - The URL to redirect to, or `false` if no admin redirect matched this screen
+
+**Returns:** `string`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_admin_redirect_url', function( $redirect_url ) {
+    if ( ! $redirect_url ) {
+        return $redirect_url;
+    }
+    return admin_url( 'options-general.php' );
+} );
+```
+{% endcode %}
+
+#### Admin screen redirects
+
+Nine filters share one pattern: each is named `dwpb_redirect_admin_<screen>`, takes a URL
+as its only parameter, and returns the URL to redirect to. These do not run on Network
+Admin screens.
+
+| Filter | Screen | Redirects when |
+| --- | --- | --- |
+| `dwpb_redirect_admin_post` | `post.php` (edit a single post) | The post being edited is the `post` type |
+| `dwpb_redirect_admin_edit` | `edit.php` (Posts list) | No post type is specified, or it is explicitly `post` |
+| `dwpb_redirect_admin_post_new` | `post-new.php` (Add New Post) | No post type is specified, or it is explicitly `post` |
+| `dwpb_redirect_admin_term` | `term.php` (edit a single term) | The taxonomy is not used by another post type |
+| `dwpb_redirect_admin_edit_tags` | `edit-tags.php` (Categories/Tags list) | The taxonomy is not used by another post type |
+| `dwpb_redirect_admin_edit_comments` | `edit-comments.php` (Comments) | No post type other than `post` supports comments |
+| `dwpb_redirect_admin_options_discussion` | `options-discussion.php` (Settings > Discussion) | No post type other than `post` supports comments |
+| `dwpb_redirect_admin_options_writing` | `options-writing.php` (Settings > Writing) | The `dwpb_remove_options_writing` filter is set to `true`. Off by default |
+| `dwpb_redirect_admin_tools` | `tools.php` (Tools > Available Tools) | There is no `page` parameter in the URL |
+
+**Since:** 0.4.0
+
+**Parameters:**
+
+* `string $url` - The URL to redirect to. Defaults to the dashboard, except `dwpb_redirect_admin_edit` and `dwpb_redirect_admin_post_new`, which default to the matching `page` screen, and `dwpb_redirect_admin_options_writing`, which defaults to Settings > General
+
+**Returns:** `string`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+// Send the Tools screen redirect to the Plugins screen instead of the dashboard.
+add_filter( 'dwpb_redirect_admin_tools', function( $url ) {
+    return admin_url( 'plugins.php' );
+} );
+```
+{% endcode %}
+
+{% hint style="info" %}
+`dwpb_redirect_admin_tools` also fires the older `dwpb_redirect_admin_options_tools`
+name, for compatibility. See [Deprecated](#deprecated).
+{% endhint %}
+
+#### **`dwpb_redirect_status_code`**
+
+Filters the HTTP status code used for every redirect the plugin performs, front-end and
+admin alike.
+
+**Since:** 0.5.0
+
+**Parameters:**
+
+* `int $status_code` - The status code to send (default: `301`)
+* `string $current_url` - The URL being redirected from
+* `string $redirect_url` - The URL being redirected to
+
+**Returns:** `int`. Must resolve to a whole number between 300 and 399; anything else falls back to 301.
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_redirect_status_code', function( $status_code, $current_url, $redirect_url ) {
+    return 302;
+}, 10, 3 );
+```
+{% endcode %}
+
+#### **`dwpb_pass_query_string_on_redirect`**
+
+Toggles whether the current request's query string is carried over to the redirect
+destination. Works together with [`dwpb_allowed_query_vars`](#dwpb_allowed_query_vars),
+which decides which keys are actually kept.
+
+**Since:** 0.5.0
+
+**Parameters:**
+
+* `bool $bool` - True to carry the query string over (default: `false`)
+
+**Returns:** `bool`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_pass_query_string_on_redirect', '__return_true' );
+```
+{% endcode %}
+
+{% hint style="warning" %}
+Both filters are needed together. This one only switches on the mechanism that looks at
+the query string, it does not decide what gets kept. With `dwpb_allowed_query_vars` left
+at its empty default, nothing is carried over even when this returns `true`.
+{% endhint %}
+
+#### **`dwpb_allowed_query_vars`**
+
+Filters the list of query string keys allowed to pass through to a redirect
+destination. Only takes effect when
+[`dwpb_pass_query_string_on_redirect`](#dwpb_pass_query_string_on_redirect) also returns
+`true`.
+
+**Since:** 0.5.0
+
+**Parameters:**
+
+* `array $allowed_query_vars` - The allowed query variable keys (default: `array()`)
+
+**Returns:** `array`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_allowed_query_vars', function( $allowed_query_vars ) {
+    return array( 'utm_source', 'utm_medium', 'utm_campaign' );
+} );
+```
+{% endcode %}
+
+### Front-End
+
+These filters control what changes for site visitors: feeds, the X-Pingback header,
+XML-RPC methods, and sitemap entries.
+
+#### **`dwpb_disable_feed`**
+
+Toggles whether a given feed request is disabled. Runs for the main post feed and, when
+no post type other than `post` supports comments, the comment feed too.
+
+**Since:** 0.4.0
+
+**Parameters:**
+
+* `bool $bool` - True to disable the feed (default: `true`)
+* `WP_Post $post` - The global post object
+* `bool $is_comment_feed` - True if this is a comment feed rather than the main feed
+
+**Returns:** `bool`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+// Keep the main post feed available.
+add_filter( 'dwpb_disable_feed', '__return_false' );
+```
+{% endcode %}
+
+#### **`dwpb_redirect_feeds`**
+
+Filters the URL a disabled feed request redirects to.
+
+**Since:** 0.4.0
+
+**Parameters:**
+
+* `string $url` - The redirect URL (default: the site's homepage, from `home_url()`)
+* `WP_Post $post` - The global post object
+* `bool $is_comment_feed` - True if this is a comment feed rather than the main feed
+
+**Returns:** `string`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_redirect_feeds', function( $url, $post, $is_comment_feed ) {
+    return home_url( '/subscribe/' );
+}, 10, 3 );
+```
+{% endcode %}
+
+#### **`dwpb_feed_message`**
+
+Toggles a plain die message in place of the feed redirect.
+
+**Since:** 0.4.0
+
+**Parameters:**
+
+* `bool $bool` - True to show a message instead of redirecting (default: `false`)
+* `WP_Post $post` - The global post object
+* `bool $is_comment_feed` - True if this is a comment feed rather than the main feed
+
+**Returns:** `bool`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_feed_message', '__return_true' );
+```
+{% endcode %}
+
+#### **`dwpb_feed_die_message`**
+
+Filters the message shown when
+[`dwpb_feed_message`](#dwpb_feed_message) is set to `true`. Only `<a>` tags survive in
+the returned string; everything else is stripped.
+
+**Since:** 0.4.0
+
+**Parameters:**
+
+* `string $message` - The message text (default: "No feed available, please visit our homepage:" followed by a link to the feed redirect URL)
+
+**Returns:** `string`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_feed_die_message', function( $message ) {
+    return 'This site does not publish a feed.';
+} );
+```
+{% endcode %}
+
+#### **`dwpb_disabled_xmlrpc_methods`**
+
+Filters the list of XML-RPC methods the plugin removes: the core, Blogger, and
+MovableType/MetaWeblog posting methods, pingback support, and the category and tag
+management methods, the last two only when no other post type uses that taxonomy.
+
+**Since:** 0.5.0
+
+**Parameters:**
+
+* `array $methods_to_remove` - The XML-RPC method names to disable
+
+**Returns:** `array|bool`. Return `false` to leave every method in place.
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+// Keep every XML-RPC method available.
+add_filter( 'dwpb_disabled_xmlrpc_methods', '__return_false' );
+```
+{% endcode %}
+
+{% hint style="info" %}
+On WordPress 7.1 and later, core removes `pingback.ping` itself outside of a production
+environment. That method stays gone there no matter what this filter returns.
+{% endhint %}
+
+#### **`dwpb_remove_pingback_header`**
+
+Toggles the `X-Pingback` HTTP header WordPress normally sends.
+
+**Since:** 0.4.0
+
+**Parameters:**
+
+* `bool $bool` - True to remove the header (default: `true`)
+
+**Returns:** `bool`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+// Keep the X-Pingback header.
+add_filter( 'dwpb_remove_pingback_header', '__return_false' );
+```
+{% endcode %}
+
+#### **`dwpb_disable_user_sitemap`**
+
+Toggles the built-in users (author) sitemap.
+
+**Since:** 0.5.0
+
+**Parameters:**
+
+* `bool $bool` - True to disable the sitemap (default: `true`, unless post types have been added to author archives with `dwpb_author_archive_post_types` and author archives are not otherwise disabled, in which case it defaults to `false`)
+
+**Returns:** `bool`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+// Always remove the user/author sitemap, regardless of author archive settings.
+add_filter( 'dwpb_disable_user_sitemap', '__return_true' );
+```
+{% endcode %}
+
+#### **`dwpb_disable_removed_sitemaps`**
+
+Toggles whether a request for a sitemap sub-file the plugin has removed entirely, such as
+`/wp-sitemap-users-1.xml` once the users provider is gone, returns a 404 instead of
+falling through to a normal page.
+
+**Since:** 0.5.6
+
+**Parameters:**
+
+* `bool $bool` - True to 404 the request (default: `true`)
+
+**Returns:** `bool`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+// Let removed sitemap sub-files fall through instead of returning a 404.
+add_filter( 'dwpb_disable_removed_sitemaps', '__return_false' );
+```
+{% endcode %}
+
+### Admin
+
+These filters control what changes in wp-admin: menus, dashboard widgets, sidebar
+widgets, and the Users table.
+
+#### **`dwpb_menu_pages_to_remove`**
+
+Filters the top-level admin pages the plugin removes.
+
+**Since:** 0.4.0
+
+**Parameters:**
+
+* `array $remove_pages` - The page slugs to remove (default: `array( 'edit.php' )`, plus `'edit-comments.php'` when no post type other than `post` supports comments)
+
+**Returns:** `array`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+// Keep the Posts menu visible.
+add_filter( 'dwpb_menu_pages_to_remove', function( $remove_pages ) {
+    return array_diff( $remove_pages, array( 'edit.php' ) );
+} );
+```
+{% endcode %}
+
+#### **`dwpb_menu_subpages_to_remove`**
+
+Filters the admin submenu pages the plugin removes. Each array key is a top-level page
+slug, its value an array of submenu page slugs to remove from under it.
+
+**Since:** 0.4.0
+
+**Parameters:**
+
+* `array $remove_subpages` - The page => subpages map (default: `array( 'tools.php' => array( 'tools.php' ), 'options-general.php' => array() )`, with `'options-writing.php'` added when `dwpb_remove_options_writing` is `true`, and `'options-discussion.php'` added when no post type other than `post` supports comments)
+
+**Returns:** `array`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+// Keep the Tools submenu page.
+add_filter( 'dwpb_menu_subpages_to_remove', function( $remove_subpages ) {
+    unset( $remove_subpages['tools.php'] );
+    return $remove_subpages;
+} );
+```
+{% endcode %}
+
+#### **`dwpb_remove_options_writing`**
+
+Toggles the Settings > Writing screen. Off by default because other plugins often add
+their own fields to that screen. Setting this to `true` removes it from the admin menu
+and redirects any direct visit to Settings > General.
+
+**Since:** 0.4.5
+
+**Parameters:**
+
+* `bool $bool` - True to remove the screen (default: `false`)
+
+**Returns:** `bool`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_remove_options_writing', '__return_true' );
+```
+{% endcode %}
+
+#### **`dwpb_unregister_widgets`**
+
+Filters whether each blog related legacy widget gets unregistered. Runs once per widget:
+Recent Comments, Tag Cloud, Categories, Archives, Calendar, Links, Recent Posts, and RSS.
+
+**Since:** 0.4.0
+
+**Parameters:**
+
+* `bool $bool` - True to unregister the widget (default: `true`)
+* `string $widget` - The widget class name currently being processed, for example `WP_Widget_Recent_Comments`
+
+**Returns:** `bool`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_unregister_widgets', function( $bool, $widget ) {
+    if ( 'WP_Widget_Recent_Comments' === $widget ) {
+        return false;
+    }
+    return $bool;
+}, 10, 2 );
+```
+{% endcode %}
+
+#### **`dwpb_disable_{$metabox_id}`**
+
+Toggles a single dashboard widget. `{$metabox_id}` is either `dashboard_quick_press` or
+`dashboard_activity`, the only two dashboard widgets the plugin removes in 0.5.6.
+
+**Since:** 0.4.1
+
+**Parameters:**
+
+* `bool $bool` - True to remove the widget (default: `true`)
+
+**Returns:** `bool`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+// Keep the Quick Press dashboard widget.
+add_filter( 'dwpb_disable_dashboard_quick_press', '__return_false' );
+```
+{% endcode %}
+
+#### **`dwpb_admin_user_post_types`**
+
+Filters the post types that get their own column on the Users screen.
+
+**Since:** 0.5.0
+
+**Parameters:**
+
+* `array $post_types` - The post type slugs to show (default: `array( 'page' )`, plus any post types added to author archives with `dwpb_author_archive_post_types`)
+
+**Returns:** `array`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_admin_user_post_types', function( $post_types ) {
+    $post_types[] = 'event';
+    return $post_types;
+} );
+```
+{% endcode %}
+
+#### **`dwpb_disable_user_post_column`**
+
+Toggles the Posts column that the plugin removes from the Users screen.
+
+**Since:** 0.5.0
+
+**Parameters:**
+
+* `bool $bool` - True to remove the column (default: `true`)
+
+**Returns:** `bool`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+// Keep the Posts column on the Users screen.
+add_filter( 'dwpb_disable_user_post_column', '__return_false' );
+```
+{% endcode %}
+
+{% hint style="info" %}
+**Changed in 0.5.6:** the correct filter name is `dwpb_disable_user_post_column`. The
+misspelled `dpwb_disable_user_post_column` still works. See [Deprecated](#deprecated).
+{% endhint %}
+
+#### **`dwpb_create_user_{$post_type}_column`**
+
+Toggles the column the plugin adds to the Users screen for each post type in
+[`dwpb_admin_user_post_types`](#dwpb_admin_user_post_types), for example `page` or a
+custom post type added to author archives.
+
+**Since:** 0.5.0
+
+**Parameters:**
+
+* `bool $bool` - True to add the column (default: `true`)
+
+**Returns:** `bool`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+// Hide the column added for the 'event' post type.
+add_filter( 'dwpb_create_user_event_column', '__return_false' );
+```
+{% endcode %}
+
+{% hint style="info" %}
+**Changed in 0.5.6:** the correct filter name is `dwpb_create_user_{$post_type}_column`.
+The misspelled `dpwb_create_user_{$post_type}_column` still works. See
+[Deprecated](#deprecated).
+{% endhint %}
+
+### Post Types & Taxonomies
+
+These filters control how the plugin detects which post types, other than `post`,
+support a given feature or taxonomy. That detection decides what stays enabled
+throughout the plugin.
+
+#### **`dwpb_post_types_supporting_{$feature}`**
+
+Filters the list of post types, other than `post`, that support a given `$feature`. The
+plugin uses this internally, for example `dwpb_post_types_supporting_comments`, to decide
+whether related admin screens, menus, and widgets stay active.
+
+**Since:** 0.4.0
+
+**Parameters:**
+
+* `array|bool $post_types_with_feature` - The post types supporting `$feature` (default: the detected list, or `false` if none)
+* `array $args` - The arguments passed to `get_post_types()` when building that list (default: `array()`)
+
+**Returns:** `array|bool`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+// Treat comments as unsupported everywhere, regardless of actual post type support.
+add_filter( 'dwpb_post_types_supporting_comments', '__return_false' );
+```
+{% endcode %}
+
+#### **`dwpb_taxonomy_support`**
+
+Short-circuits `dwpb_post_types_with_tax()`, the function the plugin uses internally to
+find which post types, other than `post`, use a given taxonomy. Returning anything other
+than `null` replaces the result entirely, skipping the plugin's own detection.
+
+**Since:** 0.4.0
+
+**Parameters:**
+
+* `mixed $override` - Return non-null to override the result (default: `null`)
+* `string|object $taxonomy` - The taxonomy slug or taxonomy object being checked
+* `array $post_types` - Every registered post type, from `get_post_types( $args, $output )`. This is not filtered down to the post types that actually use the taxonomy
+* `array $args` - The arguments passed to `dwpb_post_types_with_tax()` (default: `array()`)
+* `string $output` - Either `'names'` or `'objects'` (default: `'names'`)
+
+**Returns:** `mixed`. A non-null return replaces the function's result; `null` falls through to the plugin's normal detection.
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_taxonomy_support', function( $override, $taxonomy, $post_types, $args, $output ) {
+    if ( 'category' === $taxonomy ) {
+        return array( 'event' );
+    }
+    return $override;
+}, 10, 5 );
+```
+{% endcode %}
+
+#### **`dwpb_tag_post_types`**
+
+Filters the post types shown on a tag archive that stays public because another post
+type uses the `post_tag` taxonomy.
+
+**Since:** 0.4.0
+
+**Parameters:**
+
+* `array $post_types` - The post types, other than `post`, that use `post_tag` (default: the result of `dwpb_post_types_with_tax( 'post_tag' )`)
+* `WP_Query $query` - The main query being modified
+
+**Returns:** `array`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_tag_post_types', function( $post_types, $query ) {
+    $post_types[] = 'event';
+    return $post_types;
+}, 10, 2 );
+```
+{% endcode %}
+
+#### **`dwpb_category_post_types`**
+
+Filters the post types shown on a category archive that stays public because another
+post type uses the `category` taxonomy.
+
+**Since:** 0.4.0
+
+**Parameters:**
+
+* `array $post_types` - The post types, other than `post`, that use `category` (default: the result of `dwpb_post_types_with_tax( 'category' )`)
+* `WP_Query $query` - The main query being modified
+
+**Returns:** `array`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_category_post_types', function( $post_types, $query ) {
+    $post_types[] = 'event';
+    return $post_types;
+}, 10, 2 );
+```
+{% endcode %}
+
+#### **`dwpb_disable_author_archives`**
+
+Toggles author archives entirely. Off by default because themes and plugins commonly
+repurpose the author archive as a profile page.
+
+**Since:** 0.5.0
+
+**Parameters:**
+
+* `bool $bool` - True to disable author archives (default: `false`)
+
+**Returns:** `bool`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_disable_author_archives', '__return_true' );
+```
+{% endcode %}
+
+{% hint style="info" %}
+Turning this on also removes the users sitemap.
+{% endhint %}
+
+#### **`dwpb_author_archive_post_types`**
+
+Adds post types to author archive pages. The returned array replaces the list entirely,
+so include `post` yourself if you still want ordinary posts to keep appearing.
+
+**Since:** 0.5.0
+
+**Parameters:**
+
+* `array|bool $post_types` - The post type slugs to show on author archives (default: `array()`)
+
+**Returns:** `array|bool`
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+add_filter( 'dwpb_author_archive_post_types', function( $post_types ) {
+    return array( 'post', 'event' );
+} );
+```
+{% endcode %}
+
+{% hint style="info" %}
+This filter also decides whether the users sitemap appears. Left at its empty default,
+the users sitemap stays off. Adding any post type here turns it back on, unless
+`dwpb_disable_user_sitemap` overrides that.
+{% endhint %}
+
+### Actions
+
+Disable Blog fires one action of its own.
+
+#### **`dwpb_init`**
+
+Fires at the very start of the plugin's main class constructor, before Disable Blog
+checks for an upgrade, loads its dependencies, or registers any of its own hooks. Use it
+to run code that needs to happen before anything else in the plugin.
+
+**Since:** 0.4.0
+
+**Parameters:** None
+
+**Example:**
+
+{% code overflow="wrap" %}
+```php
+add_action( 'dwpb_init', function() {
+    // Runs before Disable Blog loads its own classes and hooks.
+} );
+```
+{% endcode %}
+
+### Deprecated
+
+These filter names still work as of 0.5.6. Each one runs through
+`apply_filters_deprecated()`, so hooking it also triggers a WordPress deprecation
+notice.
+
+The replacement filter runs first, and the deprecated one then receives its result. If
+you have callbacks on both names, the deprecated name gets the final say. Move your code
+to the replacement and drop the old callback.
+
+| Deprecated | Use instead |
+| --- | --- |
+| `dwpb_redirect_admin_options_tools` | `dwpb_redirect_admin_tools` |
+| `dpwb_disable_user_post_column` | `dwpb_disable_user_post_column` |
+| `dpwb_create_user_{$post_type}_column` | `dwpb_create_user_{$post_type}_column` |
+
+***
+
+See [PHP Functions](functions.md) for the plugin's callable functions, and [Common
+Customizations](common-customizations.md) for task-oriented recipes built on the filters
+above.

--- a/docs/extending-the-plugin/plugin-integrations.md
+++ b/docs/extending-the-plugin/plugin-integrations.md
@@ -1,0 +1,89 @@
+# Plugin Integrations
+
+Disable Blog changes its own behavior when certain other plugins are active. Two
+integrations ship with the plugin: Disable Comments and WooCommerce. Both are
+automatic. There is nothing to configure.
+
+### Disable Comments
+
+If [Disable Comments](https://wordpress.org/plugins/disable-comments/) is active,
+Disable Blog forces its own `dwpb_post_types_supporting_comments` filter to always
+return `false`, as if no post type supported comments at all.
+
+That has two separate effects, because Disable Blog checks comment support two
+different ways:
+
+* The hooks that adjust comment behavior (admin comment counts, `wp_count_comments`,
+  filtering comments out of the Comments list, and similar) only register when
+  [`dwpb_post_types_with_feature( 'comments' )`](functions.md) returns something. With
+  the filter forced to `false`, none of them register, so Disable Blog stops adjusting
+  comment behavior and leaves that to Disable Comments.
+* The screen-removal checks test the opposite condition,
+  `! dwpb_post_types_with_feature( 'comments' )`, so forcing the filter to `false`
+  makes that condition true instead. The Comments menu item and Settings > Discussion
+  are both removed, and visiting either page directly redirects to the dashboard, the
+  same as on a site where nothing but `post` supports comments.
+
+In short, with Disable Comments active, Disable Blog stops adjusting comment behavior
+itself, and its own Comments admin screens still disappear, exactly as they would with
+no comment-supporting post types at all.
+
+### WooCommerce
+
+If WooCommerce is active and at least one post type other than `post` still supports
+comments, Disable Blog adds a compatibility filter on `wp_count_comments`.
+
+The filter only changes anything on WooCommerce version 2.6.2 or earlier, meaning any
+release before 2.6.3. Those versions returned an object instead of an array from the
+site-wide comment count (`wp_count_comments( 0 )`), which broke code expecting an
+array. Disable Blog casts the count back to an array when it detects one of those old
+versions.
+
+{% hint style="info" %}
+Current WooCommerce releases are unaffected. This filter only matters on sites still
+running WooCommerce 2.6.2 or earlier.
+{% endhint %}
+
+### Writing your own integration
+
+`Disable_Blog_Integrations` is a small class of plugin-detection helpers, the same
+class behind both integrations above. Its `is_plugin_active()` method wraps
+WordPress's own `is_plugin_active()` function, loading `wp-admin/includes/plugin.php`
+first if it is not already available, since that function does not normally exist
+outside `wp-admin`. `is_disable_comments_active()` and `is_woocommerce_active()` both
+build on that one method, each checking a known plugin path and, as a fallback, a class
+or function the other plugin defines.
+
+Everything is wired together in `plugin_integrations()` on the main plugin class, which
+runs once when Disable Blog boots. There is no formal registration API for third-party
+integrations. The supported way to make Disable Blog aware of another plugin is the
+same filters covered in
+[Hooks, Filters, and Actions](hooks-filters-and-actions.md), combined with your own
+`is_plugin_active()` check, the same approach used above for Disable Comments and
+WooCommerce.
+
+For example, to make Disable Blog back off its own comment handling whenever some other
+comment-management plugin is active, add this to your theme's `functions.php` file or
+as an [MU plugin](https://wordpress.org/documentation/article/must-use-plugins/):
+
+{% code overflow="wrap" %}
+```php
+function my_dwpb_defer_to_comments_plugin() {
+    if ( ! function_exists( 'is_plugin_active' ) ) {
+        include_once ABSPATH . 'wp-admin/includes/plugin.php';
+    }
+
+    if ( is_plugin_active( 'some-other-comments-plugin/plugin.php' ) ) {
+        add_filter( 'dwpb_post_types_supporting_comments', '__return_false' );
+    }
+}
+// Priority 5 so this runs before Disable Blog's own setup, which hooks
+// 'plugins_loaded' at the default priority of 10.
+add_action( 'plugins_loaded', 'my_dwpb_defer_to_comments_plugin', 5 );
+```
+{% endcode %}
+
+This is the same pattern Disable Blog uses for Disable Comments, aimed at whichever
+plugin you need to detect. Swap in its real plugin path, and swap the filter for
+whichever behavior in [Hooks, Filters, and Actions](hooks-filters-and-actions.md) you
+want to switch off.

--- a/docs/usage/admin-changes.md
+++ b/docs/usage/admin-changes.md
@@ -1,0 +1,121 @@
+# Admin Changes
+
+Disable Blog also changes what you see in wp-admin. This page is the full reference for
+what disappears: menus, redirects, comment handling, dashboard widgets, settings
+screens, and a handful of smaller changes.
+
+### Menus
+
+The Posts menu is always removed. The Comments menu goes too, but only when nothing
+other than `post` supports comments. Pages support comments by default in WordPress, so
+in practice this menu stays unless something has changed that. See Comments, below.
+
+Under Settings, the Discussion submenu is removed under that same comments condition.
+The Writing submenu stays unless you set the `dwpb_remove_options_writing` filter to
+`true`; it's `false` by default because other plugins often extend that screen. Tools
+loses its default "Available Tools" landing page, though the Tools menu itself stays if
+another plugin adds its own tools page.
+
+Adjust the top-level removals with `dwpb_menu_pages_to_remove`, and the submenu
+removals with `dwpb_menu_subpages_to_remove`.
+
+### Admin redirects
+
+Nine admin screens redirect elsewhere once they no longer apply. The Posts list and Add
+New Post go to their Pages equivalents, Settings > Writing goes to Settings > General,
+and the rest go to the dashboard. These redirects don't run on Network Admin screens.
+
+| Screen | Redirects to | When |
+| --- | --- | --- |
+| `post.php` (edit a single post) | Dashboard | The post being edited is the `post` type |
+| `edit.php` (Posts list) | `edit.php?post_type=page` (Pages list) | No post type is specified, or it's explicitly `post` |
+| `post-new.php` (Add New Post) | `post-new.php?post_type=page` (Add New Page) | No post type is specified, or it's explicitly `post` |
+| `edit-tags.php` (Categories/Tags list) | Dashboard | The taxonomy isn't used by another post type |
+| `term.php` (edit a single term) | Dashboard | The taxonomy isn't used by another post type |
+| `edit-comments.php` (Comments) | Dashboard | No post type other than `post` supports comments |
+| `options-discussion.php` (Settings > Discussion) | Dashboard | No post type other than `post` supports comments |
+| `options-writing.php` (Settings > Writing) | `options-general.php` (Settings > General) | The `dwpb_remove_options_writing` filter is set to `true`. Off by default |
+| `tools.php` (Tools > Available Tools) | Dashboard | There's no `page` parameter in the URL, so a plugin's own tools page isn't caught |
+
+Two filters apply across the whole list: `dwpb_redirect_admin` turns off admin
+redirects entirely, and `dwpb_admin_redirect_url` overrides the destination for all of
+them. Each row also has its own filter, named for the screen it redirects, for example
+`dwpb_redirect_admin_tools` for the Tools screen.
+
+### Comments
+
+Comments stay on. Pages support comments by default in WordPress, and so does the
+built-in Attachment type, so Disable Blog leaves the Comments screen, Settings >
+Discussion, and the Comments item in the admin toolbar alone unless nothing other than
+`post` actually supports comments.
+
+If you want to turn comments off across your whole site, use the
+[Disable Comments](https://wordpress.org/plugins/disable-comments/) plugin rather than
+looking for that option here. When Disable Comments is active, Disable Blog stops
+adjusting comments itself and treats them as unsupported, which removes the Comments
+screen, Settings > Discussion, and the toolbar item. The same thing happens if anything
+else on your site removes comment support from every post type except `post`.
+
+When the Comments screen stays available, it only lists comments left on the post types
+that still support them; comments on ordinary posts are filtered out. Comment counts
+throughout the admin, including the Comments screen's status links and the toolbar
+bubble, are recalculated to match.
+
+### Dashboard
+
+Disable Blog removes two dashboard widgets: Quick Press and Activity. Each has its own
+filter if you'd rather keep one, named `dwpb_disable_{$metabox_id}`, for example
+`dwpb_disable_dashboard_quick_press`.
+
+On the At a Glance widget, the post count and comment count are hidden.
+
+### Settings screens
+
+#### Reading
+
+Once a static homepage is set, the settings that no longer apply are hidden: how many
+posts to show per page, and the feed settings for item count and whether feeds show
+full text or a summary.
+
+#### Writing
+
+The default post format field is always hidden. The default post category field is
+hidden too, unless another post type uses categories.
+
+#### Permalinks
+
+The category base and tag base fields are hidden individually when nothing else uses
+that taxonomy, and the whole "Optional" section that holds them disappears when neither
+is in use.
+
+#### Customizer
+
+Once a static homepage is set, the Homepage Settings panel is simplified to match the
+Reading screen. The choice between "Your latest posts" and "A static page," the posts
+page selector, and the excerpt display settings are all hidden, leaving just the
+homepage selector.
+
+### Other
+
+The "+ New" item in the admin toolbar no longer includes Post. Adding a new page or
+other content type still works as usual.
+
+The Users table swaps its Posts column for a Pages column, showing how many pages each
+user has authored instead. If you've added post types to author archives with
+`dwpb_author_archive_post_types`, those get their own columns too. Keep the original
+Posts column with `dwpb_disable_user_post_column`, or turn off the Pages column, or any
+other post type's column, with `dwpb_create_user_{$post_type}_column`.
+
+On the Tags and Categories screens, when they stay available because another post type
+uses that taxonomy, the post count shown next to each term reflects only that post
+type. It no longer counts ordinary posts, which aren't viewable anyway.
+
+Site Health's REST API availability check is replaced with an equivalent check against
+the `page` type instead of `post`, so it doesn't report a false problem after `post` is
+removed from the REST API.
+
+***
+
+Every behavior on this page is controlled by a filter. See
+[Hooks, Filters, and Actions](../extending-the-plugin/hooks-filters-and-actions.md) for
+the full reference, including default values and examples.

--- a/docs/usage/deactivate-and-uninstall.md
+++ b/docs/usage/deactivate-and-uninstall.md
@@ -1,0 +1,60 @@
+# Deactivate & Uninstall
+
+### Deactivate the plugin
+
+Deactivating Disable Blog is safe. All blog functionality returns immediately: posts and comments become visible again, and the plugin's redirects stop. Nothing is lost.
+
+#### From the Plugins screen
+
+1. From the WordPress admin screen, navigate to "Plugins."
+2. Locate the Disable Blog plugin.
+3. Click "Deactivate."
+
+#### With WP-CLI
+
+Deactivate the plugin with wp-cli:
+
+{% code overflow="wrap" %}
+```bash
+wp plugin deactivate disable-blog
+```
+{% endcode %}
+
+### Uninstall the plugin
+
+#### Uninstall from the Plugins screen
+
+1. Deactivate the plugin (see above).
+2. From the WordPress admin screen, navigate to "Plugins."
+3. Locate the Disable Blog plugin.
+4. Click "Delete."
+
+#### Uninstall with WP-CLI
+
+Uninstall the plugin with wp-cli:
+
+{% code overflow="wrap" %}
+```bash
+wp plugin uninstall disable-blog
+```
+{% endcode %}
+
+#### Remove via Composer
+
+Run this command:
+
+{% code overflow="wrap" %}
+```bash
+composer remove wpackagist-plugin/disable-blog
+```
+{% endcode %}
+
+### What uninstall deletes
+
+Uninstalling removes the database options Disable Blog uses to track its own version, and nothing else.
+
+Your posts, comments, categories, and tags are untouched. They stay in the database exactly as they were. See [Your Content & Data](your-content-and-data.md) for the fuller explanation.
+
+{% hint style="info" %}
+On multisite, uninstalling clears those options from every site in the network, one at a time. Networks with 5,000 or more sites skip this per-site cleanup.
+{% endhint %}

--- a/docs/usage/frequently-asked-questions.md
+++ b/docs/usage/frequently-asked-questions.md
@@ -1,7 +1,5 @@
 # Frequently Asked Questions
 
-## Frequently Asked Questions
-
 <details>
 
 <summary>Can I disable comments?</summary>

--- a/docs/usage/frequently-asked-questions.md
+++ b/docs/usage/frequently-asked-questions.md
@@ -1,0 +1,106 @@
+# Frequently Asked Questions
+
+## Frequently Asked Questions
+
+<details>
+
+<summary>Can I disable comments?</summary>
+
+Disable Blog leaves comments turned on, because pages and other post types can use comments independently of posts. If you want to turn comments off across your whole site, use the [Disable Comments](https://wordpress.org/plugins/disable-comments/) plugin. Disable Blog detects when Disable Comments is active and turns off its own comment handling, so the two plugins do not overlap.
+
+</details>
+
+<details>
+
+<summary>I want to delete my posts and comments.</summary>
+
+Deleting a post also deletes its comments, but you need to do this in a specific order since the plugin redirects the screens you would normally use to delete them. See [Your Content & Data](your-content-and-data.md) for the full steps.
+
+</details>
+
+<details>
+
+<summary>How can I disable author archives?</summary>
+
+Use the `dwpb_disable_author_archives` filter. It defaults to `false` because many themes and plugins use author archives as profile or account pages, so Disable Blog leaves them alone unless you turn them off yourself. Add this to your theme's `functions.php` file or as an [MU plugin](https://wordpress.org/documentation/article/must-use-plugins/):
+
+```php
+add_filter( 'dwpb_disable_author_archives', '__return_true' );
+```
+
+If some custom post types should still appear on author archives, list them with the `dwpb_author_archive_post_types` filter.
+
+</details>
+
+<details>
+
+<summary>How can I change the plugin's behavior?</summary>
+
+Disable Blog has no settings page. Every behavior, from redirects to feeds to sitemaps, is controlled through filters instead. See [Hooks, Filters, and Actions](../extending-the-plugin/hooks-filters-and-actions.md) for the full reference.
+
+</details>
+
+<details>
+
+<summary>Why is my blog page still showing?</summary>
+
+Disable Blog only redirects the front end when your site has a static front page set. If Settings > Reading > "Your homepage displays" is set to "Your latest posts" instead of a static page, none of the plugin's front-end redirects run, including the blog page. See [Setting Up Your Site](setting-up.md) for the full requirement.
+
+</details>
+
+<details>
+
+<summary>Where do the redirects send people?</summary>
+
+To your homepage. Single posts, date archives, the posts page, and any tag or category archive that nothing else uses all redirect there, using a 301. In wp-admin, the Posts list and Add New Post go to their Pages equivalents, and the rest of the redirected screens go to the dashboard. See [Front-End Changes](front-end-changes.md) and [Admin Changes](admin-changes.md) for the full tables.
+
+</details>
+
+<details>
+
+<summary>Why does the Query Loop block default to pages?</summary>
+
+Because posts are disabled, Disable Blog changes the Query Loop block's default post type from `post` to `page`. Without that, a newly inserted Query Loop would default to content the plugin has turned off and show nothing. You can still pick any other post type in the block settings.
+
+</details>
+
+<details>
+
+<summary>I use categories or tags on a custom post type, will they still work?</summary>
+
+Yes. Before Disable Blog hides or redirects a category or tag, it checks whether any post type other than `post` is registered to use that taxonomy. If a custom post type uses `category` or `post_tag`, the taxonomy stays fully functional there, including its admin screens, archives, and REST support. Override this detection with the `dwpb_taxonomy_support` filter by adding it to your theme's `functions.php` file or as an [MU plugin](https://wordpress.org/documentation/article/must-use-plugins/):
+
+```php
+add_filter( 'dwpb_taxonomy_support', function( $override, $taxonomy ) {
+	if ( 'post_tag' === $taxonomy ) {
+		return array( 'my_custom_post_type' );
+	}
+	return $override;
+}, 10, 2 );
+```
+
+</details>
+
+<details>
+
+<summary>Does this work on multisite?</summary>
+
+Yes. You can activate Disable Blog on a single site or across the whole network. Admin redirects are skipped on network admin screens, since those manage the network rather than a single site's content. Uninstalling clears the plugin's stored options from every site in the network, unless the network has 5,000 sites or more, in which case that per-site cleanup is skipped.
+
+</details>
+
+<details>
+
+<summary>Where are the plugin's settings?</summary>
+
+There is no settings screen. Disable Blog is configured entirely through code, using the filters listed in [Hooks, Filters, and Actions](../extending-the-plugin/hooks-filters-and-actions.md).
+
+</details>
+
+<details>
+
+<summary>Does this delete anything?</summary>
+
+No. Disable Blog only hides and redirects, it never deletes posts, comments, categories, or tags. See [Your Content & Data](your-content-and-data.md) for exactly what stays and what changes.
+
+</details>

--- a/docs/usage/front-end-changes.md
+++ b/docs/usage/front-end-changes.md
@@ -1,0 +1,106 @@
+# Front-End Changes
+
+Disable Blog changes what visitors can reach on the front end of your site. This page is
+the full reference for what changes: redirects, feeds, archives, sitemaps, and the REST
+API and XML-RPC.
+
+{% hint style="info" %}
+The redirects on this page only run once your site has a static homepage set. See
+[Setting Up Your Site](setting-up.md).
+{% endhint %}
+
+### Redirects
+
+Disable Blog redirects six kinds of front-end pages to your homepage. Sitemap requests
+are excluded from this check; see Sitemaps, below.
+
+| Page | Redirects to | When |
+| --- | --- | --- |
+| Single posts | Homepage | Always |
+| Tag archives | Homepage | Only when no other post type uses the `post_tag` taxonomy |
+| Category archives | Homepage | Only when no other post type uses the `category` taxonomy |
+| Posts page | Homepage | Only when a Posts page is set in Reading Settings |
+| Date archives | Homepage | Always |
+| Author archives | Homepage | Only when the `dwpb_disable_author_archives` filter is set to `true`. Off by default |
+
+Redirects use a 301 (Moved Permanently) status by default. Change it with the
+`dwpb_redirect_status_code` filter; invalid values fall back to 301.
+
+Query strings are dropped from the destination URL by default. Allow specific ones
+through with the `dwpb_pass_query_string_on_redirect` and `dwpb_allowed_query_vars`
+filters.
+
+Turn off all front-end redirects at once with `dwpb_redirect_front_end`, or override the
+destination URL for all of them with `dwpb_front_end_redirect_url`. Each row in the table
+above also has its own filter, named for the page it redirects, for example
+`dwpb_redirect_post` for single posts.
+
+### Feeds
+
+Disable Blog turns off the site's main post feed, in every format WordPress serves: RSS,
+RSS2, RDF, and Atom. This includes requests made with a query string, like
+`/?feed=rss2`, not just pretty-permalink URLs like `/feed/`. Feeds for other post types
+are not affected.
+
+Visiting the feed redirects to your homepage by default, using the same redirect
+settings as the rest of the site. Show a plain message instead of redirecting with the
+`dwpb_feed_message` filter, and customize that message with `dwpb_feed_die_message`. The
+redirect destination is filterable on its own with `dwpb_redirect_feeds`.
+
+Comment feeds keep working as long as some post type other than `post` supports
+comments, which is true by default since Pages support comments too. If `post` is the
+only post type that supports comments, its comment feed is disabled the same way as the
+main feed. Turn feed disabling off entirely with `dwpb_disable_feed`.
+
+Feed-related links are also removed from your site's `<head>`: the general feed links,
+the extra feed links WordPress adds on archives and single entries, the RSD link, and
+the Windows Live Writer manifest link.
+
+### Archives
+
+On a tag or category archive that stays public, because another post type also uses
+that taxonomy, the archive only shows posts from those other post types. Ordinary posts
+don't appear there. Adjust which post types show with the `dwpb_tag_post_types` and
+`dwpb_category_post_types` filters.
+
+Author archives are not changed this way by default; an author's archive page lists
+their posts exactly as it always has. Add other post types to an author's archive with
+the `dwpb_author_archive_post_types` filter. That filter replaces the list of post types
+entirely, so include `post` yourself if you still want ordinary posts to appear alongside
+the others.
+
+### Sitemaps
+
+Disable Blog updates WordPress's built-in XML sitemaps to match the rest of the site.
+
+* The post sitemap no longer lists posts.
+* The category and tag sitemaps are removed, unless another post type uses that
+  taxonomy.
+* The users (author) sitemap is removed by default. It only reappears if you add post
+  types to author archives with the `dwpb_author_archive_post_types` filter. Override
+  this directly with `dwpb_disable_user_sitemap`.
+
+Requesting a sitemap the plugin has removed, such as `/wp-sitemap-users-1.xml`, returns
+a 404 instead of a live page. Turn this off with `dwpb_disable_removed_sitemaps`.
+
+### REST API and XML-RPC
+
+The `post` type is always removed from the REST API. Its `category` and `post_tag`
+taxonomies are removed too, but only when no other post type uses them, so a custom post
+type sharing either taxonomy keeps full REST support for it.
+
+XML-RPC loses its posting methods: the ones used to create, edit, delete, and retrieve
+posts, plus the equivalent methods from the older Blogger and MovableType/MetaWeblog
+APIs, and pingback support. If no other post type uses categories or tags, the methods
+for managing those are removed too. Adjust the list with the
+`dwpb_disabled_xmlrpc_methods` filter, or return `false` from it to leave every method in
+place.
+
+The `X-Pingback` HTTP header WordPress normally sends is also removed. Turn this off
+with `dwpb_remove_pingback_header`.
+
+***
+
+Every behavior on this page is controlled by a filter. See
+[Hooks, Filters, and Actions](../extending-the-plugin/hooks-filters-and-actions.md) for
+the full reference, including default values and examples.

--- a/docs/usage/install-and-activate.md
+++ b/docs/usage/install-and-activate.md
@@ -1,0 +1,59 @@
+# Install & Activate
+
+### Install & Activate via WordPress Plugins Screen
+
+1. From the WordPress admin screen, navigate to "Plugins."
+2. Click on the "Add New Plugin" button.
+3. In the Search bar enter `Disable Blog`.
+4. Find the plugin in the results and click "Install Now."
+5. After installation, activate the plugin by clicking "Activate now."
+
+### Install via FTP
+
+1. Download the most current version of the plugin from the WP repository or Github release.
+2. Access your site's FTP using the tool of your choice, such as FileZilla or Cyberduck.
+3. Unzip the plugin files and upload the `disable-blog` plugin folder into your `wp-content/plugins/` folder.
+4. From the WordPress admin screen, navigate to "Plugins."
+5. Find the plugin and click "activate."
+
+### Install & Activate via WP CLI
+
+Install the plugin with wp-cli:
+
+{% code overflow="wrap" %}
+```bash
+wp plugin install disable-blog
+```
+{% endcode %}
+
+Activate the plugin with wp-cli:
+
+{% code overflow="wrap" %}
+```bash
+wp plugin activate disable-blog
+```
+{% endcode %}
+
+### Install via Composer
+
+To add this plugin to your project as a dependency using Composer, use [wpackagist](https://wpackagist.org/).
+
+Run this command:
+
+{% code overflow="wrap" %}
+```bash
+composer require wpackagist-plugin/disable-blog
+```
+{% endcode %}
+
+Or add the package to your `composer.json`:
+
+{% code overflow="wrap" %}
+```bash
+wpackagist-plugin/disable-blog
+```
+{% endcode %}
+
+### Next step
+
+Activating Disable Blog is not enough on its own. The plugin needs a static front page to redirect visitors to, or its redirects will not work. See [Setting Up Your Site](setting-up.md) to finish the setup.

--- a/docs/usage/install-and-activate.md
+++ b/docs/usage/install-and-activate.md
@@ -10,7 +10,7 @@
 
 ### Install via FTP
 
-1. Download the most current version of the plugin from the WP repository or Github release.
+1. Download the most current version of the plugin from the WP repository or GitHub release.
 2. Access your site's FTP using the tool of your choice, such as FileZilla or Cyberduck.
 3. Unzip the plugin files and upload the `disable-blog` plugin folder into your `wp-content/plugins/` folder.
 4. From the WordPress admin screen, navigate to "Plugins."
@@ -46,11 +46,22 @@ composer require wpackagist-plugin/disable-blog
 ```
 {% endcode %}
 
-Or add the package to your `composer.json`:
+That command assumes wpackagist is already registered as a repository in your project.
+If it is not, add it to your `composer.json` along with the plugin:
 
 {% code overflow="wrap" %}
-```bash
-wpackagist-plugin/disable-blog
+```json
+{
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://wpackagist.org"
+        }
+    ],
+    "require": {
+        "wpackagist-plugin/disable-blog": "^0.5"
+    }
+}
 ```
 {% endcode %}
 

--- a/docs/usage/setting-up.md
+++ b/docs/usage/setting-up.md
@@ -1,0 +1,30 @@
+# Setting Up Your Site
+
+{% hint style="warning" %}
+Settings > Reading > "Your homepage displays" must be set to "A static page," with a page selected. Otherwise, Disable Blog's redirects will not work, and your blog index stays reachable on the front end.
+{% endhint %}
+
+### Set a static homepage
+
+1. From the WordPress admin screen, navigate to Settings > Reading.
+2. Under "Your homepage displays," choose "A static page."
+3. From the Homepage dropdown, select the page you want visitors to land on.
+4. Click "Save Changes."
+
+### The optional Posts page setting
+
+The "Posts page" dropdown on the same screen is not required. You can leave it unset.
+
+If you do set one, Disable Blog redirects it to your homepage, the same as it redirects any other blog URL. If you set the Posts page to the same page as your homepage, the plugin shows an admin notice telling you the two need to be different pages.
+
+### Why a static homepage is required
+
+Disable Blog works by redirecting posts, archives, and the blog index to your homepage. To send visitors anywhere, it needs to know which page that is.
+
+If "Your homepage displays" is still set to "Your latest posts," WordPress has no static front page, and the plugin has nothing to redirect to. None of its front-end redirects run in that case, so posts, archives, and the blog index all stay live and reachable.
+
+The rest of the plugin still works. Posts stay out of search results, the REST API, and the admin menu either way. It is only the redirects that need a homepage.
+
+### The admin notice
+
+While a static homepage is missing, Disable Blog shows a red admin notice: "Disable Blog is not fully active until a static page is selected for the site's homepage." On the Plugins screen and on list screens like Pages, the notice links to Reading Settings. On the Reading Settings screen itself, it tells you to select a page for your homepage below instead. You'll see this notice on those three screens until a homepage is set.

--- a/docs/usage/your-content-and-data.md
+++ b/docs/usage/your-content-and-data.md
@@ -1,0 +1,34 @@
+# Your Content & Data
+
+Activating Disable Blog will not delete anything on your site. This page explains exactly what happens to your content, and how to get it back.
+
+### Nothing is deleted
+
+Your posts, categories, tags, and comments all stay in the database exactly as they were before you activated the plugin. Disable Blog hides and redirects blog content, it never removes it.
+
+### What "disabled" means in practice
+
+While the plugin is active, that content is not reachable on the front end and not editable in wp-admin. A post's URL redirects visitors to your homepage, and the Posts admin screens redirect you away, most of them to the dashboard. The content is not gone, it is only out of reach.
+
+### Getting your content back
+
+Deactivate the plugin and everything returns immediately. Posts reappear on the front end, comments come back, and the Posts menu returns in wp-admin. Nothing needs to be restored or re-imported, because nothing was ever removed.
+
+### If you actually want to delete the posts
+
+If you want that content gone for good, the order matters:
+
+1. Deactivate the plugin.
+2. Delete the posts you no longer want. Deleting a post also deletes its comments.
+3. Delete any categories and tags you no longer need.
+4. Reactivate the plugin.
+
+{% hint style="warning" %}
+Do this in order. While Disable Blog is active, the screens you need to delete posts, categories, and tags are redirected, so deactivate first.
+{% endhint %}
+
+### What the plugin stores
+
+Disable Blog stores two small options in the database: `dwpb_version` and `dwpb_previous_version`. They record the plugin version currently installed and the version you upgraded from, and the plugin uses them only to detect upgrades, not to store any of your content or settings.
+
+Uninstalling the plugin removes both options. See [Deactivate & Uninstall](deactivate-and-uninstall.md) for what uninstalling does.


### PR DESCRIPTION
Adds a GitBook documentation site under `/docs/`, matching the setup used by archived-post-status. It will publish at docs.disable.blog.

## What's here

- `.gitbook.yaml` at the repo root, pointing GitBook at `./docs/`
- **Usage:** install, setup, front-end changes, admin changes, content and data, uninstall, FAQ
- **Extending:** full hook reference, the two public PHP functions, customization recipes, plugin integrations
- `README.md` trims its functionality list and FAQ in favor of links into `docs/`, which now cover both in more depth. Links are relative so they resolve on GitHub before the site is live.
- `.distignore` excludes `/docs/`, `/.dev/`, and `.gitbook.yaml` so none of it ships in the plugin ZIP

## Documents 0.5.6, not 0.5.5

Every claim was verified against the `e2e/playwright` source rather than `stable`, since 0.5.6 changes the public filter surface: `dwpb_disable_removed_sitemaps` is new, three filters were renamed with `apply_filters_deprecated()` shims, and two dashboard-widget filters that never had any effect were removed.

## Verification

- All 48 hook names in the source have a reference entry, confirmed by enumerating every `apply_filters` and `do_action` call
- All 49 PHP examples lint clean on PHP 8.4, with `accepted_args` matched to each callback's parameter count
- Every relative link resolves; `SUMMARY.md` and the files on disk match in both directions
- No plugin behavior is changed by this branch

## Notes for review

- `.dev/specs/` holds the design spec for this work. It is excluded from the build; drop the two spec commits if you would rather not keep it in the repo.
- Screenshots were deliberately left out. `docs/.gitbook/assets/` exists and is ready for them.
- Separately committed to `e2e/playwright` as `2317a93`: a docblock correction for `dwpb_taxonomy_support`, whose third parameter was documented as the post types using the taxonomy when the code passes every registered post type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)