### PR TITLE
Add PHPUnit unit test suite

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -62,3 +62,38 @@ jobs:
 
     - name: "Run PHPStan"
       run: "composer phpstan"
+
+  phpunit:
+    name: "Run PHPUnit"
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        php-versions: ['7.4', '8.4']
+    steps:
+    - name: "Checkout"
+      uses: "actions/checkout@v4"
+    - name: "Install PHP"
+      uses: "shivammathur/setup-php@v2"
+      with:
+        php-version: ${{ matrix.php-versions }}
+        coverage: "none"
+    - name: "Install dependencies"
+      run: "composer install"
+    - name: "Run PHPUnit"
+      run: "composer test"
+
+  coverage:
+    name: "Measure test coverage"
+    runs-on: "ubuntu-latest"
+    steps:
+    - name: "Checkout"
+      uses: "actions/checkout@v4"
+    - name: "Install PHP"
+      uses: "shivammathur/setup-php@v2"
+      with:
+        php-version: "8.4"
+        coverage: "xdebug"
+    - name: "Install dependencies"
+      run: "composer install"
+    - name: "Run PHPUnit with coverage"
+      run: "composer test:coverage"

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 /artifacts/
 /playwright-report/
 /.wp-env.override.json
+
+# PHPUnit artifacts
+.phpunit.cache/
+/coverage/

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,12 @@
     ],
     "lint": [
       "find *.php includes/ -type f -name '*.php' -print0 | xargs -0 -L1 -P4 -- php -l"
+    ],
+    "test": [
+      "./vendor/bin/phpunit"
+    ],
+    "test:coverage": [
+      "@php -dxdebug.mode=coverage ./vendor/bin/phpunit --coverage-text"
     ]
   },
   "minimum-stability": "stable",
@@ -48,6 +54,10 @@
     "phpcompatibility/phpcompatibility-wp": "^2.1",
     "szepeviktor/phpstan-wordpress": "^2.0",
     "sirbrillig/phpcs-variable-analysis": "^2.12",
-    "automattic/vipwpcs": "^3.0"
+    "automattic/vipwpcs": "^3.0",
+    "phpunit/phpunit": "^9.6",
+    "10up/wp_mock": "^1.1",
+    "yoast/phpunit-polyfills": "^4.0",
+    "mockery/mockery": "^1.6"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.11",
-    "phpstan/phpstan": "^2.1",
+    "phpstan/phpstan": "^2.2",
     "phpstan/extension-installer": "^1.4",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
@@ -58,6 +58,7 @@
     "phpunit/phpunit": "^9.6",
     "10up/wp_mock": "^1.1",
     "yoast/phpunit-polyfills": "^4.0",
-    "mockery/mockery": "^1.6"
+    "mockery/mockery": "^1.6",
+    "phpstan/phpstan-phpunit": "^2.0"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "314638330857cf7646212d2955546426",
+    "content-hash": "5557ab4354e3c56623db44889ea3c0bf",
     "packages": [
         {
             "name": "composer/installers",
@@ -155,6 +155,108 @@
     ],
     "packages-dev": [
         {
+            "name": "10up/wp_mock",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/10up/wp_mock.git",
+                "reference": "446ea70837dda6174c5a1018a40c213ffe6b29f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/10up/wp_mock/zipball/446ea70837dda6174c5a1018a40c213ffe6b29f7",
+                "reference": "446ea70837dda6174c5a1018a40c213ffe6b29f7",
+                "shasum": ""
+            },
+            "require": {
+                "antecedent/patchwork": "^2.1",
+                "mockery/mockery": "^1.6",
+                "php": ">=7.4 < 9",
+                "phpunit/phpunit": "^9.6"
+            },
+            "require-dev": {
+                "behat/behat": "^v3.11.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "friendsofphp/php-cs-fixer": "^3.4",
+                "php-coveralls/php-coveralls": "^v2.7",
+                "php-stubs/wordpress-globals": "^0.2",
+                "php-stubs/wordpress-stubs": "^6.3",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpstan/phpstan": "^1.10",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "sebastian/comparator": "^4.0.8",
+                "sempro/phpunit-pretty-print": "^1.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "WP_Mock\\": "./php/WP_Mock"
+                },
+                "classmap": [
+                    "php/WP_Mock.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "A mocking library to take the pain out of unit testing for WordPress",
+            "support": {
+                "issues": "https://github.com/10up/wp_mock/issues",
+                "source": "https://github.com/10up/wp_mock/tree/1.1.1"
+            },
+            "time": "2025-12-02T21:19:19+00:00"
+        },
+        {
+            "name": "antecedent/patchwork",
+            "version": "2.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/antecedent/patchwork.git",
+                "reference": "8b6b235f405af175259c8f56aea5fc23ab9f03ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/8b6b235f405af175259c8f56aea5fc23ab9f03ce",
+                "reference": "8b6b235f405af175259c8f56aea5fc23ab9f03ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignas Rudaitis",
+                    "email": "ignas.rudaitis@gmail.com"
+                }
+            ],
+            "description": "Method redefinition (monkey-patching) functionality for PHP.",
+            "homepage": "https://antecedent.github.io/patchwork/",
+            "keywords": [
+                "aop",
+                "aspect",
+                "interception",
+                "monkeypatching",
+                "redefinition",
+                "runkit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/antecedent/patchwork/issues",
+                "source": "https://github.com/antecedent/patchwork/tree/2.2.3"
+            },
+            "time": "2025-09-17T09:00:56+00:00"
+        },
+        {
             "name": "automattic/vipwpcs",
             "version": "3.0.1",
             "source": {
@@ -282,6 +384,444 @@
                 "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
             },
             "time": "2022-02-04T12:51:07+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.4"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5.58"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-05T06:47:08+00:00"
+        },
+        {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
+            },
+            "time": "2025-04-30T06:54:44+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.6.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "^2.0.1",
+                "lib-pcre": ">=7.0",
+                "php": ">=7.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "library/helpers.php",
+                    "library/Mockery.php"
+                ],
+                "psr-4": {
+                    "Mockery\\": "library/Mockery"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "https://github.com/padraic",
+                    "role": "Author"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "https://davedevelopment.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nathanael Esayeas",
+                    "email": "nathanael.esayeas@protonmail.com",
+                    "homepage": "https://github.com/ghostwriter",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "support": {
+                "docs": "https://docs.mockery.io/",
+                "issues": "https://github.com/mockery/mockery/issues",
+                "rss": "https://github.com/mockery/mockery/releases.atom",
+                "security": "https://github.com/mockery/mockery/security/advisories",
+                "source": "https://github.com/mockery/mockery"
+            },
+            "time": "2024-05-16T03:13:13+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
             "name": "php-stubs/wordpress-stubs",
@@ -825,6 +1365,1431 @@
             "time": "2026-02-11T14:48:56+00:00"
         },
         {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:23:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.35",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0edba2f3a0c48df3553cb9b640810b30df60302b",
+                "reference": "0edba2f3a0c48df3553cb9b640810b30df60302b",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.35"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-07-06T14:48:07+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:22:56+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:30:58+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:03:27+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:10:35+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T06:57:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
             "name": "sirbrillig/phpcs-variable-analysis",
             "version": "v2.13.0",
             "source": {
@@ -1023,6 +2988,56 @@
             "time": "2025-09-14T02:58:22+00:00"
         },
         {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
             "name": "wp-coding-standards/wpcs",
             "version": "3.3.0",
             "source": {
@@ -1087,6 +3102,69 @@
                 }
             ],
             "time": "2025-11-25T12:08:04+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "yoast/yoastcs": "^3.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2025-02-09T18:58:54+00:00"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5557ab4354e3c56623db44889ea3c0bf",
+    "content-hash": "f2a6e26eb465f0bf85f76f2e8f7c7b07",
     "packages": [
         {
             "name": "composer/installers",
@@ -1313,11 +1313,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.39",
+            "version": "2.2.8",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c6f73a2af4cbcd99c931d0fb8f08548cc0fa8224",
-                "reference": "c6f73a2af4cbcd99c931d0fb8f08548cc0fa8224",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e285254e60f33c21902efef4a926ca0987c06804",
+                "reference": "e285254e60f33c21902efef4a926ca0987c06804",
                 "shasum": ""
             },
             "require": {
@@ -1339,6 +1339,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -1362,7 +1373,65 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-11T14:48:56+00:00"
+            "time": "2026-08-04T22:21:45+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-phpunit",
+            "version": "2.0.18",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-phpunit.git",
+                "reference": "f5dc20ff8082d02339b60cab68ec3eb0d859fb30"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/f5dc20ff8082d02339b60cab68ec3eb0d859fb30",
+                "reference": "f5dc20ff8082d02339b60cab68ec3eb0d859fb30",
+                "shasum": ""
+            },
+            "require": {
+                "phar-io/version": "^3.2",
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.2.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^5",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "shipmonk/name-collision-detector": "^2.1"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPUnit extensions and rules for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.18"
+            },
+            "time": "2026-07-04T12:16:09+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/includes/class-disable-blog-admin.php
+++ b/includes/class-disable-blog-admin.php
@@ -49,13 +49,14 @@ class Disable_Blog_Admin {
 	 * Initialize the class and set its properties.
 	 *
 	 * @since 0.4.0
-	 * @param string $plugin_name The name of this plugin.
-	 * @param string $version     The version of this plugin.
+	 * @param string                       $plugin_name The name of this plugin.
+	 * @param string                       $version     The version of this plugin.
+	 * @param Disable_Blog_Functions|null  $functions   Optional functions instance, e.g. a test double. Defaults to a new instance.
 	 */
-	public function __construct( $plugin_name, $version ) {
+	public function __construct( $plugin_name, $version, $functions = null ) {
 		$this->plugin_name = $plugin_name;
 		$this->version     = $version;
-		$this->functions   = new Disable_Blog_Functions();
+		$this->functions   = $functions ? $functions : new Disable_Blog_Functions();
 	}
 
 	/**

--- a/includes/class-disable-blog-public.php
+++ b/includes/class-disable-blog-public.php
@@ -48,13 +48,14 @@ class Disable_Blog_Public {
 	 * Initialize the class and set its properties.
 	 *
 	 * @since 0.2.0
-	 * @param string $plugin_name The name of the plugin.
-	 * @param string $version     The version of this plugin.
+	 * @param string                       $plugin_name The name of the plugin.
+	 * @param string                       $version     The version of this plugin.
+	 * @param Disable_Blog_Functions|null  $functions   Optional functions instance, e.g. a test double. Defaults to a new instance.
 	 */
-	public function __construct( $plugin_name, $version ) {
+	public function __construct( $plugin_name, $version, $functions = null ) {
 		$this->plugin_name = $plugin_name;
 		$this->version     = $version;
-		$this->functions   = new Disable_Blog_Functions();
+		$this->functions   = $functions ? $functions : new Disable_Blog_Functions();
 	}
 
 	/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -80,6 +80,7 @@ function dwpb_post_types_with_feature( $feature, $args = array() ) {
  *
  * @since 0.2.0
  * @since 0.4.0 pulled out of class, unique function.
+ * @since 0.5.6 added caching.
  * @see register_post_types(), get_post_types(), get_object_taxonomies()
  * @uses get_post_types(), get_object_taxonomies(), apply_filters()
  * @param string|object $taxonomy Required. The taxonomy object or taxonomy slug.
@@ -98,28 +99,46 @@ function dwpb_post_types_with_tax( $taxonomy, $args = array(), $output = 'names'
 		$taxonomy = $taxonomy->name;
 	}
 
-	// Get all the post types.
+	// Get all the post types matching $args -- computed unconditionally, cache hit or not,
+	// because the dwpb_taxonomy_support filter below documents this as one of its
+	// arguments on every call.
 	$post_types = get_post_types( $args, $output );
 
-	// setup the finished product.
-	$post_types_with_tax = array();
-	foreach ( $post_types as $post_type ) {
+	// Check the cache. The key must incorporate $args and $output too, since either
+	// changes the result for the same taxonomy. Each component is hashed separately
+	// (rather than concatenated raw) so that no combination of $taxonomy/$output values
+	// can straddle the '-' delimiter and collide with a different combination.
+	$cache_name          = 'post-types-with-tax-' . md5( esc_attr( $taxonomy ) ) . '-' . md5( $output ) . '-' . md5( maybe_serialize( $args ) );
+	$post_types_with_tax = wp_cache_get( $cache_name, 'post-types-by-tax' );
 
-		// If post types are objects.
-		if ( is_object( $post_type ) ) {
-			$type = $post_type->name;
-			// If post types are strings.
-		} else {
-			$type = (string) $post_type;
-		}
+	// If the cache is empty, then work out which of the post types above use the taxonomy.
+	if ( false === $post_types_with_tax || ! is_array( $post_types_with_tax ) ) {
 
-		// is the post included in this post type, but not 'post' type.
-		if ( ! empty( $type ) && 'post' !== $type ) {
-			$taxonomies = get_object_taxonomies( $type, 'names' );
-			if ( in_array( $taxonomy, $taxonomies, true ) ) {
-				$post_types_with_tax[] = $post_type;
+		// setup the finished product.
+		$post_types_with_tax = array();
+		foreach ( $post_types as $post_type ) {
+
+			// If post types are objects.
+			if ( is_object( $post_type ) ) {
+				$type = $post_type->name;
+				// If post types are strings.
+			} else {
+				$type = (string) $post_type;
+			}
+
+			// is the post included in this post type, but not 'post' type.
+			if ( ! empty( $type ) && 'post' !== $type ) {
+				$taxonomies = get_object_taxonomies( $type, 'names' );
+				if ( in_array( $taxonomy, $taxonomies, true ) ) {
+					$post_types_with_tax[] = $post_type;
+				}
 			}
 		}
+
+		// Keep the array if there are any, otherwise make it return false.
+		$post_types_with_tax = empty( $post_types_with_tax ) ? false : $post_types_with_tax;
+
+		wp_cache_set( $cache_name, $post_types_with_tax, 'post-types-by-tax' );
 	}
 
 	/**

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,7 +9,7 @@
 	<exclude-pattern>/.github/</exclude-pattern>
 	<exclude-pattern>/.wordpress-org/</exclude-pattern>
 	<exclude-pattern>/languages/</exclude-pattern>
-	<exclude-pattern>/tests/(?!e2e/fixtures/)</exclude-pattern>
+	<exclude-pattern>/tests/(?!e2e/fixtures/|php/)</exclude-pattern>
 	<exclude-pattern>/bin/</exclude-pattern>
 	<exclude-pattern>/assets/</exclude-pattern>
 
@@ -45,9 +45,12 @@
 	<rule ref="VariableAnalysis"/>
 
 	<!-- The e2e fixtures document the plugin methods they mirror, and a
-		 `Class::method()` reference reads as commented-out code to this sniff. -->
+		 `Class::method()` reference reads as commented-out code to this sniff. Same
+		 reasoning applies to the `// define_admin_hooks().` / `// define_public_hooks().`
+		 section labels inside DisableBlogTest's expected-hooks arrays. -->
 	<rule ref="Squiz.PHP.CommentedOutCode">
 		<exclude-pattern>/tests/e2e/fixtures/</exclude-pattern>
+		<exclude-pattern>/tests/php/DisableBlogTest.php</exclude-pattern>
 	</rule>
 
 	<!-- Override prefix rules to accept our prefixes -->
@@ -61,6 +64,16 @@
 				<element value="DWPB"/>
 			</property>
 		</properties>
+		<!-- Test classes, fixture classes, and test-only constants (e.g. the ABSPATH
+			 bootstrap.php defines to point WP_Mock at tests/php/Support/fixtures/) are not
+			 part of the plugin's public surface and are never loaded in production. -->
+		<exclude-pattern>/tests/php/</exclude-pattern>
+	</rule>
+
+	<!-- tests/php sets $_REQUEST and $_SERVER directly as fixtures for the code under test
+		 to read; there is no real request to verify a nonce against. -->
+	<rule ref="WordPress.Security.NonceVerification">
+		<exclude-pattern>/tests/php/</exclude-pattern>
 	</rule>
 
 	<!-- Text domain -->

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -22,7 +22,6 @@ parameters:
         # errors we don't care about.
         - '#^Property Disable_Blog_Public::\$plugin_name is never read, only written\.#'
         - '#^Property Disable_Blog_Public::\$version is never read, only written\.#'
-        - '#^Constant DWPB_URL not found\.#'
 
         # tests/php-only exemptions. None of these may leak into includes/: each is
         # scoped to the single test file that needs it.
@@ -94,6 +93,12 @@ parameters:
         -
             message: '#^Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::#'
             path: tests/php/PublicMiscTest.php
+        -
+            message: '#^Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::#'
+            path: tests/php/AdminRedirectsTest.php
+        -
+            message: '#^Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::#'
+            path: tests/php/AdminHooksTest.php
 
         # Disable_Blog_Public::header_feeds() is documented @return void and never returns a
         # value on any path. assertNull() on its call result is how this test proves the

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -50,6 +50,16 @@ parameters:
             message: '#^Result of method Disable_Blog_Functions::redirect\(\) \(void\) is used\.$#'
             path: tests/php/DisableBlogFunctionsTest.php
 
+        # Disable_Blog_Public::modify_query() is documented @return void and never returns a
+        # value on any path. assertNull() on its call result is how these tests prove the
+        # function completed rather than fatal-erroring partway through -- phpunit.xml's
+        # failOnRisky="true" means the test needs an assertion, and the Mockery expectations
+        # set on $query (verified separately, at tear_down()'s Mockery::close()) don't count
+        # as one; a void call has no other observable result to assert on.
+        -
+            message: '#^Result of method Disable_Blog_Public::modify_query\(\) \(void\) is used\.$#'
+            path: tests/php/PublicRedirectsTest.php
+
         # WC() must be declared as a real global function (not a closure assigned to a
         # variable) for function_exists('WC') to observe it, and it must stay nested inside
         # this @runInSeparateProcess test method rather than move to file scope -- a
@@ -61,3 +71,47 @@ parameters:
         -
             message: '#^Inner named functions are not supported by PHPStan\.#'
             path: tests/php/IntegrationsTest.php
+
+        # Same reasoning as the WC() entry above: wp_sitemaps_get_server() must be a real global
+        # function (function_exists('wp_sitemaps_get_server') can't observe a closure) and must
+        # stay nested inside each @runInSeparateProcess test method rather than move to file
+        # scope, or a file-scope declaration would run on every process and permanently break the
+        # "function missing" case elsewhere in this file.
+        -
+            message: '#^Inner named functions are not supported by PHPStan\.#'
+            path: tests/php/PublicMiscTest.php
+
+        # Mockery\LegacyMockInterface::shouldReceive() is documented to return
+        # Expectation|ExpectationInterface|HigherOrderMessage, but PHPStan can only resolve the
+        # union down to a specific method's real Expectation-typed return with the separate
+        # phpstan-mockery extension -- Phase 3's composer rules disallow adding a new dependency
+        # for it. Without it, chaining any Expectation-only method (once(), with(), never(), ...)
+        # off shouldReceive() reads as undefined against the narrower ExpectationInterface|
+        # HigherOrderMessage union PHPStan does resolve, even though it exists and works at runtime.
+        -
+            message: '#^Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::#'
+            path: tests/php/PublicRedirectsTest.php
+        -
+            message: '#^Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::#'
+            path: tests/php/PublicMiscTest.php
+
+        # Disable_Blog_Public::header_feeds() is documented @return void and never returns a
+        # value on any path. assertNull() on its call result is how this test proves the
+        # function completed rather than fatal-erroring partway through the four remove_action()
+        # calls -- phpunit.xml's failOnRisky="true" means the test needs an assertion, and a
+        # void call has no other observable result to assert on.
+        -
+            message: '#^Result of method Disable_Blog_Public::header_feeds\(\) \(void\) is used\.$#'
+            path: tests/php/PublicFeedsTest.php
+
+        # Disable_Blog_Public::remove_pingback_header_fallback() and disable_removed_sitemaps()
+        # are both documented @return void and never return a value on any path. assertNull() on
+        # their call result is how these tests prove each function completed rather than
+        # fatal-erroring partway through -- phpunit.xml's failOnRisky="true" means the test needs
+        # an assertion, and a void call has no other observable result to assert on.
+        -
+            message: '#^Result of method Disable_Blog_Public::remove_pingback_header_fallback\(\) \(void\) is used\.$#'
+            path: tests/php/PublicMiscTest.php
+        -
+            message: '#^Result of method Disable_Blog_Public::disable_removed_sitemaps\(\) \(void\) is used\.$#'
+            path: tests/php/PublicMiscTest.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -99,6 +99,23 @@ parameters:
         -
             message: '#^Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::#'
             path: tests/php/AdminHooksTest.php
+        -
+            message: '#^Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::#'
+            path: tests/php/AdminCommentsTest.php
+        -
+            message: '#^Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::#'
+            path: tests/php/AdminMiscTest.php
+
+        # get_term_post_count_by_type()'s tests mock WP_Query itself (see
+        # stub_wp_query_returns_posts()'s docblock in AdminCommentsTest.php for why an
+        # overload mock is used instead of a same-named fixture class). end() on
+        # Mockery\Container::getMocks() types as mixed|false because getMocks() can, in
+        # general, return an empty array; in this specific overload-mock flow it always
+        # returns the instance just constructed. There is no supported way to narrow that
+        # without the disallowed phpstan-mockery extension.
+        -
+            message: '#^Cannot access property \$posts on Mockery\\MockInterface\|false\.$#'
+            path: tests/php/AdminCommentsTest.php
 
         # Disable_Blog_Public::header_feeds() is documented @return void and never returns a
         # value on any path. assertNull() on its call result is how this test proves the

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,14 +7,57 @@ parameters:
         - includes/functions.php
     scanDirectories:
         - includes/
+        - tests/php/
+        # WP_Mock's Action_Responder, Filter_Responder and HookedCallbackResponder classes
+        # live as secondary classes inside Action.php/Filter.php/HookedCallback.php rather
+        # than their own PSR-4-mapped files, so composer's autoloader never registers them
+        # on their own; PHPStan needs the directory scanned directly to resolve ->reply().
+        - vendor/10up/wp_mock/php/
     paths:
         - includes/
+        - tests/php/
     ignoreErrors:
         # Method can return bool via filter.
         - '#^Method Disable_Blog_Public::get_disabled_xmlrpc_methods\(\) never returns bool so it can be removed from the return type\.#'
         # errors we don't care about.
         - '#^Property Disable_Blog_Public::\$plugin_name is never read, only written\.#'
         - '#^Property Disable_Blog_Public::\$version is never read, only written\.#'
-        # Implode is correctly used in get_comments_count for supported PHP versions of this plugin.
-        - '#^Parameter \#2 \$array of function implode expects array\<string\>, array\<array\|string\> given\.#'
         - '#^Constant DWPB_URL not found\.#'
+
+        # tests/php-only exemptions. None of these may leak into includes/: each is
+        # scoped to the single test file that needs it.
+
+        # dwpb_post_types_with_feature()/dwpb_post_types_with_tax() take undeclared-type
+        # $feature/$taxonomy parameters (docblock-only "string"/"object|string") and both
+        # explicitly runtime-check is_string()/is_object() before doing anything else.
+        # These tests deliberately feed the invalid types that check exists to catch, to
+        # prove the defensive branch itself -- passing only the docblock-legal types would
+        # delete the coverage the test exists to provide.
+        -
+            message: '#^Parameter \#1 \$feature of function dwpb_post_types_with_feature expects string, (?:int|false|null|array\<int, string\>) given\.$#'
+            path: tests/php/HelperFunctionsTest.php
+        -
+            message: '#^Parameter \#1 \$taxonomy of function dwpb_post_types_with_tax expects object\|string, (?:int|false|null|array\<int, string\>) given\.$#'
+            path: tests/php/HelperFunctionsTest.php
+
+        # Disable_Blog_Functions::redirect() is documented @return void and never returns
+        # a value on any path. assertNull() on its call result is how these two tests prove
+        # the loop-guard/invalid-url branches return normally (not via the wp_safe_redirect()
+        # + exit; path, which is asserted separately via a thrown exception) -- phpunit.xml's
+        # failOnRisky="true" means the test needs an assertion, and a void call has no other
+        # observable result to assert on.
+        -
+            message: '#^Result of method Disable_Blog_Functions::redirect\(\) \(void\) is used\.$#'
+            path: tests/php/DisableBlogFunctionsTest.php
+
+        # WC() must be declared as a real global function (not a closure assigned to a
+        # variable) for function_exists('WC') to observe it, and it must stay nested inside
+        # this @runInSeparateProcess test method rather than move to file scope -- a
+        # file-scope declaration would run unconditionally on every process, including
+        # non-isolated tests, permanently breaking the "function missing" cases elsewhere in
+        # this file. PHPStan cannot analyse a conditionally-declared inner named function
+        # (see https://github.com/phpstan/phpstan/issues/165); there is no supported
+        # alternative that preserves the isolation this test depends on.
+        -
+            message: '#^Inner named functions are not supported by PHPStan\.#'
+            path: tests/php/IntegrationsTest.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+         bootstrap="./tests/php/bootstrap.php"
+         colors="true"
+         failOnWarning="true"
+         failOnRisky="true"
+         cacheResultFile=".phpunit.cache/test-results">
+    <testsuites>
+        <testsuite name="unit">
+            <directory suffix="Test.php">./tests/php/</directory>
+        </testsuite>
+    </testsuites>
+    <coverage cacheDirectory=".phpunit.cache/code-coverage">
+        <include>
+            <directory suffix=".php">includes/</directory>
+        </include>
+        <exclude>
+            <file>includes/index.php</file>
+        </exclude>
+    </coverage>
+</phpunit>

--- a/tests/php/ActivatorTest.php
+++ b/tests/php/ActivatorTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Tests for includes/class-disable-blog-activator.php.
+ *
+ * @package DisableBlog
+ */
+
+/**
+ * @covers Disable_Blog_Activator
+ */
+class ActivatorTest extends PluginLifecycleTestCase {
+
+	protected function target_class(): string {
+		return Disable_Blog_Activator::class;
+	}
+
+	protected function lifecycle_method(): string {
+		return 'activate';
+	}
+
+	protected function single_nonce_action_prefix(): string {
+		return 'activate-plugin_';
+	}
+
+	protected function single_action_value(): string {
+		return 'activate';
+	}
+
+	protected function bulk_action_value(): string {
+		return 'activate-selected';
+	}
+}

--- a/tests/php/AdminCommentsTest.php
+++ b/tests/php/AdminCommentsTest.php
@@ -1,0 +1,711 @@
+<?php
+/**
+ * Tests for Disable_Blog_Admin's comment-related surface: get_comment_counts(),
+ * filter_wp_count_comments(), filter_admin_table_comment_count(), comment_filter(),
+ * filter_comment_status(), filter_existing_comments(), filter_taxonomy_count() and
+ * get_term_post_count_by_type().
+ *
+ * @package DisableBlog
+ */
+
+// Not required by tests/php/bootstrap.php on purpose (see ConstructorInjectionTest.php's note;
+// LoaderTest's autoloader test needs Disable_Blog_Functions to remain undefined until its own
+// isolated process). require_once is safe regardless of which test file happens to load first.
+require_once __DIR__ . '/../../includes/class-disable-blog-functions.php';
+require_once __DIR__ . '/Support/fixtures/class-admin-wpdb-double.php';
+
+/**
+ * @covers Disable_Blog_Admin::get_comment_counts
+ * @covers Disable_Blog_Admin::filter_wp_count_comments
+ * @covers Disable_Blog_Admin::filter_admin_table_comment_count
+ * @covers Disable_Blog_Admin::comment_filter
+ * @covers Disable_Blog_Admin::filter_comment_status
+ * @covers Disable_Blog_Admin::filter_existing_comments
+ * @covers Disable_Blog_Admin::filter_taxonomy_count
+ * @covers Disable_Blog_Admin::get_term_post_count_by_type
+ */
+class AdminCommentsTest extends TestCase {
+
+	/**
+	 * The global $wpdb as it stood before the test, so it can be restored in tear_down().
+	 *
+	 * @var mixed
+	 */
+	private $original_wpdb;
+
+	/**
+	 * The global $pagenow as it stood before the test, so it can be restored in tear_down().
+	 *
+	 * @var mixed
+	 */
+	private $original_pagenow;
+
+	/**
+	 * The global $current_screen as it stood before the test, so it can be restored in tear_down().
+	 *
+	 * @var mixed
+	 */
+	private $original_current_screen;
+
+	protected function set_up() {
+		parent::set_up();
+
+		global $wpdb, $pagenow, $current_screen;
+		$this->original_wpdb           = $wpdb ?? null;
+		$this->original_pagenow        = $pagenow ?? null;
+		$this->original_current_screen = $current_screen ?? null;
+		$pagenow                       = null;
+	}
+
+	protected function tear_down() {
+		global $wpdb, $pagenow, $current_screen;
+		$wpdb           = $this->original_wpdb;
+		$pagenow        = $this->original_pagenow;
+		$current_screen = $this->original_current_screen;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Forces dwpb_post_types_with_feature( $feature ) to return $return_value.
+	 *
+	 * wp_cache_get() returning ANY array (even an empty one) is a cache HIT as far as
+	 * dwpb_post_types_with_feature() is concerned -- it skips get_post_types()/
+	 * post_type_supports() entirely and passes the cached value straight to the
+	 * dwpb_post_types_supporting_{$feature} filter, whose reply IS the function's return
+	 * value regardless of what was "cached".
+	 *
+	 * @param string     $feature      The feature slug (e.g. 'comments').
+	 * @param array|bool $return_value The value dwpb_post_types_with_feature() should return.
+	 * @return void
+	 */
+	private function stub_feature_cache_hit( $feature, $return_value ) {
+		WP_Mock::userFunction( 'esc_attr' )->with( $feature )->andReturn( $feature );
+		WP_Mock::userFunction( 'wp_cache_get' )
+			->with( "post-types-supporting-{$feature}", 'post-types-by-feature' )
+			->andReturn( array() );
+		WP_Mock::onFilter( "dwpb_post_types_supporting_{$feature}" )
+			->with( array(), array() )
+			->reply( $return_value );
+	}
+
+	/**
+	 * Builds a $wpdb double whose get_results() answers $rows and whose ->comments /
+	 * ->posts table-name properties are set, exactly as get_comment_counts()'s SQL string
+	 * interpolation reads them.
+	 *
+	 * A plain declared class (rather than Mockery::mock()) so phpstan can see the
+	 * ->comments/->posts properties and the get_results() method for itself.
+	 *
+	 * @param array $rows The rows get_results() should return.
+	 * @return void
+	 */
+	private function stub_wpdb_get_results( array $rows ) {
+		global $wpdb;
+		$wpdb = new Disable_Blog_Admin_Wpdb_Double( $rows );
+
+		WP_Mock::userFunction( 'esc_sql' )->andReturnUsing(
+			function ( $value ) {
+				return $value;
+			}
+		);
+	}
+
+	/**
+	 * get_comment_counts()
+	 */
+
+	public function test_get_comment_counts_returns_zeroed_counts_when_no_post_types_support_comments() {
+		$this->stub_feature_cache_hit( 'comments', false );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$expected = array(
+			'moderated'           => 0,
+			'approved'            => 0,
+			'awaiting_moderation' => 0,
+			'spam'                => 0,
+			'trash'               => 0,
+			'post-trashed'        => 0,
+			'total_comments'      => 0,
+			'all'                 => 0,
+		);
+		$this->assertSame( $expected, $admin->get_comment_counts() );
+	}
+
+	/**
+	 * `! is_array( $supported_post_types )` is the second half of the early-return `||`
+	 * check; a truthy, non-array reply (never returned by the real helper, but a valid
+	 * filter reply) is the only way to prove that half is evaluated and honored.
+	 */
+	public function test_get_comment_counts_returns_zeroed_counts_when_supported_post_types_not_an_array() {
+		$this->stub_feature_cache_hit( 'comments', true );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$expected = array(
+			'moderated'           => 0,
+			'approved'            => 0,
+			'awaiting_moderation' => 0,
+			'spam'                => 0,
+			'trash'               => 0,
+			'post-trashed'        => 0,
+			'total_comments'      => 0,
+			'all'                 => 0,
+		);
+		$this->assertSame( $expected, $admin->get_comment_counts() );
+	}
+
+	public function test_get_comment_counts_trash_row_only() {
+		$this->stub_feature_cache_hit( 'comments', array( 'page' ) );
+		$this->stub_wpdb_get_results(
+			array(
+				array(
+					'comment_approved' => 'trash',
+					'total'            => '2',
+				),
+			)
+		);
+
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$counts = $admin->get_comment_counts();
+
+		$this->assertSame( 2, $counts['trash'] );
+		$this->assertSame( 0, $counts['total_comments'] );
+		$this->assertSame( 0, $counts['all'] );
+	}
+
+	public function test_get_comment_counts_post_trashed_row_only() {
+		$this->stub_feature_cache_hit( 'comments', array( 'page' ) );
+		$this->stub_wpdb_get_results(
+			array(
+				array(
+					'comment_approved' => 'post-trashed',
+					'total'            => '1',
+				),
+			)
+		);
+
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$counts = $admin->get_comment_counts();
+
+		$this->assertSame( 1, $counts['post-trashed'] );
+		$this->assertSame( 0, $counts['total_comments'] );
+		$this->assertSame( 0, $counts['all'] );
+	}
+
+	public function test_get_comment_counts_spam_row_only() {
+		$this->stub_feature_cache_hit( 'comments', array( 'page' ) );
+		$this->stub_wpdb_get_results(
+			array(
+				array(
+					'comment_approved' => 'spam',
+					'total'            => '4',
+				),
+			)
+		);
+
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$counts = $admin->get_comment_counts();
+
+		$this->assertSame( 4, $counts['spam'] );
+		$this->assertSame( 4, $counts['total_comments'] );
+		$this->assertSame( 0, $counts['all'] );
+	}
+
+	public function test_get_comment_counts_approved_row_only() {
+		$this->stub_feature_cache_hit( 'comments', array( 'page' ) );
+		$this->stub_wpdb_get_results(
+			array(
+				array(
+					'comment_approved' => '1',
+					'total'            => '10',
+				),
+			)
+		);
+
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$counts = $admin->get_comment_counts();
+
+		$this->assertSame( 10, $counts['approved'] );
+		$this->assertSame( 10, $counts['total_comments'] );
+		$this->assertSame( 10, $counts['all'] );
+	}
+
+	public function test_get_comment_counts_awaiting_moderation_row_only() {
+		$this->stub_feature_cache_hit( 'comments', array( 'page' ) );
+		$this->stub_wpdb_get_results(
+			array(
+				array(
+					'comment_approved' => '0',
+					'total'            => '3',
+				),
+			)
+		);
+
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$counts = $admin->get_comment_counts();
+
+		$this->assertSame( 3, $counts['awaiting_moderation'] );
+		$this->assertSame( 3, $counts['moderated'] );
+		$this->assertSame( 3, $counts['total_comments'] );
+		$this->assertSame( 3, $counts['all'] );
+	}
+
+	/**
+	 * An unrecognized comment_approved value must hit the switch's `default: break;` arm
+	 * and leave every counter untouched.
+	 */
+	public function test_get_comment_counts_unrecognized_status_row_hits_default_arm() {
+		$this->stub_feature_cache_hit( 'comments', array( 'page' ) );
+		$this->stub_wpdb_get_results(
+			array(
+				array(
+					'comment_approved' => 'unmapped-status',
+					'total'            => '99',
+				),
+			)
+		);
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$expected = array(
+			'moderated'           => 0,
+			'approved'            => 0,
+			'awaiting_moderation' => 0,
+			'spam'                => 0,
+			'trash'               => 0,
+			'post-trashed'        => 0,
+			'total_comments'      => 0,
+			'all'                 => 0,
+		);
+		$this->assertSame( $expected, $admin->get_comment_counts() );
+	}
+
+	/**
+	 * All six switch arms in a single response, proving the running totals accumulate
+	 * correctly across rows rather than only in isolation.
+	 */
+	public function test_get_comment_counts_aggregates_every_status_across_multiple_rows() {
+		$this->stub_feature_cache_hit( 'comments', array( 'page' ) );
+		$this->stub_wpdb_get_results(
+			array(
+				array(
+					'comment_approved' => 'trash',
+					'total'            => '2',
+				),
+				array(
+					'comment_approved' => 'post-trashed',
+					'total'            => '1',
+				),
+				array(
+					'comment_approved' => 'spam',
+					'total'            => '4',
+				),
+				array(
+					'comment_approved' => '1',
+					'total'            => '10',
+				),
+				array(
+					'comment_approved' => '0',
+					'total'            => '3',
+				),
+				array(
+					'comment_approved' => 'unmapped-status',
+					'total'            => '99',
+				),
+			)
+		);
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$expected = array(
+			'moderated'           => 3,
+			'approved'            => 10,
+			'awaiting_moderation' => 3,
+			'spam'                => 4,
+			'trash'               => 2,
+			'post-trashed'        => 1,
+			'total_comments'      => 17,
+			'all'                 => 13,
+		);
+		$this->assertSame( $expected, $admin->get_comment_counts() );
+	}
+
+	/**
+	 * filter_wp_count_comments()
+	 */
+
+	public function test_filter_wp_count_comments_returns_cached_value_when_post_id_zero_and_cache_hit() {
+		$cached = (object) array( 'all' => 5 );
+		WP_Mock::userFunction( 'wp_cache_get' )->once()->with( 'comments-0', 'counts' )->andReturn( $cached );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		// Deliberately nothing else stubbed: get_comment_counts()'s dependencies (e.g. the
+		// dwpb_post_types_supporting_comments filter) would throw under strict mode if
+		// reached, proving the cache hit short-circuits before get_comment_counts() runs.
+		$this->assertSame( $cached, $admin->filter_wp_count_comments( new stdClass(), 0 ) );
+	}
+
+	public function test_filter_wp_count_comments_computes_and_caches_on_cache_miss() {
+		WP_Mock::userFunction( 'wp_cache_get' )->once()->with( 'comments-0', 'counts' )->andReturn( false );
+
+		$computed = array(
+			'moderated'           => 0,
+			'approved'            => 2,
+			'awaiting_moderation' => 3,
+			'spam'                => 0,
+			'trash'               => 0,
+			'post-trashed'        => 0,
+			'total_comments'      => 5,
+			'all'                 => 5,
+		);
+
+		$admin = $this->getMockBuilder( Disable_Blog_Admin::class )
+			->setConstructorArgs( array( 'disable-blog', '0.5.6' ) )
+			->onlyMethods( array( 'get_comment_counts' ) )
+			->getMock();
+		$admin->method( 'get_comment_counts' )->willReturn( $computed );
+
+		$expected                          = $computed;
+		$expected['moderated']             = 3; // Overwritten from 'awaiting_moderation'.
+		unset( $expected['awaiting_moderation'] );
+
+		WP_Mock::userFunction( 'wp_cache_set' )->once()->with(
+			'comments-0',
+			Mockery::on(
+				function ( $comments ) use ( $expected ) {
+					$this->assertSame( $expected, (array) $comments );
+					return true;
+				}
+			),
+			'counts'
+		);
+
+		$result = $admin->filter_wp_count_comments( new stdClass(), 0 );
+
+		$this->assertSame( $expected, (array) $result );
+	}
+
+	public function test_filter_wp_count_comments_returns_comments_unchanged_when_post_id_nonzero() {
+		$admin    = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$comments = (object) array( 'all' => 9 );
+
+		// Nothing stubbed: wp_cache_get()/get_comment_counts() must never be reached.
+		$this->assertSame( $comments, $admin->filter_wp_count_comments( $comments, 42 ) );
+	}
+
+	/**
+	 * filter_admin_table_comment_count()
+	 */
+
+	public function test_filter_admin_table_comment_count_rewrites_matching_views_on_edit_comments_screen() {
+		global $current_screen;
+		$current_screen     = new stdClass();
+		$current_screen->id = 'edit-comments';
+
+		$admin = $this->getMockBuilder( Disable_Blog_Admin::class )
+			->setConstructorArgs( array( 'disable-blog', '0.5.6' ) )
+			->onlyMethods( array( 'get_comment_counts' ) )
+			->getMock();
+		$admin->method( 'get_comment_counts' )->willReturn(
+			array(
+				'all'   => 3,
+				'trash' => 1,
+			)
+		);
+
+		$views = array(
+			'all'      => 'All <span class="count">(5)</span>',
+			'trash'    => 'Trash <span class="count">(2)</span>',
+			'approved' => 'Approved <span class="count">(4)</span>', // No matching key in the updated counts.
+		);
+
+		$result = $admin->filter_admin_table_comment_count( $views );
+
+		$this->assertSame( 'All <span class="count">(<span class="all-count">3</span>)</span>', $result['all'] );
+		$this->assertSame( 'Trash <span class="count">(<span class="trash-count">1</span>)</span>', $result['trash'] );
+		$this->assertSame( $views['approved'], $result['approved'] );
+	}
+
+	public function test_filter_admin_table_comment_count_leaves_views_unchanged_on_other_screens() {
+		global $current_screen;
+		$current_screen     = new stdClass();
+		$current_screen->id = 'edit-post';
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$views = array( 'all' => 'All <span class="count">(5)</span>' );
+
+		// get_comment_counts() must never be reached: nothing further is stubbed.
+		$this->assertSame( $views, $admin->filter_admin_table_comment_count( $views ) );
+	}
+
+	/**
+	 * comment_filter()
+	 */
+
+	public function test_comment_filter_returns_unchanged_when_pagenow_not_set() {
+		$admin    = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$comments = new stdClass();
+
+		$this->assertSame( $comments, $admin->comment_filter( $comments ) );
+	}
+
+	public function test_comment_filter_sets_post_type_query_var_on_edit_comments_with_supported_types() {
+		global $pagenow;
+		$pagenow = 'edit-comments.php';
+
+		$this->stub_feature_cache_hit( 'comments', array( 'book' ) );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+
+		$admin                = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$comments              = new stdClass();
+		$comments->query_vars  = array();
+
+		$result = $admin->comment_filter( $comments );
+
+		$this->assertSame( array( 'book' ), $result->query_vars['post_type'] );
+	}
+
+	public function test_comment_filter_leaves_comments_unchanged_when_no_supported_post_types() {
+		global $pagenow;
+		$pagenow = 'edit-comments.php';
+
+		$this->stub_feature_cache_hit( 'comments', false );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+
+		$admin                 = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$comments              = new stdClass();
+		$comments->query_vars  = array();
+
+		$result = $admin->comment_filter( $comments );
+
+		$this->assertSame( array(), $result->query_vars );
+	}
+
+	public function test_comment_filter_leaves_comments_unchanged_when_not_on_edit_comments_page() {
+		global $pagenow;
+		$pagenow = 'edit.php';
+
+		$this->stub_feature_cache_hit( 'comments', array( 'book' ) );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+
+		$admin                = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$comments              = new stdClass();
+		$comments->query_vars  = array();
+
+		$result = $admin->comment_filter( $comments );
+
+		$this->assertSame( array(), $result->query_vars );
+	}
+
+	/**
+	 * filter_comment_status()
+	 */
+
+	public function test_filter_comment_status_returns_false_for_post_post_type() {
+		WP_Mock::userFunction( 'get_post_type' )->once()->with( 5 )->andReturn( 'post' );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->filter_comment_status( true, 5 ) );
+	}
+
+	public function test_filter_comment_status_passes_open_through_for_other_post_types() {
+		WP_Mock::userFunction( 'get_post_type' )->once()->with( 5 )->andReturn( 'page' );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $admin->filter_comment_status( true, 5 ) );
+		WP_Mock::userFunction( 'get_post_type' )->once()->with( 5 )->andReturn( 'page' );
+		$this->assertFalse( $admin->filter_comment_status( false, 5 ) );
+	}
+
+	/**
+	 * filter_existing_comments()
+	 */
+
+	public function test_filter_existing_comments_returns_empty_array_for_post_post_type() {
+		WP_Mock::userFunction( 'get_post_type' )->once()->with( 5 )->andReturn( 'post' );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( array(), $admin->filter_existing_comments( array( 'a-comment' ), 5 ) );
+	}
+
+	public function test_filter_existing_comments_passes_comments_through_for_other_post_types() {
+		WP_Mock::userFunction( 'get_post_type' )->once()->with( 5 )->andReturn( 'page' );
+
+		$admin    = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$comments = array( 'a-comment' );
+
+		$this->assertSame( $comments, $admin->filter_existing_comments( $comments, 5 ) );
+	}
+
+	/**
+	 * filter_taxonomy_count()
+	 */
+
+	public function test_filter_taxonomy_count_updates_count_for_category_tag() {
+		global $current_screen;
+		$current_screen            = new stdClass();
+		$current_screen->post_type = 'book';
+		WP_Mock::userFunction( 'get_current_screen' )->once()->andReturn( $current_screen );
+
+		$admin = $this->getMockBuilder( Disable_Blog_Admin::class )
+			->setConstructorArgs( array( 'disable-blog', '0.5.6' ) )
+			->onlyMethods( array( 'get_term_post_count_by_type' ) )
+			->getMock();
+		$admin->expects( $this->once() )
+			->method( 'get_term_post_count_by_type' )
+			->with( 7, 'category', 'book' )
+			->willReturn( 4 );
+
+		$tag           = new stdClass();
+		$tag->taxonomy = 'category';
+		$tag->term_id  = 7;
+		$tag->count    = 1;
+
+		$actions = array( 'edit' => '<a>Edit</a>' );
+		$result  = $admin->filter_taxonomy_count( $actions, $tag );
+
+		$this->assertSame( $actions, $result );
+		$this->assertSame( 4, $tag->count );
+	}
+
+	public function test_filter_taxonomy_count_updates_count_for_post_tag_tag() {
+		global $current_screen;
+		$current_screen            = new stdClass();
+		$current_screen->post_type = 'page';
+		WP_Mock::userFunction( 'get_current_screen' )->once()->andReturn( $current_screen );
+
+		$admin = $this->getMockBuilder( Disable_Blog_Admin::class )
+			->setConstructorArgs( array( 'disable-blog', '0.5.6' ) )
+			->onlyMethods( array( 'get_term_post_count_by_type' ) )
+			->getMock();
+		$admin->expects( $this->once() )
+			->method( 'get_term_post_count_by_type' )
+			->with( 9, 'post_tag', 'page' )
+			->willReturn( 0 );
+
+		$tag           = new stdClass();
+		$tag->taxonomy = 'post_tag';
+		$tag->term_id  = 9;
+		$tag->count    = 6;
+
+		$admin->filter_taxonomy_count( array(), $tag );
+
+		$this->assertSame( 0, $tag->count );
+	}
+
+	public function test_filter_taxonomy_count_leaves_unrelated_taxonomy_unchanged() {
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$tag           = new stdClass();
+		$tag->taxonomy = 'custom_tax';
+		$tag->term_id  = 3;
+		$tag->count    = 2;
+
+		// get_current_screen() must never be reached: nothing further is stubbed.
+		$admin->filter_taxonomy_count( array(), $tag );
+
+		$this->assertSame( 2, $tag->count );
+	}
+
+	public function test_filter_taxonomy_count_leaves_tag_unchanged_when_required_properties_missing() {
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$tag           = new stdClass();
+		$tag->taxonomy = 'category';
+		// The count and term id properties are deliberately left unset.
+
+		$actions = array( 'edit' => '<a>Edit</a>' );
+		$this->assertSame( $actions, $admin->filter_taxonomy_count( $actions, $tag ) );
+	}
+
+	/**
+	 * get_term_post_count_by_type()
+	 */
+
+	/**
+	 * Makes the next `new WP_Query( $args )` call return an instance whose ->posts is
+	 * $posts, and records the constructor args into $captured_args by reference.
+	 *
+	 * Uses Mockery::mock( 'overload:WP_Query' ) rather than a same-named fixture class: a
+	 * real `class WP_Query` declared in tests/php/ would be picked up by phpstan.neon.dist's
+	 * directory scan and shadow the real WP_Query stub phpstan resolves from
+	 * szepeviktor/phpstan-wordpress when analysing includes/class-disable-blog-admin.php's own
+	 * WP_Query usage (see class-wp-post-stub.php's docblock for the same reasoning). An
+	 * overload mock is instead defined purely at runtime, so phpstan's static scan never sees
+	 * it -- but that also means the instance handed back for the ->posts assignment below is
+	 * only known to phpstan as Mockery\MockInterface, which declares no ->posts property.
+	 * There is no supported way to type that without the disallowed phpstan-mockery
+	 * extension; see this file's scoped phpstan.neon.dist ignores for the resulting errors.
+	 *
+	 * @param array      $posts         The posts array the query should report.
+	 * @param array|null $captured_args Set by reference to the args WP_Query was constructed with.
+	 * @return void
+	 */
+	private function stub_wp_query_returns_posts( array $posts, &$captured_args = null ) {
+		$container = Mockery::getContainer();
+		$container->mock( 'overload:WP_Query' )
+			->shouldReceive( '__construct' )
+			->once()
+			->andReturnUsing(
+				function ( $args ) use ( $container, $posts, &$captured_args ) {
+					$captured_args    = $args;
+					$mocks            = $container->getMocks();
+					$instance         = end( $mocks );
+					$instance->posts  = $posts;
+				}
+			);
+	}
+
+	/**
+	 * Declaring WP_Query (even as a mock) is permanent for the rest of the process, so
+	 * every test using stub_wp_query_returns_posts() must run isolated.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_term_post_count_by_type_returns_post_count_when_posts_found() {
+		$this->stub_wp_query_returns_posts( array( 101, 102, 103 ) );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( 3, $admin->get_term_post_count_by_type( 5, 'category', 'page' ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_term_post_count_by_type_returns_zero_when_no_posts_found() {
+		$this->stub_wp_query_returns_posts( array() );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( 0, $admin->get_term_post_count_by_type( 5, 'category', 'page' ) );
+	}
+
+	/**
+	 * Proves the query args passed to `new WP_Query()` are wired correctly: the taxonomy,
+	 * term id and post type all land in the expected places.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_term_post_count_by_type_builds_expected_query_args() {
+		$captured_args = null;
+		$this->stub_wp_query_returns_posts( array(), $captured_args );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->get_term_post_count_by_type( 7, 'post_tag', 'page' );
+
+		$this->assertSame( 'page', $captured_args['post_type'] );
+		$this->assertSame( 'ids', $captured_args['fields'] );
+		$this->assertSame( 'post_tag', $captured_args['tax_query'][0]['taxonomy'] );
+		$this->assertSame( 7, $captured_args['tax_query'][0]['terms'] );
+	}
+}

--- a/tests/php/AdminHooksTest.php
+++ b/tests/php/AdminHooksTest.php
@@ -1,0 +1,726 @@
+<?php
+/**
+ * Tests for the remaining Disable_Blog_Admin hook-callback surface: remove_menu_pages(),
+ * remove_dashboard_widgets(), remove_widgets(), filter_widget_removal(),
+ * remove_admin_bar_links(), remove_writing_options(), admin_body_class(), has_front_page(),
+ * disable_press_this(), enqueue_styles(), enqueue_scripts(), customizer_styles(),
+ * customizer_scripts() and plugin_links().
+ *
+ * @package DisableBlog
+ */
+
+// Not required by tests/php/bootstrap.php on purpose (see ConstructorInjectionTest.php's note;
+// LoaderTest's autoloader test needs Disable_Blog_Functions to remain undefined until its own
+// isolated process). require_once is safe regardless of which test file happens to load first.
+require_once __DIR__ . '/../../includes/class-disable-blog-functions.php';
+
+// DWPB_URL is only ever defined by disable-blog.php, which this suite never loads (see
+// phpstan.neon.dist's "Constant DWPB_URL not found" ignore, added for the same reason).
+// enqueue_scripts() and customizer_scripts() both read it directly, so it must exist before
+// either runs; guarded so re-running this file within the same process is safe.
+if ( ! defined( 'DWPB_URL' ) ) {
+	define( 'DWPB_URL', 'https://example.test/wp-content/plugins/disable-blog/' );
+}
+
+/**
+ * @covers Disable_Blog_Admin::remove_menu_pages
+ * @covers Disable_Blog_Admin::remove_dashboard_widgets
+ * @covers Disable_Blog_Admin::remove_widgets
+ * @covers Disable_Blog_Admin::filter_widget_removal
+ * @covers Disable_Blog_Admin::remove_admin_bar_links
+ * @covers Disable_Blog_Admin::remove_writing_options
+ * @covers Disable_Blog_Admin::admin_body_class
+ * @covers Disable_Blog_Admin::has_front_page
+ * @covers Disable_Blog_Admin::disable_press_this
+ * @covers Disable_Blog_Admin::enqueue_styles
+ * @covers Disable_Blog_Admin::enqueue_scripts
+ * @covers Disable_Blog_Admin::customizer_styles
+ * @covers Disable_Blog_Admin::customizer_scripts
+ * @covers Disable_Blog_Admin::plugin_links
+ */
+class AdminHooksTest extends TestCase {
+
+	/**
+	 * The global $wp_admin_bar as it stood before the test, so it can be restored in tear_down().
+	 *
+	 * @var mixed
+	 */
+	private $original_wp_admin_bar;
+
+	/**
+	 * The global $pagenow as it stood before the test, so it can be restored in tear_down().
+	 *
+	 * @var mixed
+	 */
+	private $original_pagenow;
+
+	protected function set_up() {
+		parent::set_up();
+
+		global $wp_admin_bar, $pagenow;
+		$this->original_wp_admin_bar = $wp_admin_bar ?? null;
+		$this->original_pagenow      = $pagenow ?? null;
+		$wp_admin_bar                = null;
+		$pagenow                     = null;
+	}
+
+	protected function tear_down() {
+		global $wp_admin_bar, $pagenow;
+		$wp_admin_bar = $this->original_wp_admin_bar;
+		$pagenow      = $this->original_pagenow;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Stubs the WordPress functions dwpb_post_types_with_tax() calls on every invocation,
+	 * regardless of taxonomy or cache state: get_post_types(), wp_cache_get()/wp_cache_set()
+	 * and maybe_serialize(), all called with the ( array(), 'names' ) arguments this file's
+	 * tests always use.
+	 *
+	 * @return void
+	 */
+	private function stub_tax_lookup_plumbing() {
+		WP_Mock::userFunction( 'get_post_types' )->with( array(), 'names' )->andReturn( array() );
+		WP_Mock::userFunction( 'wp_cache_get' )->andReturn( false );
+		WP_Mock::userFunction( 'wp_cache_set' )->andReturn( null );
+		WP_Mock::userFunction( 'maybe_serialize' )->with( array() )->andReturn( 'a:0:{}' );
+	}
+
+	/**
+	 * Forces dwpb_post_types_with_tax( $taxonomy ) to return $return_value, via the
+	 * dwpb_taxonomy_support short-circuit filter -- requires stub_tax_lookup_plumbing() to
+	 * have been called first in the same test.
+	 *
+	 * @param string     $taxonomy     The taxonomy slug ('post_tag' or 'category').
+	 * @param array|bool $return_value The value dwpb_post_types_with_tax() should return.
+	 * @return void
+	 */
+	private function stub_post_types_with_tax_result( $taxonomy, $return_value ) {
+		WP_Mock::userFunction( 'esc_attr' )->with( $taxonomy )->andReturn( $taxonomy );
+		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
+			->with( null, $taxonomy, array(), array(), 'names' )
+			->reply( $return_value );
+	}
+
+	/**
+	 * Forces dwpb_post_types_with_feature( $feature ) to return $return_value.
+	 *
+	 * wp_cache_get() returning ANY array (even an empty one) is a cache HIT as far as
+	 * dwpb_post_types_with_feature() is concerned -- it skips get_post_types()/
+	 * post_type_supports() entirely and passes the cached value straight to the
+	 * dwpb_post_types_supporting_{$feature} filter, whose reply IS the function's return
+	 * value regardless of what was "cached".
+	 *
+	 * @param string     $feature      The feature slug (e.g. 'comments').
+	 * @param array|bool $return_value The value dwpb_post_types_with_feature() should return.
+	 * @return void
+	 */
+	private function stub_feature_cache_hit( $feature, $return_value ) {
+		WP_Mock::userFunction( 'esc_attr' )->with( $feature )->andReturn( $feature );
+		WP_Mock::userFunction( 'wp_cache_get' )
+			->with( "post-types-supporting-{$feature}", 'post-types-by-feature' )
+			->andReturn( array() );
+		WP_Mock::onFilter( "dwpb_post_types_supporting_{$feature}" )
+			->with( array(), array() )
+			->reply( $return_value );
+	}
+
+	/**
+	 * Forces remove_writing_options()'s dwpb_remove_options_writing filter to $return_value.
+	 *
+	 * @param bool $return_value The value the filter should reply with.
+	 * @return void
+	 */
+	private function stub_remove_writing_options( $return_value ) {
+		WP_Mock::onFilter( 'dwpb_remove_options_writing' )->with( false )->reply( $return_value );
+	}
+
+	/**
+	 * remove_menu_pages()
+	 */
+
+	/**
+	 * With comments supported elsewhere and the writing page kept, only edit.php and its
+	 * tools.php submenu entry are removed.
+	 */
+	public function test_remove_menu_pages_removes_only_edit_and_tools_by_default() {
+		$this->stub_feature_cache_hit( 'comments', array( 'page' ) );
+		$this->stub_remove_writing_options( false );
+
+		WP_Mock::onFilter( 'dwpb_menu_pages_to_remove' )->with( array( 'edit.php' ) )->reply( array( 'edit.php' ) );
+		WP_Mock::userFunction( 'remove_menu_page' )->once()->with( 'edit.php' );
+
+		$expected_subpages = array(
+			'tools.php'           => array( 'tools.php' ),
+			'options-general.php' => array(),
+		);
+		WP_Mock::onFilter( 'dwpb_menu_subpages_to_remove' )->with( $expected_subpages )->reply( $expected_subpages );
+		WP_Mock::userFunction( 'remove_submenu_page' )->once()->with( 'tools.php', 'tools.php' );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->remove_menu_pages();
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * When no post type (other than 'post') supports comments, edit-comments.php and the
+	 * Settings > Discussion submenu entry are removed too.
+	 */
+	public function test_remove_menu_pages_also_removes_comments_pages_when_unsupported() {
+		$this->stub_feature_cache_hit( 'comments', false );
+		$this->stub_remove_writing_options( false );
+
+		$expected_pages = array( 'edit.php', 'edit-comments.php' );
+		WP_Mock::onFilter( 'dwpb_menu_pages_to_remove' )->with( $expected_pages )->reply( $expected_pages );
+		WP_Mock::userFunction( 'remove_menu_page' )->once()->with( 'edit.php' );
+		WP_Mock::userFunction( 'remove_menu_page' )->once()->with( 'edit-comments.php' );
+
+		$expected_subpages = array(
+			'tools.php'           => array( 'tools.php' ),
+			'options-general.php' => array( 'options-discussion.php' ),
+		);
+		WP_Mock::onFilter( 'dwpb_menu_subpages_to_remove' )->with( $expected_subpages )->reply( $expected_subpages );
+		WP_Mock::userFunction( 'remove_submenu_page' )->once()->with( 'tools.php', 'tools.php' );
+		WP_Mock::userFunction( 'remove_submenu_page' )->once()->with( 'options-general.php', 'options-discussion.php' );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->remove_menu_pages();
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * When remove_writing_options() is true, the writing submenu entry is removed too.
+	 */
+	public function test_remove_menu_pages_removes_writing_page_when_remove_writing_options_true() {
+		$this->stub_feature_cache_hit( 'comments', array( 'page' ) );
+		$this->stub_remove_writing_options( true );
+
+		WP_Mock::onFilter( 'dwpb_menu_pages_to_remove' )->with( array( 'edit.php' ) )->reply( array( 'edit.php' ) );
+		WP_Mock::userFunction( 'remove_menu_page' )->once()->with( 'edit.php' );
+
+		$expected_subpages = array(
+			'tools.php'           => array( 'tools.php' ),
+			'options-general.php' => array( 'options-writing.php' ),
+		);
+		WP_Mock::onFilter( 'dwpb_menu_subpages_to_remove' )->with( $expected_subpages )->reply( $expected_subpages );
+		WP_Mock::userFunction( 'remove_submenu_page' )->once()->with( 'tools.php', 'tools.php' );
+		WP_Mock::userFunction( 'remove_submenu_page' )->once()->with( 'options-general.php', 'options-writing.php' );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->remove_menu_pages();
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * dwpb_menu_pages_to_remove must be able to add an extra top-level page to remove.
+	 */
+	public function test_remove_menu_pages_dwpb_menu_pages_to_remove_filter_can_add_a_page() {
+		$this->stub_feature_cache_hit( 'comments', array( 'page' ) );
+		$this->stub_remove_writing_options( false );
+
+		WP_Mock::onFilter( 'dwpb_menu_pages_to_remove' )
+			->with( array( 'edit.php' ) )
+			->reply( array( 'edit.php', 'extra-page.php' ) );
+		WP_Mock::userFunction( 'remove_menu_page' )->once()->with( 'edit.php' );
+		WP_Mock::userFunction( 'remove_menu_page' )->once()->with( 'extra-page.php' );
+
+		$expected_subpages = array(
+			'tools.php'           => array( 'tools.php' ),
+			'options-general.php' => array(),
+		);
+		WP_Mock::onFilter( 'dwpb_menu_subpages_to_remove' )->with( $expected_subpages )->reply( $expected_subpages );
+		WP_Mock::userFunction( 'remove_submenu_page' )->once()->with( 'tools.php', 'tools.php' );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->remove_menu_pages();
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * dwpb_menu_subpages_to_remove must be able to replace the subpages map entirely,
+	 * including the backwards-compatible single-string (rather than array) subpage form.
+	 */
+	public function test_remove_menu_pages_dwpb_menu_subpages_to_remove_filter_supports_string_value() {
+		$this->stub_feature_cache_hit( 'comments', array( 'page' ) );
+		$this->stub_remove_writing_options( false );
+
+		WP_Mock::onFilter( 'dwpb_menu_pages_to_remove' )->with( array( 'edit.php' ) )->reply( array( 'edit.php' ) );
+		WP_Mock::userFunction( 'remove_menu_page' )->once()->with( 'edit.php' );
+
+		$default_subpages = array(
+			'tools.php'           => array( 'tools.php' ),
+			'options-general.php' => array(),
+		);
+		$overridden_subpages = array( 'custom-page.php' => 'custom-subpage.php' );
+		WP_Mock::onFilter( 'dwpb_menu_subpages_to_remove' )->with( $default_subpages )->reply( $overridden_subpages );
+		WP_Mock::userFunction( 'remove_submenu_page' )->once()->with( 'custom-page.php', 'custom-subpage.php' );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->remove_menu_pages();
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * remove_dashboard_widgets()
+	 */
+
+	public function test_remove_dashboard_widgets_removes_both_widgets_by_default() {
+		WP_Mock::onFilter( 'dwpb_disable_dashboard_quick_press' )->with( true )->reply( true );
+		WP_Mock::onFilter( 'dwpb_disable_dashboard_activity' )->with( true )->reply( true );
+		WP_Mock::userFunction( 'remove_meta_box' )->once()->with( 'dashboard_quick_press', 'dashboard', 'side' );
+		WP_Mock::userFunction( 'remove_meta_box' )->once()->with( 'dashboard_activity', 'dashboard', 'normal' );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->remove_dashboard_widgets();
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	public function test_remove_dashboard_widgets_keeps_quick_press_when_its_filter_returns_false() {
+		WP_Mock::onFilter( 'dwpb_disable_dashboard_quick_press' )->with( true )->reply( false );
+		WP_Mock::onFilter( 'dwpb_disable_dashboard_activity' )->with( true )->reply( true );
+		WP_Mock::userFunction( 'remove_meta_box' )->never()->with( 'dashboard_quick_press', 'dashboard', 'side' );
+		WP_Mock::userFunction( 'remove_meta_box' )->once()->with( 'dashboard_activity', 'dashboard', 'normal' );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->remove_dashboard_widgets();
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	public function test_remove_dashboard_widgets_keeps_activity_when_its_filter_returns_false() {
+		WP_Mock::onFilter( 'dwpb_disable_dashboard_quick_press' )->with( true )->reply( true );
+		WP_Mock::onFilter( 'dwpb_disable_dashboard_activity' )->with( true )->reply( false );
+		WP_Mock::userFunction( 'remove_meta_box' )->once()->with( 'dashboard_quick_press', 'dashboard', 'side' );
+		WP_Mock::userFunction( 'remove_meta_box' )->never()->with( 'dashboard_activity', 'dashboard', 'normal' );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->remove_dashboard_widgets();
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * remove_widgets()
+	 */
+
+	/**
+	 * The full list of widget classes remove_widgets() considers unregistering, in the
+	 * order the method itself declares them.
+	 *
+	 * @return string[]
+	 */
+	private function widget_class_names() {
+		return array(
+			'WP_Widget_Recent_Comments',
+			'WP_Widget_Tag_Cloud',
+			'WP_Widget_Categories',
+			'WP_Widget_Archives',
+			'WP_Widget_Calendar',
+			'WP_Widget_Links',
+			'WP_Widget_Recent_Posts',
+			'WP_Widget_RSS',
+		);
+	}
+
+	public function test_remove_widgets_unregisters_every_supported_widget_by_default() {
+		foreach ( $this->widget_class_names() as $widget ) {
+			WP_Mock::onFilter( 'dwpb_unregister_widgets' )->with( true, $widget )->reply( true );
+			WP_Mock::userFunction( 'unregister_widget' )->once()->with( $widget );
+		}
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->remove_widgets();
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * dwpb_unregister_widgets must be able to keep a single widget registered without
+	 * affecting the others.
+	 */
+	public function test_remove_widgets_dwpb_unregister_widgets_filter_can_keep_one_widget() {
+		foreach ( $this->widget_class_names() as $widget ) {
+			$unregister = 'WP_Widget_Categories' !== $widget;
+			WP_Mock::onFilter( 'dwpb_unregister_widgets' )->with( true, $widget )->reply( $unregister );
+			if ( $unregister ) {
+				WP_Mock::userFunction( 'unregister_widget' )->once()->with( $widget );
+			} else {
+				WP_Mock::userFunction( 'unregister_widget' )->never()->with( $widget );
+			}
+		}
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->remove_widgets();
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * filter_widget_removal()
+	 */
+
+	public function test_filter_widget_removal_hides_categories_widget_when_category_used_elsewhere() {
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', array( 'book' ) );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->filter_widget_removal( true, 'WP_Widget_Categories' ) );
+	}
+
+	public function test_filter_widget_removal_keeps_categories_widget_when_category_not_used_elsewhere() {
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', false );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $admin->filter_widget_removal( true, 'WP_Widget_Categories' ) );
+	}
+
+	public function test_filter_widget_removal_hides_recent_comments_widget_when_another_post_type_supports_comments() {
+		$this->stub_feature_cache_hit( 'comments', array( 'book' ) );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->filter_widget_removal( true, 'WP_Widget_Recent_Comments' ) );
+	}
+
+	public function test_filter_widget_removal_keeps_recent_comments_widget_when_no_other_post_type_supports_comments() {
+		$this->stub_feature_cache_hit( 'comments', false );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $admin->filter_widget_removal( true, 'WP_Widget_Recent_Comments' ) );
+	}
+
+	public function test_filter_widget_removal_hides_tag_cloud_widget_when_post_tag_used_elsewhere() {
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', array( 'book' ) );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->filter_widget_removal( true, 'WP_Widget_Tag_Cloud' ) );
+	}
+
+	public function test_filter_widget_removal_keeps_tag_cloud_widget_when_post_tag_not_used_elsewhere() {
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $admin->filter_widget_removal( true, 'WP_Widget_Tag_Cloud' ) );
+	}
+
+	/**
+	 * A widget name matching none of the three special cases passes $show through unchanged,
+	 * with no dependency on dwpb_post_types_with_tax()/dwpb_post_types_with_feature() at all.
+	 */
+	public function test_filter_widget_removal_passes_through_unrelated_widget_unchanged() {
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $admin->filter_widget_removal( true, 'WP_Widget_Links' ) );
+		$this->assertFalse( $admin->filter_widget_removal( false, 'WP_Widget_Links' ) );
+	}
+
+	/**
+	 * remove_admin_bar_links()
+	 */
+
+	public function test_remove_admin_bar_links_removes_comments_menu_when_unsupported_elsewhere() {
+		global $wp_admin_bar;
+		$wp_admin_bar = Mockery::mock();
+		$wp_admin_bar->shouldReceive( 'remove_menu' )->once()->with( 'comments' );
+		$wp_admin_bar->shouldReceive( 'remove_node' )->once()->with( 'new-post' );
+
+		$this->stub_feature_cache_hit( 'comments', false );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->remove_admin_bar_links();
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	public function test_remove_admin_bar_links_keeps_comments_menu_when_supported_elsewhere() {
+		global $wp_admin_bar;
+		$wp_admin_bar = Mockery::mock();
+		$wp_admin_bar->shouldNotReceive( 'remove_menu' );
+		$wp_admin_bar->shouldReceive( 'remove_node' )->once()->with( 'new-post' );
+
+		$this->stub_feature_cache_hit( 'comments', array( 'book' ) );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->remove_admin_bar_links();
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * remove_writing_options()
+	 */
+
+	public function test_remove_writing_options_false_by_default() {
+		$this->stub_remove_writing_options( false );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->remove_writing_options() );
+	}
+
+	public function test_remove_writing_options_dwpb_remove_options_writing_filter_can_enable_it() {
+		$this->stub_remove_writing_options( true );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $admin->remove_writing_options() );
+	}
+
+	/**
+	 * admin_body_class()
+	 */
+
+	public function test_admin_body_class_appends_class_when_front_page_set() {
+		WP_Mock::userFunction( 'get_option' )->with( 'show_on_front' )->andReturn( 'page' );
+		WP_Mock::userFunction( 'get_option' )->with( 'page_on_front' )->andReturn( 5 );
+		WP_Mock::userFunction( 'absint' )->with( 5 )->andReturn( 5 );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( 'some-classes disabled-blog', $admin->admin_body_class( 'some-classes' ) );
+	}
+
+	public function test_admin_body_class_unchanged_when_no_front_page_set() {
+		WP_Mock::userFunction( 'get_option' )->with( 'show_on_front' )->andReturn( 'posts' );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( 'some-classes', $admin->admin_body_class( 'some-classes' ) );
+	}
+
+	/**
+	 * has_front_page()
+	 */
+
+	public function test_has_front_page_true_when_static_front_page_set() {
+		WP_Mock::userFunction( 'get_option' )->with( 'show_on_front' )->andReturn( 'page' );
+		WP_Mock::userFunction( 'get_option' )->with( 'page_on_front' )->andReturn( 5 );
+		WP_Mock::userFunction( 'absint' )->with( 5 )->andReturn( 5 );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $admin->has_front_page() );
+	}
+
+	/**
+	 * show_on_front !== 'page' short-circuits the && before get_option( 'page_on_front' ) is
+	 * ever called -- leaving it unstubbed here is what proves that.
+	 */
+	public function test_has_front_page_false_when_show_on_front_is_not_page() {
+		WP_Mock::userFunction( 'get_option' )->with( 'show_on_front' )->andReturn( 'posts' );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->has_front_page() );
+	}
+
+	public function test_has_front_page_false_when_page_on_front_is_zero() {
+		WP_Mock::userFunction( 'get_option' )->with( 'show_on_front' )->andReturn( 'page' );
+		WP_Mock::userFunction( 'get_option' )->with( 'page_on_front' )->andReturn( 0 );
+		WP_Mock::userFunction( 'absint' )->with( 0 )->andReturn( 0 );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->has_front_page() );
+	}
+
+	/**
+	 * disable_press_this()
+	 */
+
+	public function test_disable_press_this_terminates_via_wp_die() {
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( '"Press This" functionality has been disabled.' );
+
+		$admin->disable_press_this();
+	}
+
+	/**
+	 * enqueue_styles()
+	 */
+
+	public function test_enqueue_styles_registers_expected_handle_and_version() {
+		WP_Mock::userFunction( 'plugin_dir_url' )
+			->once()
+			->andReturn( 'https://example.test/wp-content/plugins/disable-blog/includes/' );
+		WP_Mock::userFunction( 'wp_enqueue_style' )
+			->once()
+			->with(
+				'disable-blog',
+				'https://example.test/wp-content/plugins/disable-blog/includes/../assets/css/disable-blog-admin.css',
+				array(),
+				'0.5.6',
+				'all'
+			);
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->enqueue_styles();
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * enqueue_scripts()
+	 */
+
+	public function test_enqueue_scripts_localizes_expected_vars() {
+		global $pagenow;
+		$pagenow = 'edit.php';
+
+		WP_Mock::userFunction( 'wp_enqueue_script' )
+			->once()
+			->with( 'disable-blog', DWPB_URL . 'assets/js/disable-blog-admin.js', array(), '0.5.6', true );
+
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', array( 'book' ) );
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+		$this->stub_feature_cache_hit( 'comments', false );
+
+		WP_Mock::userFunction( 'wp_localize_script' )
+			->once()
+			->with(
+				'disable-blog',
+				'dwpb',
+				Mockery::on(
+					function ( $js_vars ) {
+						// WP_Mock's ->with() matches plain arrays with loose (==) comparison,
+						// under which a non-empty array or truthy string is indistinguishable
+						// from (bool) true. assertSame() enforces the real per-key types
+						// (string 'page', strict bool for the three *Supported flags) that
+						// wp_localize_script()/json_encode() actually depend on.
+						$this->assertSame(
+							array(
+								'page'                => 'edit',
+								'categoriesSupported' => true,
+								'tagsSupported'       => false,
+								'commentsSupported'   => false,
+							),
+							$js_vars
+						);
+						return true;
+					}
+				)
+			);
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->enqueue_scripts();
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * customizer_styles()
+	 */
+
+	public function test_customizer_styles_outputs_style_block_when_front_page_set() {
+		WP_Mock::userFunction( 'get_option' )->with( 'show_on_front' )->andReturn( 'page' );
+		WP_Mock::userFunction( 'get_option' )->with( 'page_on_front' )->andReturn( 5 );
+		WP_Mock::userFunction( 'absint' )->with( 5 )->andReturn( 5 );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		ob_start();
+		$admin->customizer_styles();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '#customize-control-show_on_front', $output );
+	}
+
+	public function test_customizer_styles_outputs_nothing_when_no_front_page_set() {
+		WP_Mock::userFunction( 'get_option' )->with( 'show_on_front' )->andReturn( 'posts' );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		ob_start();
+		$admin->customizer_styles();
+		$output = ob_get_clean();
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * customizer_scripts()
+	 */
+
+	public function test_customizer_scripts_enqueues_and_localizes_expected_vars() {
+		WP_Mock::userFunction( 'wp_enqueue_script' )
+			->once()
+			->with(
+				'disable-blog-customizer-scripts',
+				DWPB_URL . 'assets/js/disable-blog-customizer.js',
+				array( 'jquery', 'customize-controls' ),
+				'0.5.6',
+				true
+			);
+
+		WP_Mock::userFunction( 'wp_localize_script' )
+			->once()
+			->with(
+				'disable-blog-customizer-scripts',
+				'dwpbCustomizer',
+				array(
+					'homepageSettingsText' => "You can choose what's displayed on the homepage of your site. To set a static homepage, create or select the page below.",
+				)
+			);
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->customizer_scripts();
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * plugin_links()
+	 */
+
+	public function test_plugin_links_returns_unchanged_links_when_user_cannot_install_plugins() {
+		WP_Mock::userFunction( 'current_user_can' )->once()->with( 'install_plugins' )->andReturn( false );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$links = array( 'deactivate' => '<a>Deactivate</a>' );
+		$this->assertSame( $links, $admin->plugin_links( $links, 'disable-blog/disable-blog.php' ) );
+	}
+
+	public function test_plugin_links_adds_meta_links_for_this_plugins_file() {
+		WP_Mock::userFunction( 'current_user_can' )->once()->with( 'install_plugins' )->andReturn( true );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$links  = array( 'deactivate' => '<a>Deactivate</a>' );
+		$result = $admin->plugin_links( $links, 'disable-blog/disable-blog.php' );
+
+		$this->assertArrayHasKey( 'deactivate', $result );
+		$this->assertArrayHasKey( 'support', $result );
+		$this->assertArrayHasKey( 'review', $result );
+		$this->assertArrayHasKey( 'donate', $result );
+		$this->assertArrayHasKey( 'github', $result );
+		$this->assertCount( 5, $result );
+	}
+
+	public function test_plugin_links_returns_unchanged_links_for_a_different_plugin_file() {
+		WP_Mock::userFunction( 'current_user_can' )->once()->with( 'install_plugins' )->andReturn( true );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$links = array( 'deactivate' => '<a>Deactivate</a>' );
+		$this->assertSame( $links, $admin->plugin_links( $links, 'some-other-plugin/some-other-plugin.php' ) );
+	}
+}

--- a/tests/php/AdminMiscTest.php
+++ b/tests/php/AdminMiscTest.php
@@ -1,0 +1,763 @@
+<?php
+/**
+ * Tests for the remaining Disable_Blog_Admin surface: modify_post_type_arguments(),
+ * modify_taxonomies_arguments(), admin_notices(), update_posts_page_notice(),
+ * posts_page_notice(), page_post_states(), available_permalink_structure_tags(),
+ * filter_block_type_metadata(), site_status_tests() and get_test_rest_availability().
+ *
+ * Disable_Blog_Admin::__construct() is deliberately not covered again here -- both of its
+ * branches (an injected $functions instance actually being used, and a real one being
+ * constructed when omitted) are already proven by ConstructorInjectionTest.php.
+ *
+ * @package DisableBlog
+ */
+
+// Not required by tests/php/bootstrap.php on purpose (see ConstructorInjectionTest.php's note;
+// LoaderTest's autoloader test needs Disable_Blog_Functions to remain undefined until its own
+// isolated process). require_once is safe regardless of which test file happens to load first.
+require_once __DIR__ . '/../../includes/class-disable-blog-functions.php';
+
+// page_post_states() tests below use WP_Post, already required globally by
+// tests/php/bootstrap.php's require of Support/fixtures/class-wp-post-stub.php.
+
+/**
+ * @covers Disable_Blog_Admin::modify_post_type_arguments
+ * @covers Disable_Blog_Admin::modify_taxonomies_arguments
+ * @covers Disable_Blog_Admin::admin_notices
+ * @covers Disable_Blog_Admin::update_posts_page_notice
+ * @covers Disable_Blog_Admin::posts_page_notice
+ * @covers Disable_Blog_Admin::page_post_states
+ * @covers Disable_Blog_Admin::available_permalink_structure_tags
+ * @covers Disable_Blog_Admin::filter_block_type_metadata
+ * @covers Disable_Blog_Admin::site_status_tests
+ * @covers Disable_Blog_Admin::get_test_rest_availability
+ */
+class AdminMiscTest extends TestCase {
+
+	/**
+	 * The global $wp_post_types as it stood before the test, so it can be restored in
+	 * tear_down().
+	 *
+	 * @var mixed
+	 */
+	private $original_wp_post_types;
+
+	/**
+	 * The global $wp_taxonomies as it stood before the test, so it can be restored in
+	 * tear_down().
+	 *
+	 * @var mixed
+	 */
+	private $original_wp_taxonomies;
+
+	/**
+	 * $_COOKIE as it stood before the test, so it can be restored in tear_down().
+	 *
+	 * @var array
+	 */
+	private $original_cookie;
+
+	/**
+	 * $_SERVER as it stood before the test, so it can be restored in tear_down().
+	 *
+	 * @var array
+	 */
+	private $original_server;
+
+	protected function set_up() {
+		parent::set_up();
+
+		global $wp_post_types, $wp_taxonomies;
+		$this->original_wp_post_types = $wp_post_types ?? null;
+		$this->original_wp_taxonomies = $wp_taxonomies ?? null;
+		$this->original_cookie        = $_COOKIE; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		$this->original_server        = $_SERVER;
+	}
+
+	protected function tear_down() {
+		global $wp_post_types, $wp_taxonomies;
+		$wp_post_types = $this->original_wp_post_types;
+		$wp_taxonomies = $this->original_wp_taxonomies;
+		$_COOKIE        = $this->original_cookie; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		$_SERVER        = $this->original_server;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Stubs the WordPress functions dwpb_post_types_with_tax() calls on every invocation,
+	 * regardless of taxonomy or cache state: get_post_types(), wp_cache_get()/wp_cache_set()
+	 * and maybe_serialize(), all called with the ( array(), 'names' ) arguments this file's
+	 * tests always use.
+	 *
+	 * @return void
+	 */
+	private function stub_tax_lookup_plumbing() {
+		WP_Mock::userFunction( 'get_post_types' )->with( array(), 'names' )->andReturn( array() );
+		WP_Mock::userFunction( 'wp_cache_get' )->andReturn( false );
+		WP_Mock::userFunction( 'wp_cache_set' )->andReturn( null );
+		WP_Mock::userFunction( 'maybe_serialize' )->with( array() )->andReturn( 'a:0:{}' );
+	}
+
+	/**
+	 * Forces dwpb_post_types_with_tax( $taxonomy ) to return $return_value, via the
+	 * dwpb_taxonomy_support short-circuit filter -- requires stub_tax_lookup_plumbing() to
+	 * have been called first in the same test.
+	 *
+	 * @param string     $taxonomy     The taxonomy slug ('post_tag' or 'category').
+	 * @param array|bool $return_value The value dwpb_post_types_with_tax() should return.
+	 * @return void
+	 */
+	private function stub_post_types_with_tax_result( $taxonomy, $return_value ) {
+		WP_Mock::userFunction( 'esc_attr' )->with( $taxonomy )->andReturn( $taxonomy );
+		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
+			->with( null, $taxonomy, array(), array(), 'names' )
+			->reply( $return_value );
+	}
+
+	/**
+	 * Stubs has_front_page()'s two get_option() calls (and the absint() of the second).
+	 *
+	 * @param string $show_on_front The show_on_front option value.
+	 * @param int    $page_on_front The page_on_front option value.
+	 * @return void
+	 */
+	private function stub_has_front_page( $show_on_front, $page_on_front ) {
+		WP_Mock::userFunction( 'get_option' )->with( 'show_on_front' )->andReturn( $show_on_front );
+		if ( 'page' === $show_on_front ) {
+			WP_Mock::userFunction( 'get_option' )->with( 'page_on_front' )->andReturn( $page_on_front );
+			WP_Mock::userFunction( 'absint' )->with( $page_on_front )->andReturn( $page_on_front );
+		}
+	}
+
+	/**
+	 * modify_post_type_arguments()
+	 */
+
+	public function test_modify_post_type_arguments_disables_expected_properties_when_all_set() {
+		global $wp_post_types;
+
+		$post_type = new stdClass();
+		foreach ( array( 'has_archive', 'public', 'publicly_queryable', 'rewrite', 'query_var', 'show_ui', 'show_in_admin_bar', 'show_in_nav_menus', 'show_in_menu', 'show_in_rest' ) as $arg ) {
+			$post_type->$arg = true;
+		}
+		$post_type->label = 'Posts'; // A property NOT in the removal list, to prove it's untouched.
+
+		$wp_post_types = array( 'post' => $post_type );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->modify_post_type_arguments();
+
+		foreach ( array( 'has_archive', 'public', 'publicly_queryable', 'rewrite', 'query_var', 'show_ui', 'show_in_admin_bar', 'show_in_nav_menus', 'show_in_menu', 'show_in_rest' ) as $arg ) {
+			$this->assertFalse( $post_type->$arg, $arg );
+		}
+		$this->assertTrue( $post_type->exclude_from_search );
+		$this->assertSame( array(), $post_type->supports );
+		$this->assertSame( 'Posts', $post_type->label );
+	}
+
+	public function test_modify_post_type_arguments_only_disables_properties_that_are_set() {
+		global $wp_post_types;
+
+		$post_type              = new stdClass();
+		$post_type->has_archive = true;
+		// 'rewrite' and every other removable property are deliberately left unset.
+
+		$wp_post_types = array( 'post' => $post_type );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->modify_post_type_arguments();
+
+		$this->assertFalse( $post_type->has_archive );
+		$this->assertFalse( isset( $post_type->rewrite ) );
+		$this->assertTrue( $post_type->exclude_from_search );
+		$this->assertSame( array(), $post_type->supports );
+	}
+
+	public function test_modify_post_type_arguments_does_nothing_when_post_type_not_set() {
+		global $wp_post_types;
+
+		$page_type     = new stdClass();
+		$wp_post_types = array( 'page' => $page_type );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->modify_post_type_arguments();
+
+		$this->assertSame( array( 'page' ), array_keys( $wp_post_types ) );
+		$this->assertFalse( property_exists( $page_type, 'exclude_from_search' ) );
+	}
+
+	/**
+	 * modify_taxonomies_arguments()
+	 */
+
+	public function test_modify_taxonomies_arguments_removes_post_and_disables_public_args_when_only_post_type() {
+		global $wp_taxonomies;
+
+		$category                = new stdClass();
+		$category->object_type   = array( 'post' );
+		foreach ( array( 'has_archive', 'public', 'publicly_queryable', 'query_var', 'show_ui', 'show_tagcloud', 'show_in_admin_bar', 'show_in_quick_edit', 'show_in_nav_menus', 'show_admin_column', 'show_in_menu', 'show_in_rest' ) as $arg ) {
+			$category->$arg = true;
+		}
+		$wp_taxonomies = array( 'category' => $category );
+
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', false );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->modify_taxonomies_arguments();
+
+		$this->assertNotContains( 'post', $category->object_type );
+		foreach ( array( 'has_archive', 'public', 'publicly_queryable', 'query_var', 'show_ui', 'show_tagcloud', 'show_in_admin_bar', 'show_in_quick_edit', 'show_in_nav_menus', 'show_admin_column', 'show_in_menu', 'show_in_rest' ) as $arg ) {
+			$this->assertFalse( $category->$arg, $arg );
+		}
+	}
+
+	public function test_modify_taxonomies_arguments_keeps_public_args_when_other_post_type_uses_taxonomy() {
+		global $wp_taxonomies;
+
+		$category               = new stdClass();
+		$category->object_type  = array( 'post' );
+		$category->public       = true;
+		$wp_taxonomies           = array( 'category' => $category );
+
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', array( 'book' ) );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->modify_taxonomies_arguments();
+
+		// 'post' is still stripped from object_type unconditionally...
+		$this->assertNotContains( 'post', $category->object_type );
+		// ...but the public arguments are left alone, since another post type uses it.
+		$this->assertTrue( $category->public );
+	}
+
+	public function test_modify_taxonomies_arguments_skips_when_taxonomy_not_set() {
+		global $wp_taxonomies;
+
+		$post_format         = new stdClass();
+		$post_format->public = true;
+		$wp_taxonomies        = array( 'post_format' => $post_format );
+
+		// Neither dwpb_post_types_with_tax() nor anything else may be reached: nothing
+		// is stubbed.
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->modify_taxonomies_arguments();
+
+		$this->assertSame( array( 'post_format' ), array_keys( $wp_taxonomies ) );
+		$this->assertTrue( $post_format->public );
+	}
+
+	public function test_modify_taxonomies_arguments_leaves_object_type_unchanged_when_post_not_present() {
+		global $wp_taxonomies;
+
+		$category               = new stdClass();
+		$category->object_type  = array( 'book' ); // 'post' is not present -- array_search() returns false.
+		$wp_taxonomies           = array( 'category' => $category );
+
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', false );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->modify_taxonomies_arguments();
+
+		$this->assertSame( array( 'book' ), $category->object_type );
+	}
+
+	public function test_modify_taxonomies_arguments_skips_object_type_removal_when_not_an_array() {
+		global $wp_taxonomies;
+
+		$category              = new stdClass();
+		$category->object_type = 'post'; // Not an array -- is_array() gate skips the removal block entirely.
+		$wp_taxonomies          = array( 'category' => $category );
+
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', false );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->modify_taxonomies_arguments();
+
+		$this->assertSame( 'post', $category->object_type );
+	}
+
+	/**
+	 * admin_notices()
+	 */
+
+	public function test_admin_notices_returns_early_on_unsupported_screen() {
+		$current_screen       = new stdClass();
+		$current_screen->base = 'dashboard';
+		WP_Mock::userFunction( 'get_current_screen' )->once()->andReturn( $current_screen );
+
+		// has_front_page() must never be reached: nothing further is stubbed.
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		ob_start();
+		$admin->admin_notices();
+		$this->assertSame( '', ob_get_clean() );
+	}
+
+	public function test_admin_notices_returns_early_when_screen_base_not_set() {
+		WP_Mock::userFunction( 'get_current_screen' )->once()->andReturn( new stdClass() );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		ob_start();
+		$admin->admin_notices();
+		$this->assertSame( '', ob_get_clean() );
+	}
+
+	public function test_admin_notices_prints_reading_settings_link_when_no_front_page_and_not_on_reading_screen() {
+		$current_screen       = new stdClass();
+		$current_screen->base = 'edit';
+		WP_Mock::userFunction( 'get_current_screen' )->once()->andReturn( $current_screen );
+
+		$this->stub_has_front_page( 'posts', 0 );
+
+		$reading_url = 'https://example.test/wp-admin/options-reading.php';
+		WP_Mock::userFunction( 'get_admin_url' )->once()->with( null, 'options-reading.php' )->andReturn( $reading_url );
+		WP_Mock::userFunction( 'wp_kses_post' )->once()->andReturnUsing(
+			function ( $value ) {
+				return $value;
+			}
+		);
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		ob_start();
+		$admin->admin_notices();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'notice-error', $output );
+		$this->assertStringContainsString( $reading_url, $output );
+	}
+
+	public function test_admin_notices_prints_selection_prompt_when_no_front_page_and_on_reading_screen() {
+		$current_screen       = new stdClass();
+		$current_screen->base = 'options-reading';
+		WP_Mock::userFunction( 'get_current_screen' )->once()->andReturn( $current_screen );
+
+		$this->stub_has_front_page( 'posts', 0 );
+
+		WP_Mock::userFunction( 'wp_kses_post' )->once()->andReturnUsing(
+			function ( $value ) {
+				return $value;
+			}
+		);
+
+		// get_admin_url() must never be reached: nothing further is stubbed.
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		ob_start();
+		$admin->admin_notices();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Select a page for your homepage below.', $output );
+	}
+
+	public function test_admin_notices_prints_conflict_warning_when_front_page_equals_posts_page_on_reading_screen() {
+		$current_screen       = new stdClass();
+		$current_screen->base = 'options-reading';
+		WP_Mock::userFunction( 'get_current_screen' )->once()->andReturn( $current_screen );
+
+		$this->stub_has_front_page( 'page', 5 );
+		WP_Mock::userFunction( 'get_option' )->with( 'page_for_posts' )->andReturn( 5 );
+
+		WP_Mock::userFunction( 'esc_attr' )->once()->andReturnUsing(
+			function ( $value ) {
+				return $value;
+			}
+		);
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		ob_start();
+		$admin->admin_notices();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'requires a homepage that is different', $output );
+	}
+
+	public function test_admin_notices_prints_nothing_when_front_page_set_and_pages_differ() {
+		$current_screen       = new stdClass();
+		$current_screen->base = 'options-reading';
+		WP_Mock::userFunction( 'get_current_screen' )->once()->andReturn( $current_screen );
+
+		$this->stub_has_front_page( 'page', 5 );
+		WP_Mock::userFunction( 'get_option' )->with( 'page_for_posts' )->andReturn( 9 );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		ob_start();
+		$admin->admin_notices();
+		$this->assertSame( '', ob_get_clean() );
+	}
+
+	/**
+	 * update_posts_page_notice()
+	 */
+
+	public function test_update_posts_page_notice_swaps_the_notice_when_editing_the_posts_page() {
+		WP_Mock::userFunction( 'get_option' )->once()->with( 'page_for_posts' )->andReturn( 5 );
+		WP_Mock::userFunction( 'get_the_ID' )->once()->andReturn( 5 );
+		WP_Mock::userFunction( 'remove_action' )->once()->with( 'edit_form_after_title', '_wp_posts_page_notice' );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		WP_Mock::expectActionAdded( 'edit_form_after_title', array( $admin, 'posts_page_notice' ) );
+
+		$admin->update_posts_page_notice();
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	public function test_update_posts_page_notice_no_op_when_not_editing_the_posts_page() {
+		WP_Mock::userFunction( 'get_option' )->once()->with( 'page_for_posts' )->andReturn( 5 );
+		WP_Mock::userFunction( 'get_the_ID' )->once()->andReturn( 9 );
+
+		// remove_action()/add_action() must never be reached: nothing further is stubbed.
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->update_posts_page_notice();
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * posts_page_notice()
+	 */
+
+	public function test_posts_page_notice_echoes_expected_markup() {
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		ob_start();
+		$admin->posts_page_notice();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'notice notice-warning inline', $output );
+		$this->assertStringContainsString( 'redirected to the homepage', $output );
+	}
+
+	/**
+	 * page_post_states()
+	 */
+
+	public function test_page_post_states_adds_redirected_state_when_front_page_set_and_ids_match() {
+		$this->stub_has_front_page( 'page', 5 );
+		WP_Mock::userFunction( 'get_option' )->with( 'page_for_posts' )->andReturn( 5 );
+		WP_Mock::userFunction( 'absint' )->with( 5 )->andReturn( 5 );
+
+		$post = new WP_Post( array( 'ID' => 5 ) );
+
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$result = $admin->page_post_states( array( 'existing' => 'Existing' ), $post );
+
+		$this->assertArrayHasKey( 'dwpb-redirected', $result );
+		$this->assertSame( 'Existing', $result['existing'] );
+	}
+
+	public function test_page_post_states_unchanged_when_ids_do_not_match() {
+		$this->stub_has_front_page( 'page', 5 );
+		WP_Mock::userFunction( 'get_option' )->with( 'page_for_posts' )->andReturn( 5 );
+		WP_Mock::userFunction( 'absint' )->with( 5 )->andReturn( 5 );
+
+		$post = new WP_Post( array( 'ID' => 9 ) );
+
+		$admin       = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$post_states = array( 'existing' => 'Existing' );
+
+		$this->assertSame( $post_states, $admin->page_post_states( $post_states, $post ) );
+	}
+
+	public function test_page_post_states_unchanged_when_no_front_page_set() {
+		$this->stub_has_front_page( 'posts', 0 );
+
+		$post = new WP_Post( array( 'ID' => 5 ) );
+
+		// get_option( 'page_for_posts' ) must never be reached: has_front_page() short-
+		// circuits the && before it.
+		$admin       = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$post_states = array( 'existing' => 'Existing' );
+
+		$this->assertSame( $post_states, $admin->page_post_states( $post_states, $post ) );
+	}
+
+	/**
+	 * available_permalink_structure_tags()
+	 */
+
+	public function test_available_permalink_structure_tags_removes_category_when_unsupported() {
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', false );
+		WP_Mock::onFilter( 'dwpb_disable_author_archives' )->with( false )->reply( false );
+
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$result = $admin->available_permalink_structure_tags(
+			array(
+				'category' => '%category%',
+				'author'   => '%author%',
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'category', $result );
+		$this->assertArrayHasKey( 'author', $result );
+	}
+
+	public function test_available_permalink_structure_tags_keeps_category_when_supported() {
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', array( 'book' ) );
+		WP_Mock::onFilter( 'dwpb_disable_author_archives' )->with( false )->reply( false );
+
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$result = $admin->available_permalink_structure_tags( array( 'category' => '%category%' ) );
+
+		$this->assertArrayHasKey( 'category', $result );
+	}
+
+	public function test_available_permalink_structure_tags_removes_author_when_author_archives_disabled() {
+		WP_Mock::onFilter( 'dwpb_disable_author_archives' )->with( false )->reply( true );
+
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$result = $admin->available_permalink_structure_tags( array( 'author' => '%author%' ) );
+
+		$this->assertArrayNotHasKey( 'author', $result );
+	}
+
+	public function test_available_permalink_structure_tags_keeps_author_when_author_archives_enabled() {
+		WP_Mock::onFilter( 'dwpb_disable_author_archives' )->with( false )->reply( false );
+
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$result = $admin->available_permalink_structure_tags( array( 'author' => '%author%' ) );
+
+		$this->assertArrayHasKey( 'author', $result );
+	}
+
+	public function test_available_permalink_structure_tags_no_op_when_keys_absent() {
+		// Neither dwpb_post_types_with_tax() nor dwpb_disable_author_archives may be
+		// reached: nothing is stubbed.
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$result = $admin->available_permalink_structure_tags( array( 'month' => '%monthnum%' ) );
+
+		$this->assertSame( array( 'month' => '%monthnum%' ), $result );
+	}
+
+	/**
+	 * filter_block_type_metadata()
+	 */
+
+	public function test_filter_block_type_metadata_leaves_unrelated_block_unchanged() {
+		$admin    = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$metadata = array( 'name' => 'core/paragraph' );
+
+		$this->assertSame( $metadata, $admin->filter_block_type_metadata( $metadata ) );
+	}
+
+	public function test_filter_block_type_metadata_changes_query_block_default_post_type_to_page() {
+		$admin    = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$metadata = array(
+			'name'       => 'core/query',
+			'attributes' => array(
+				'query' => array(
+					'default' => array( 'postType' => 'post' ),
+				),
+			),
+		);
+
+		$result = $admin->filter_block_type_metadata( $metadata );
+
+		$this->assertSame( 'page', $result['attributes']['query']['default']['postType'] );
+	}
+
+	public function test_filter_block_type_metadata_leaves_query_block_unchanged_when_default_missing() {
+		$admin    = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$metadata = array(
+			'name'       => 'core/query',
+			'attributes' => array(),
+		);
+
+		$this->assertSame( $metadata, $admin->filter_block_type_metadata( $metadata ) );
+	}
+
+	public function test_filter_block_type_metadata_bails_when_name_missing() {
+		$admin    = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$metadata = array( 'attributes' => array() );
+
+		$this->assertSame( $metadata, $admin->filter_block_type_metadata( $metadata ) );
+	}
+
+	/**
+	 * Documents behavior, not a distinct branch: the guard's `! is_string( $metadata['name'] )`
+	 * half is unreachable-as-observable. Proven by mutation -- deleting that half of the
+	 * guard and rerunning this test still passes, because the subsequent
+	 * `'core/query' === $metadata['name']` strict comparison already evaluates to false for
+	 * any non-string $metadata['name'] under PHP's strict-equality type rules, independent
+	 * of the guard. This test asserts the function's actual (correct) output for a
+	 * non-string name; it does not, and cannot, isolate the is_string() check itself.
+	 */
+	public function test_filter_block_type_metadata_bails_when_name_not_a_string() {
+		$admin    = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$metadata = array( 'name' => array( 'core/query' ) );
+
+		$this->assertSame( $metadata, $admin->filter_block_type_metadata( $metadata ) );
+	}
+
+	/**
+	 * site_status_tests()
+	 */
+
+	public function test_site_status_tests_replaces_rest_availability_test_callback() {
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$tests = array(
+			'direct' => array(
+				'rest_availability' => array( 'test' => 'rest_availability' ),
+			),
+		);
+
+		$result = $admin->site_status_tests( $tests );
+
+		$this->assertSame( array( $admin, 'get_test_rest_availability' ), $result['direct']['rest_availability']['test'] );
+	}
+
+	public function test_site_status_tests_leaves_tests_unchanged_when_rest_availability_absent() {
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$tests = array( 'direct' => array( 'other_test' => array( 'test' => 'other_test' ) ) );
+
+		$this->assertSame( $tests, $admin->site_status_tests( $tests ) );
+	}
+
+	/**
+	 * get_test_rest_availability()
+	 */
+
+	/**
+	 * Stubs everything get_test_rest_availability() unconditionally reaches before its
+	 * wp_remote_get() branch check: wp_unslash( $_COOKIE ), wp_create_nonce(),
+	 * the https_local_ssl_verify filter, rest_url() and add_query_arg().
+	 *
+	 * @return void
+	 */
+	private function stub_get_test_rest_availability_common() {
+		WP_Mock::userFunction( 'wp_unslash' )->with( array() )->andReturn( array() );
+		WP_Mock::userFunction( 'wp_create_nonce' )->once()->with( 'wp_rest' )->andReturn( 'a-nonce' );
+		WP_Mock::onFilter( 'https_local_ssl_verify' )->with( false )->reply( false );
+		WP_Mock::userFunction( 'rest_url' )->once()->with( 'wp/v2/types/page' )->andReturn( 'https://example.test/wp-json/wp/v2/types/page' );
+		WP_Mock::userFunction( 'add_query_arg' )
+			->once()
+			->with( array( 'context' => 'edit' ), 'https://example.test/wp-json/wp/v2/types/page' )
+			->andReturn( 'https://example.test/wp-json/wp/v2/types/page?context=edit' );
+	}
+
+	public function test_get_test_rest_availability_happy_path_when_capabilities_present() {
+		$this->stub_get_test_rest_availability_common();
+
+		$response = array( 'body' => '{"capabilities":{"read":true}}' );
+		WP_Mock::userFunction( 'wp_remote_get' )->once()->andReturn( $response );
+		WP_Mock::userFunction( 'is_wp_error' )->once()->with( $response )->andReturn( false );
+		WP_Mock::userFunction( 'wp_remote_retrieve_response_code' )->once()->with( $response )->andReturn( 200 );
+		WP_Mock::userFunction( 'wp_remote_retrieve_body' )->with( $response )->andReturn( $response['body'] );
+
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$result = $admin->get_test_rest_availability();
+
+		$this->assertSame( 'good', $result['status'] );
+		$this->assertSame( 'The REST API is available', $result['label'] );
+	}
+
+	public function test_get_test_rest_availability_wp_error_branch() {
+		$this->stub_get_test_rest_availability_common();
+
+		$error = Mockery::mock();
+		$error->shouldReceive( 'get_error_message' )->once()->andReturn( 'Connection refused' );
+		$error->shouldReceive( 'get_error_code' )->once()->andReturn( 'http_request_failed' );
+		WP_Mock::userFunction( 'wp_remote_get' )->once()->andReturn( $error );
+		WP_Mock::userFunction( 'is_wp_error' )->once()->with( $error )->andReturn( true );
+
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$result = $admin->get_test_rest_availability();
+
+		$this->assertSame( 'critical', $result['status'] );
+		$this->assertSame( 'The REST API encountered an error', $result['label'] );
+		$this->assertStringContainsString( 'Connection refused', $result['description'] );
+		$this->assertStringContainsString( 'http_request_failed', $result['description'] );
+	}
+
+	public function test_get_test_rest_availability_non_200_response_branch() {
+		$this->stub_get_test_rest_availability_common();
+
+		$response = array( 'body' => 'Not Found' );
+		WP_Mock::userFunction( 'wp_remote_get' )->once()->andReturn( $response );
+		WP_Mock::userFunction( 'is_wp_error' )->once()->with( $response )->andReturn( false );
+		// Called twice: once for the elseif condition, once again inside the error message.
+		WP_Mock::userFunction( 'wp_remote_retrieve_response_code' )->twice()->with( $response )->andReturn( 404 );
+		WP_Mock::userFunction( 'wp_remote_retrieve_body' )->with( $response )->andReturn( 'Not Found' );
+		WP_Mock::userFunction( 'esc_html' )->with( 'Not Found' )->andReturn( 'Not Found' );
+
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$result = $admin->get_test_rest_availability();
+
+		$this->assertSame( 'recommended', $result['status'] );
+		$this->assertSame( 'The REST API encountered an unexpected result', $result['label'] );
+		$this->assertStringContainsString( '404', $result['description'] );
+	}
+
+	public function test_get_test_rest_availability_200_missing_capabilities_branch() {
+		$this->stub_get_test_rest_availability_common();
+
+		$response = array( 'body' => '{"other":"value"}' );
+		WP_Mock::userFunction( 'wp_remote_get' )->once()->andReturn( $response );
+		WP_Mock::userFunction( 'is_wp_error' )->once()->with( $response )->andReturn( false );
+		WP_Mock::userFunction( 'wp_remote_retrieve_response_code' )->once()->with( $response )->andReturn( 200 );
+		WP_Mock::userFunction( 'wp_remote_retrieve_body' )->with( $response )->andReturn( $response['body'] );
+
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$result = $admin->get_test_rest_availability();
+
+		$this->assertSame( 'recommended', $result['status'] );
+		$this->assertSame( 'The REST API did not behave correctly', $result['label'] );
+		$this->assertStringContainsString( 'context', $result['description'] );
+	}
+
+	/**
+	 * Proves the Basic-auth header is only added when PHP_AUTH_USER/PHP_AUTH_PW are both
+	 * present on $_SERVER -- every other test in this group leaves them unset.
+	 */
+	public function test_get_test_rest_availability_includes_basic_auth_header_when_present() {
+		// phpcs:disable WordPressVIPMinimum.Variables.ServerVariables.BasicAuthentication -- exercising the exact same $_SERVER keys the method under test reads.
+		$_SERVER['PHP_AUTH_USER'] = 'admin';
+		$_SERVER['PHP_AUTH_PW']   = 'secret';
+		// phpcs:enable WordPressVIPMinimum.Variables.ServerVariables.BasicAuthentication
+
+		WP_Mock::userFunction( 'wp_unslash' )->with( array() )->andReturn( array() );
+		WP_Mock::userFunction( 'wp_unslash' )->with( 'admin' )->andReturn( 'admin' );
+		WP_Mock::userFunction( 'wp_unslash' )->with( 'secret' )->andReturn( 'secret' );
+		WP_Mock::userFunction( 'wp_create_nonce' )->once()->with( 'wp_rest' )->andReturn( 'a-nonce' );
+		WP_Mock::onFilter( 'https_local_ssl_verify' )->with( false )->reply( false );
+		WP_Mock::userFunction( 'rest_url' )->once()->with( 'wp/v2/types/page' )->andReturn( 'https://example.test/wp-json/wp/v2/types/page' );
+		WP_Mock::userFunction( 'add_query_arg' )
+			->once()
+			->with( array( 'context' => 'edit' ), 'https://example.test/wp-json/wp/v2/types/page' )
+			->andReturn( 'https://example.test/wp-json/wp/v2/types/page?context=edit' );
+
+		$response = array( 'body' => '{"capabilities":{"read":true}}' );
+		WP_Mock::userFunction( 'wp_remote_get' )
+			->once()
+			->with(
+				'https://example.test/wp-json/wp/v2/types/page?context=edit',
+				Mockery::on(
+					function ( $args ) {
+						return isset( $args['headers']['Authorization'] )
+							&& 'Basic ' . base64_encode( 'admin:secret' ) === $args['headers']['Authorization'];
+					}
+				)
+			)
+			->andReturn( $response );
+		WP_Mock::userFunction( 'is_wp_error' )->once()->with( $response )->andReturn( false );
+		WP_Mock::userFunction( 'wp_remote_retrieve_response_code' )->once()->with( $response )->andReturn( 200 );
+		WP_Mock::userFunction( 'wp_remote_retrieve_body' )->with( $response )->andReturn( $response['body'] );
+
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$result = $admin->get_test_rest_availability();
+
+		$this->assertSame( 'good', $result['status'] );
+	}
+}

--- a/tests/php/AdminRedirectsTest.php
+++ b/tests/php/AdminRedirectsTest.php
@@ -233,6 +233,49 @@ class AdminRedirectsTest extends TestCase {
 	}
 
 	/**
+	 * Continue semantics: is_admin_page() is forced (as in the break test below) to report
+	 * a match for every slug the loop checks, so 'post' (the first row) and then 'edit'
+	 * (the second row) are both reached. redirect_admin_post() is driven to return false --
+	 * neither boolean true nor a non-empty string -- so the 'post' row's `else` arm hits
+	 * `continue` rather than `break`, and the loop moves on to check 'edit' instead of
+	 * stopping. dwpb_redirect_admin_edit firing, and its url reaching redirect(), is what
+	 * proves the loop actually continued: if `continue` were replaced with `break`, the
+	 * loop would stop at 'post' and $functions->redirect_calls would stay empty.
+	 */
+	public function test_redirect_admin_pages_continues_past_slug_when_redirect_function_returns_false() {
+		global $pagenow;
+		// The value doesn't matter to is_admin_page() here (it's mocked to always match),
+		// but it must be a real string to pass the `! isset( $pagenow )` guard.
+		$pagenow = 'post.php';
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$edit_url      = 'https://example.test/wp-admin/edit.php?post_type=page';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+
+		// $_GET['post'] is deliberately left unset, so redirect_admin_post() short-
+		// circuits to false without needing get_post_type() stubbed -- this is what
+		// drives the 'post' row into the `continue` arm.
+		// $_GET['post_type'] is also left unset, so redirect_admin_edit() takes its
+		// url-returning branch on the very next iteration.
+		WP_Mock::userFunction( 'admin_url' )->with( 'edit.php?post_type=page' )->andReturn( $edit_url );
+		WP_Mock::userFunction( 'esc_url_raw' )->with( $edit_url )->andReturn( $edit_url );
+		WP_Mock::onFilter( 'dwpb_redirect_admin_edit' )->with( $edit_url )->reply( $edit_url );
+		$this->stub_final_filters_passthrough( $edit_url );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = $this->getMockBuilder( Disable_Blog_Admin::class )
+			->setConstructorArgs( array( 'disable-blog', '0.5.6', $functions ) )
+			->onlyMethods( array( 'is_admin_page' ) )
+			->getMock();
+		$admin->method( 'is_admin_page' )->willReturn( true );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $edit_url ), $functions->redirect_calls );
+	}
+
+	/**
 	 * Break semantics: is_admin_page() is forced to report a match for every slug the loop
 	 * checks, so the FIRST entry in $admin_redirects ('post') is reached before any later
 	 * entry. dwpb_redirect_admin_edit (the second row's filter) is deliberately left

--- a/tests/php/AdminRedirectsTest.php
+++ b/tests/php/AdminRedirectsTest.php
@@ -1,0 +1,1074 @@
+<?php
+/**
+ * Tests for Disable_Blog_Admin::redirect_admin_pages(), its is_admin_page() gate, and each
+ * individual redirect_admin_* delegate method.
+ *
+ * @package DisableBlog
+ */
+
+// Not required by tests/php/bootstrap.php on purpose (see ConstructorInjectionTest.php's note;
+// LoaderTest's autoloader test needs Disable_Blog_Functions to remain undefined until its own
+// isolated process). require_once is safe regardless of which test file happens to load first.
+require_once __DIR__ . '/../../includes/class-disable-blog-functions.php';
+require_once __DIR__ . '/Support/fixtures/class-admin-functions-double.php';
+
+/**
+ * @covers Disable_Blog_Admin::redirect_admin_pages
+ * @covers Disable_Blog_Admin::is_admin_page
+ * @covers Disable_Blog_Admin::redirect_admin_post
+ * @covers Disable_Blog_Admin::redirect_admin_edit
+ * @covers Disable_Blog_Admin::redirect_admin_post_new
+ * @covers Disable_Blog_Admin::redirect_admin_term
+ * @covers Disable_Blog_Admin::redirect_admin_edit_tags
+ * @covers Disable_Blog_Admin::redirect_admin_edit_comments
+ * @covers Disable_Blog_Admin::redirect_admin_options_discussion
+ * @covers Disable_Blog_Admin::redirect_admin_options_writing
+ * @covers Disable_Blog_Admin::redirect_admin_tools
+ */
+class AdminRedirectsTest extends TestCase {
+
+	/**
+	 * The global $pagenow as it stood before the test, so it can be restored in tear_down().
+	 *
+	 * @var mixed
+	 */
+	private $original_pagenow;
+
+	/**
+	 * The superglobal $_GET as it stood before the test, so it can be restored in tear_down().
+	 *
+	 * @var array
+	 */
+	private $original_get;
+
+	protected function set_up() {
+		parent::set_up();
+
+		global $pagenow;
+		$this->original_pagenow = $pagenow ?? null;
+		// A null $pagenow is indistinguishable from an unset one to isset(), which is all
+		// redirect_admin_pages()'s first guard and is_admin_page() ever check it with.
+		$pagenow = null;
+
+		$this->original_get = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$_GET                = array(); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	}
+
+	protected function tear_down() {
+		global $pagenow;
+		$pagenow = $this->original_pagenow;
+
+		$_GET = $this->original_get; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Stubs get_current_screen() (null, so the multisite guard's is_callable() check is
+	 * false), is_multisite() (false, so the guard's first condition is false) and
+	 * admin_url( 'index.php' ) (the unconditional $dashboard_url computed right after both
+	 * guards) -- everything redirect_admin_pages() needs before it reaches the dispatch loop.
+	 *
+	 * @param string $dashboard_url The url admin_url( 'index.php' ) should return.
+	 * @return void
+	 */
+	private function stub_dashboard_guards_pass( $dashboard_url ) {
+		WP_Mock::userFunction( 'get_current_screen' )->andReturn( null );
+		WP_Mock::userFunction( 'is_multisite' )->andReturn( false );
+		WP_Mock::userFunction( 'admin_url' )->with( 'index.php' )->andReturn( $dashboard_url );
+	}
+
+	/**
+	 * Stubs the two filters redirect_admin_pages() applies, in order, after the dispatch loop
+	 * computes $redirect_url: dwpb_admin_redirect_url (passthrough) and dwpb_redirect_admin
+	 * (unfiltered true, so the redirect isn't skipped) -- so $redirect_url reaches
+	 * $functions->redirect() unmodified by either.
+	 *
+	 * @param string $redirect_url The url expected to reach redirect() unmodified.
+	 * @return void
+	 */
+	private function stub_final_filters_passthrough( $redirect_url ) {
+		WP_Mock::onFilter( 'dwpb_admin_redirect_url' )->with( $redirect_url )->reply( $redirect_url );
+		WP_Mock::onFilter( 'dwpb_redirect_admin' )->with( true, $redirect_url )->reply( true );
+	}
+
+	/**
+	 * Stubs the WordPress functions dwpb_post_types_with_tax() calls on every invocation,
+	 * regardless of taxonomy or cache state: get_post_types(), wp_cache_get()/wp_cache_set()
+	 * and maybe_serialize(), all called with the ( array(), 'names' ) arguments this file's
+	 * tests always use.
+	 *
+	 * @return void
+	 */
+	private function stub_tax_lookup_plumbing() {
+		WP_Mock::userFunction( 'get_post_types' )->with( array(), 'names' )->andReturn( array() );
+		WP_Mock::userFunction( 'wp_cache_get' )->andReturn( false );
+		WP_Mock::userFunction( 'wp_cache_set' )->andReturn( null );
+		WP_Mock::userFunction( 'maybe_serialize' )->with( array() )->andReturn( 'a:0:{}' );
+	}
+
+	/**
+	 * Forces dwpb_post_types_with_tax( $taxonomy ) to return $return_value, via the
+	 * dwpb_taxonomy_support short-circuit filter -- requires stub_tax_lookup_plumbing() to
+	 * have been called first in the same test.
+	 *
+	 * @param string     $taxonomy     The taxonomy slug ('post_tag' or 'category').
+	 * @param array|bool $return_value The value dwpb_post_types_with_tax() should return.
+	 * @return void
+	 */
+	private function stub_post_types_with_tax_result( $taxonomy, $return_value ) {
+		WP_Mock::userFunction( 'esc_attr' )->with( $taxonomy )->andReturn( $taxonomy );
+		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
+			->with( null, $taxonomy, array(), array(), 'names' )
+			->reply( $return_value );
+	}
+
+	/**
+	 * Forces dwpb_post_types_with_feature( $feature ) to return $return_value.
+	 *
+	 * wp_cache_get() returning ANY array (even an empty one) is a cache HIT as far as
+	 * dwpb_post_types_with_feature() is concerned -- it skips get_post_types()/
+	 * post_type_supports() entirely and passes the cached value straight to the
+	 * dwpb_post_types_supporting_{$feature} filter, whose reply IS the function's return
+	 * value regardless of what was "cached".
+	 *
+	 * @param string     $feature      The feature slug (e.g. 'comments').
+	 * @param array|bool $return_value The value dwpb_post_types_with_feature() should return.
+	 * @return void
+	 */
+	private function stub_feature_cache_hit( $feature, $return_value ) {
+		WP_Mock::userFunction( 'esc_attr' )->with( $feature )->andReturn( $feature );
+		WP_Mock::userFunction( 'wp_cache_get' )
+			->with( "post-types-supporting-{$feature}", 'post-types-by-feature' )
+			->andReturn( array() );
+		WP_Mock::onFilter( "dwpb_post_types_supporting_{$feature}" )
+			->with( array(), array() )
+			->reply( $return_value );
+	}
+
+	/**
+	 * redirect_admin_pages()
+	 */
+
+	/**
+	 * The `! isset( $pagenow )` guard is the very first thing the method checks, so nothing
+	 * else may be stubbed here -- an unexpected call to an un-mocked WP function fatals.
+	 */
+	public function test_redirect_admin_pages_returns_early_when_pagenow_not_set() {
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array(), $functions->redirect_calls );
+	}
+
+	/**
+	 * On multisite, a network-admin screen must bail before the dispatch loop even starts.
+	 */
+	public function test_redirect_admin_pages_returns_early_on_multisite_network_admin_screen() {
+		global $pagenow;
+		$pagenow = 'post.php'; // Passes guard 1; must never be reached beyond guard 2.
+
+		$screen = Mockery::mock();
+		$screen->shouldReceive( 'in_admin' )->once()->with( 'network' )->andReturn( true );
+
+		WP_Mock::userFunction( 'get_current_screen' )->once()->andReturn( $screen );
+		WP_Mock::userFunction( 'is_multisite' )->once()->andReturn( true );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array(), $functions->redirect_calls );
+	}
+
+	/**
+	 * is_multisite() alone must not be enough to bail -- $screen->in_admin( 'network' )
+	 * returning false must let execution continue into the dispatch loop.
+	 */
+	public function test_redirect_admin_pages_continues_past_guard_when_screen_not_on_network_admin() {
+		global $pagenow;
+		$pagenow = 'unrelated-page.php'; // Matches no admin_redirects slug.
+
+		$screen = Mockery::mock();
+		$screen->shouldReceive( 'in_admin' )->once()->with( 'network' )->andReturn( false );
+
+		WP_Mock::userFunction( 'get_current_screen' )->once()->andReturn( $screen );
+		WP_Mock::userFunction( 'is_multisite' )->once()->andReturn( true );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		WP_Mock::userFunction( 'admin_url' )->with( 'index.php' )->andReturn( $dashboard_url );
+		WP_Mock::onFilter( 'dwpb_admin_redirect_url' )->with( false )->reply( false );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array(), $functions->redirect_calls );
+	}
+
+	/**
+	 * When $pagenow doesn't match any of the nine admin_redirects slugs, the loop never
+	 * finds a match, $redirect_url stays false, and no redirect happens.
+	 */
+	public function test_redirect_admin_pages_does_nothing_when_pagenow_matches_no_slug() {
+		global $pagenow;
+		$pagenow = 'unrelated-page.php';
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+		WP_Mock::onFilter( 'dwpb_admin_redirect_url' )->with( false )->reply( false );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array(), $functions->redirect_calls );
+	}
+
+	/**
+	 * Break semantics: is_admin_page() is forced to report a match for every slug the loop
+	 * checks, so the FIRST entry in $admin_redirects ('post') is reached before any later
+	 * entry. dwpb_redirect_admin_edit (the second row's filter) is deliberately left
+	 * unstubbed: if `break` were removed, the loop would reach 'edit' next and call
+	 * apply_filters() on that hook, which strict mode turns into a hard failure.
+	 */
+	public function test_redirect_admin_pages_break_stops_loop_at_first_matching_slug() {
+		global $pagenow;
+		// The value doesn't matter to is_admin_page() here (it's mocked to always match),
+		// but it must be a real string to pass the `! isset( $pagenow )` guard.
+		$pagenow = 'post.php';
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+
+		$_GET['post'] = 5;
+		WP_Mock::userFunction( 'get_post_type' )->with( 5 )->andReturn( 'post' );
+
+		$post_wins_url = 'https://example.test/wp-admin/post-wins/';
+		WP_Mock::onFilter( 'dwpb_redirect_admin_post' )->with( $dashboard_url )->reply( $post_wins_url );
+		$this->stub_final_filters_passthrough( $post_wins_url );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = $this->getMockBuilder( Disable_Blog_Admin::class )
+			->setConstructorArgs( array( 'disable-blog', '0.5.6', $functions ) )
+			->onlyMethods( array( 'is_admin_page' ) )
+			->getMock();
+		$admin->method( 'is_admin_page' )->willReturn( true );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $post_wins_url ), $functions->redirect_calls );
+	}
+
+	/**
+	 * dwpb_admin_redirect_url is a global override applied after the per-page filter and
+	 * after the loop, so it must win over the per-page filtered value.
+	 */
+	public function test_redirect_admin_pages_dwpb_admin_redirect_url_filter_overrides_final_url() {
+		global $pagenow;
+		$pagenow = 'tools.php';
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+
+		WP_Mock::onFilter( 'dwpb_redirect_admin_tools' )->with( $dashboard_url )->reply( $dashboard_url );
+		WP_Mock::userFunction( 'apply_filters_deprecated' )
+			->once()
+			->with( 'dwpb_redirect_admin_options_tools', array( $dashboard_url ), '0.5.6', 'dwpb_redirect_admin_tools' )
+			->andReturn( $dashboard_url );
+
+		$global_override_url = 'https://example.test/wp-admin/global-override/';
+		WP_Mock::onFilter( 'dwpb_admin_redirect_url' )->with( $dashboard_url )->reply( $global_override_url );
+		WP_Mock::onFilter( 'dwpb_redirect_admin' )->with( true, $global_override_url )->reply( true );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $global_override_url ), $functions->redirect_calls );
+	}
+
+	/**
+	 * dwpb_redirect_admin toggle: false disables the redirect entirely, even though a slug
+	 * matched and a redirect url was computed.
+	 */
+	public function test_redirect_admin_pages_dwpb_redirect_admin_false_skips_redirect_entirely() {
+		global $pagenow;
+		$pagenow = 'tools.php';
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+
+		WP_Mock::onFilter( 'dwpb_redirect_admin_tools' )->with( $dashboard_url )->reply( $dashboard_url );
+		WP_Mock::userFunction( 'apply_filters_deprecated' )
+			->once()
+			->with( 'dwpb_redirect_admin_options_tools', array( $dashboard_url ), '0.5.6', 'dwpb_redirect_admin_tools' )
+			->andReturn( $dashboard_url );
+
+		WP_Mock::onFilter( 'dwpb_admin_redirect_url' )->with( $dashboard_url )->reply( $dashboard_url );
+		WP_Mock::onFilter( 'dwpb_redirect_admin' )->with( true, $dashboard_url )->reply( false );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array(), $functions->redirect_calls );
+	}
+
+	/**
+	 * 'post' row: redirect_admin_post() returns bool true -> dashboard redirect.
+	 */
+	public function test_redirect_admin_pages_redirects_post_screen_with_default_url() {
+		global $pagenow;
+		$pagenow      = 'post.php';
+		$_GET['post'] = 5;
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+		WP_Mock::userFunction( 'get_post_type' )->with( 5 )->andReturn( 'post' );
+
+		WP_Mock::onFilter( 'dwpb_redirect_admin_post' )->with( $dashboard_url )->reply( $dashboard_url );
+		$this->stub_final_filters_passthrough( $dashboard_url );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $dashboard_url ), $functions->redirect_calls );
+	}
+
+	public function test_redirect_admin_pages_dwpb_redirect_admin_post_filter_overrides_url() {
+		global $pagenow;
+		$pagenow      = 'post.php';
+		$_GET['post'] = 5;
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+		WP_Mock::userFunction( 'get_post_type' )->with( 5 )->andReturn( 'post' );
+
+		$custom_url = 'https://example.test/wp-admin/custom-post/';
+		WP_Mock::onFilter( 'dwpb_redirect_admin_post' )->with( $dashboard_url )->reply( $custom_url );
+		$this->stub_final_filters_passthrough( $custom_url );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $custom_url ), $functions->redirect_calls );
+	}
+
+	/**
+	 * 'edit' row: redirect_admin_edit() returns a url string (never bool true).
+	 */
+	public function test_redirect_admin_pages_redirects_edit_screen_with_default_url() {
+		global $pagenow;
+		$pagenow = 'edit.php';
+		// The post_type query var is intentionally left absent.
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$edit_url      = 'https://example.test/wp-admin/edit.php?post_type=page';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+		WP_Mock::userFunction( 'admin_url' )->with( 'edit.php?post_type=page' )->andReturn( $edit_url );
+		WP_Mock::userFunction( 'esc_url_raw' )->with( $edit_url )->andReturn( $edit_url );
+
+		WP_Mock::onFilter( 'dwpb_redirect_admin_edit' )->with( $edit_url )->reply( $edit_url );
+		$this->stub_final_filters_passthrough( $edit_url );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $edit_url ), $functions->redirect_calls );
+	}
+
+	public function test_redirect_admin_pages_dwpb_redirect_admin_edit_filter_overrides_url() {
+		global $pagenow;
+		$pagenow = 'edit.php';
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$edit_url      = 'https://example.test/wp-admin/edit.php?post_type=page';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+		WP_Mock::userFunction( 'admin_url' )->with( 'edit.php?post_type=page' )->andReturn( $edit_url );
+		WP_Mock::userFunction( 'esc_url_raw' )->with( $edit_url )->andReturn( $edit_url );
+
+		$custom_url = 'https://example.test/wp-admin/custom-edit/';
+		WP_Mock::onFilter( 'dwpb_redirect_admin_edit' )->with( $edit_url )->reply( $custom_url );
+		$this->stub_final_filters_passthrough( $custom_url );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $custom_url ), $functions->redirect_calls );
+	}
+
+	/**
+	 * 'post-new' row: redirect_admin_post_new() returns a url string (never bool true).
+	 */
+	public function test_redirect_admin_pages_redirects_post_new_screen_with_default_url() {
+		global $pagenow;
+		$pagenow = 'post-new.php';
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$post_new_url  = 'https://example.test/wp-admin/post-new.php?post_type=page';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+		WP_Mock::userFunction( 'admin_url' )->with( 'post-new.php?post_type=page' )->andReturn( $post_new_url );
+		WP_Mock::userFunction( 'esc_url_raw' )->with( $post_new_url )->andReturn( $post_new_url );
+
+		WP_Mock::onFilter( 'dwpb_redirect_admin_post_new' )->with( $post_new_url )->reply( $post_new_url );
+		$this->stub_final_filters_passthrough( $post_new_url );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $post_new_url ), $functions->redirect_calls );
+	}
+
+	public function test_redirect_admin_pages_dwpb_redirect_admin_post_new_filter_overrides_url() {
+		global $pagenow;
+		$pagenow = 'post-new.php';
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$post_new_url  = 'https://example.test/wp-admin/post-new.php?post_type=page';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+		WP_Mock::userFunction( 'admin_url' )->with( 'post-new.php?post_type=page' )->andReturn( $post_new_url );
+		WP_Mock::userFunction( 'esc_url_raw' )->with( $post_new_url )->andReturn( $post_new_url );
+
+		$custom_url = 'https://example.test/wp-admin/custom-post-new/';
+		WP_Mock::onFilter( 'dwpb_redirect_admin_post_new' )->with( $post_new_url )->reply( $custom_url );
+		$this->stub_final_filters_passthrough( $custom_url );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $custom_url ), $functions->redirect_calls );
+	}
+
+	/**
+	 * 'edit-tags' row: redirect_admin_edit_tags() returns bool true -> dashboard redirect.
+	 */
+	public function test_redirect_admin_pages_redirects_edit_tags_screen_with_default_url() {
+		global $pagenow;
+		$pagenow          = 'edit-tags.php';
+		$_GET['taxonomy'] = 'post_tag';
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+
+		WP_Mock::onFilter( 'dwpb_redirect_admin_edit_tags' )->with( $dashboard_url )->reply( $dashboard_url );
+		$this->stub_final_filters_passthrough( $dashboard_url );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $dashboard_url ), $functions->redirect_calls );
+	}
+
+	public function test_redirect_admin_pages_dwpb_redirect_admin_edit_tags_filter_overrides_url() {
+		global $pagenow;
+		$pagenow          = 'edit-tags.php';
+		$_GET['taxonomy'] = 'post_tag';
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+
+		$custom_url = 'https://example.test/wp-admin/custom-edit-tags/';
+		WP_Mock::onFilter( 'dwpb_redirect_admin_edit_tags' )->with( $dashboard_url )->reply( $custom_url );
+		$this->stub_final_filters_passthrough( $custom_url );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $custom_url ), $functions->redirect_calls );
+	}
+
+	/**
+	 * 'term' row: redirect_admin_term() returns bool true -> dashboard redirect.
+	 */
+	public function test_redirect_admin_pages_redirects_term_screen_with_default_url() {
+		global $pagenow;
+		$pagenow          = 'term.php';
+		$_GET['taxonomy'] = 'category';
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', false );
+
+		WP_Mock::onFilter( 'dwpb_redirect_admin_term' )->with( $dashboard_url )->reply( $dashboard_url );
+		$this->stub_final_filters_passthrough( $dashboard_url );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $dashboard_url ), $functions->redirect_calls );
+	}
+
+	public function test_redirect_admin_pages_dwpb_redirect_admin_term_filter_overrides_url() {
+		global $pagenow;
+		$pagenow          = 'term.php';
+		$_GET['taxonomy'] = 'category';
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', false );
+
+		$custom_url = 'https://example.test/wp-admin/custom-term/';
+		WP_Mock::onFilter( 'dwpb_redirect_admin_term' )->with( $dashboard_url )->reply( $custom_url );
+		$this->stub_final_filters_passthrough( $custom_url );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $custom_url ), $functions->redirect_calls );
+	}
+
+	/**
+	 * 'edit-comments' row: redirect_admin_edit_comments() returns bool true -> dashboard redirect.
+	 */
+	public function test_redirect_admin_pages_redirects_edit_comments_screen_with_default_url() {
+		global $pagenow;
+		$pagenow = 'edit-comments.php';
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+		$this->stub_feature_cache_hit( 'comments', false );
+
+		WP_Mock::onFilter( 'dwpb_redirect_admin_edit_comments' )->with( $dashboard_url )->reply( $dashboard_url );
+		$this->stub_final_filters_passthrough( $dashboard_url );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $dashboard_url ), $functions->redirect_calls );
+	}
+
+	public function test_redirect_admin_pages_dwpb_redirect_admin_edit_comments_filter_overrides_url() {
+		global $pagenow;
+		$pagenow = 'edit-comments.php';
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+		$this->stub_feature_cache_hit( 'comments', false );
+
+		$custom_url = 'https://example.test/wp-admin/custom-edit-comments/';
+		WP_Mock::onFilter( 'dwpb_redirect_admin_edit_comments' )->with( $dashboard_url )->reply( $custom_url );
+		$this->stub_final_filters_passthrough( $custom_url );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $custom_url ), $functions->redirect_calls );
+	}
+
+	/**
+	 * 'options-discussion' row: redirect_admin_options_discussion() wraps
+	 * redirect_admin_edit_comments(), but is dispatched under its own slug and filter.
+	 */
+	public function test_redirect_admin_pages_redirects_options_discussion_screen_with_default_url() {
+		global $pagenow;
+		$pagenow = 'options-discussion.php';
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+		$this->stub_feature_cache_hit( 'comments', false );
+
+		WP_Mock::onFilter( 'dwpb_redirect_admin_options_discussion' )->with( $dashboard_url )->reply( $dashboard_url );
+		$this->stub_final_filters_passthrough( $dashboard_url );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $dashboard_url ), $functions->redirect_calls );
+	}
+
+	public function test_redirect_admin_pages_dwpb_redirect_admin_options_discussion_filter_overrides_url() {
+		global $pagenow;
+		$pagenow = 'options-discussion.php';
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+		$this->stub_feature_cache_hit( 'comments', false );
+
+		$custom_url = 'https://example.test/wp-admin/custom-options-discussion/';
+		WP_Mock::onFilter( 'dwpb_redirect_admin_options_discussion' )->with( $dashboard_url )->reply( $custom_url );
+		$this->stub_final_filters_passthrough( $custom_url );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $custom_url ), $functions->redirect_calls );
+	}
+
+	/**
+	 * 'options-writing' row: redirect_admin_options_writing() returns a url string (never
+	 * bool true).
+	 */
+	public function test_redirect_admin_pages_redirects_options_writing_screen_with_default_url() {
+		global $pagenow;
+		$pagenow = 'options-writing.php';
+
+		$dashboard_url    = 'https://example.test/wp-admin/index.php';
+		$options_general_url = 'https://example.test/wp-admin/options-general.php';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+		WP_Mock::onFilter( 'dwpb_remove_options_writing' )->with( false )->reply( true );
+		WP_Mock::userFunction( 'admin_url' )->with( 'options-general.php' )->andReturn( $options_general_url );
+		WP_Mock::userFunction( 'esc_url_raw' )->with( $options_general_url )->andReturn( $options_general_url );
+
+		WP_Mock::onFilter( 'dwpb_redirect_admin_options_writing' )->with( $options_general_url )->reply( $options_general_url );
+		$this->stub_final_filters_passthrough( $options_general_url );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $options_general_url ), $functions->redirect_calls );
+	}
+
+	public function test_redirect_admin_pages_dwpb_redirect_admin_options_writing_filter_overrides_url() {
+		global $pagenow;
+		$pagenow = 'options-writing.php';
+
+		$dashboard_url        = 'https://example.test/wp-admin/index.php';
+		$options_general_url  = 'https://example.test/wp-admin/options-general.php';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+		WP_Mock::onFilter( 'dwpb_remove_options_writing' )->with( false )->reply( true );
+		WP_Mock::userFunction( 'admin_url' )->with( 'options-general.php' )->andReturn( $options_general_url );
+		WP_Mock::userFunction( 'esc_url_raw' )->with( $options_general_url )->andReturn( $options_general_url );
+
+		$custom_url = 'https://example.test/wp-admin/custom-options-writing/';
+		WP_Mock::onFilter( 'dwpb_redirect_admin_options_writing' )->with( $options_general_url )->reply( $custom_url );
+		$this->stub_final_filters_passthrough( $custom_url );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $custom_url ), $functions->redirect_calls );
+	}
+
+	/**
+	 * 'tools' row: redirect_admin_tools() returns bool true -> dashboard redirect, and the
+	 * 'tools' page is the only one that also fires the back-compat
+	 * dwpb_redirect_admin_options_tools deprecated filter afterwards.
+	 */
+	public function test_redirect_admin_pages_redirects_tools_screen_with_default_url() {
+		global $pagenow;
+		$pagenow = 'tools.php';
+		// The page query var is intentionally left absent.
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+
+		WP_Mock::onFilter( 'dwpb_redirect_admin_tools' )->with( $dashboard_url )->reply( $dashboard_url );
+		WP_Mock::userFunction( 'apply_filters_deprecated' )
+			->once()
+			->with( 'dwpb_redirect_admin_options_tools', array( $dashboard_url ), '0.5.6', 'dwpb_redirect_admin_tools' )
+			->andReturn( $dashboard_url );
+		$this->stub_final_filters_passthrough( $dashboard_url );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $dashboard_url ), $functions->redirect_calls );
+	}
+
+	public function test_redirect_admin_pages_dwpb_redirect_admin_tools_filter_overrides_url() {
+		global $pagenow;
+		$pagenow = 'tools.php';
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+
+		$primary_custom_url = 'https://example.test/wp-admin/custom-tools/';
+		WP_Mock::onFilter( 'dwpb_redirect_admin_tools' )->with( $dashboard_url )->reply( $primary_custom_url );
+		WP_Mock::userFunction( 'apply_filters_deprecated' )
+			->once()
+			->with( 'dwpb_redirect_admin_options_tools', array( $primary_custom_url ), '0.5.6', 'dwpb_redirect_admin_tools' )
+			->andReturn( $primary_custom_url );
+		$this->stub_final_filters_passthrough( $primary_custom_url );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $primary_custom_url ), $functions->redirect_calls );
+	}
+
+	/**
+	 * The deprecated dwpb_redirect_admin_options_tools filter runs AFTER the primary
+	 * dwpb_redirect_admin_tools filter and can independently override its result.
+	 */
+	public function test_redirect_admin_pages_dwpb_redirect_admin_options_tools_deprecated_filter_overrides_url() {
+		global $pagenow;
+		$pagenow = 'tools.php';
+
+		$dashboard_url = 'https://example.test/wp-admin/index.php';
+		$this->stub_dashboard_guards_pass( $dashboard_url );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
+
+		WP_Mock::onFilter( 'dwpb_redirect_admin_tools' )->with( $dashboard_url )->reply( $dashboard_url );
+
+		$deprecated_custom_url = 'https://example.test/wp-admin/deprecated-tools/';
+		WP_Mock::userFunction( 'apply_filters_deprecated' )
+			->once()
+			->with( 'dwpb_redirect_admin_options_tools', array( $dashboard_url ), '0.5.6', 'dwpb_redirect_admin_tools' )
+			->andReturn( $deprecated_custom_url );
+		$this->stub_final_filters_passthrough( $deprecated_custom_url );
+
+		$functions = new Disable_Blog_Admin_Functions_Double();
+		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
+
+		$admin->redirect_admin_pages();
+
+		$this->assertSame( array( $deprecated_custom_url ), $functions->redirect_calls );
+	}
+
+	/**
+	 * is_admin_page()
+	 */
+
+	public function test_is_admin_page_false_when_not_is_admin() {
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->is_admin_page( 'post' ) );
+	}
+
+	public function test_is_admin_page_false_when_pagenow_not_set() {
+		// set_up()'s default leaves $pagenow null, which reads as unset to isset().
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( true );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->is_admin_page( 'post' ) );
+	}
+
+	public function test_is_admin_page_false_when_pagenow_not_a_string() {
+		global $pagenow;
+		$pagenow = array( 'post.php' );
+
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( true );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->is_admin_page( 'post' ) );
+	}
+
+	public function test_is_admin_page_false_when_pagenow_does_not_match() {
+		global $pagenow;
+		$pagenow = 'edit.php';
+
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( true );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->is_admin_page( 'post' ) );
+	}
+
+	public function test_is_admin_page_true_when_pagenow_matches() {
+		global $pagenow;
+		$pagenow = 'post.php';
+
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( true );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $admin->is_admin_page( 'post' ) );
+	}
+
+	/**
+	 * redirect_admin_post()
+	 */
+
+	public function test_redirect_admin_post_true_when_get_post_id_is_a_post() {
+		$_GET['post'] = 5;
+		WP_Mock::userFunction( 'get_post_type' )->once()->with( 5 )->andReturn( 'post' );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $admin->redirect_admin_post() );
+	}
+
+	public function test_redirect_admin_post_false_when_get_post_id_is_not_a_post() {
+		$_GET['post'] = 5;
+		WP_Mock::userFunction( 'get_post_type' )->once()->with( 5 )->andReturn( 'page' );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->redirect_admin_post() );
+	}
+
+	public function test_redirect_admin_post_false_when_get_post_not_set() {
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->redirect_admin_post() );
+	}
+
+	/**
+	 * redirect_admin_edit()
+	 */
+
+	public function test_redirect_admin_edit_redirects_when_post_type_not_set() {
+		$url = 'https://example.test/wp-admin/edit.php?post_type=page';
+		WP_Mock::userFunction( 'admin_url' )->once()->with( 'edit.php?post_type=page' )->andReturn( $url );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( $url, $admin->redirect_admin_edit() );
+	}
+
+	public function test_redirect_admin_edit_redirects_when_post_type_is_post() {
+		$_GET['post_type'] = 'post';
+		$url                = 'https://example.test/wp-admin/edit.php?post_type=page';
+		WP_Mock::userFunction( 'admin_url' )->once()->with( 'edit.php?post_type=page' )->andReturn( $url );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( $url, $admin->redirect_admin_edit() );
+	}
+
+	public function test_redirect_admin_edit_false_when_post_type_is_other() {
+		$_GET['post_type'] = 'page';
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->redirect_admin_edit() );
+	}
+
+	/**
+	 * redirect_admin_post_new()
+	 */
+
+	public function test_redirect_admin_post_new_redirects_when_post_type_not_set() {
+		$url = 'https://example.test/wp-admin/post-new.php?post_type=page';
+		WP_Mock::userFunction( 'admin_url' )->once()->with( 'post-new.php?post_type=page' )->andReturn( $url );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( $url, $admin->redirect_admin_post_new() );
+	}
+
+	public function test_redirect_admin_post_new_redirects_when_post_type_is_post() {
+		$_GET['post_type'] = 'post';
+		$url                = 'https://example.test/wp-admin/post-new.php?post_type=page';
+		WP_Mock::userFunction( 'admin_url' )->once()->with( 'post-new.php?post_type=page' )->andReturn( $url );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( $url, $admin->redirect_admin_post_new() );
+	}
+
+	public function test_redirect_admin_post_new_false_when_post_type_is_other() {
+		$_GET['post_type'] = 'page';
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->redirect_admin_post_new() );
+	}
+
+	/**
+	 * redirect_admin_term()
+	 */
+
+	public function test_redirect_admin_term_true_when_taxonomy_not_used_elsewhere() {
+		$_GET['taxonomy'] = 'category';
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', false );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $admin->redirect_admin_term() );
+	}
+
+	public function test_redirect_admin_term_false_when_taxonomy_used_elsewhere() {
+		$_GET['taxonomy'] = 'category';
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', array( 'book' ) );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->redirect_admin_term() );
+	}
+
+	public function test_redirect_admin_term_false_when_taxonomy_not_set() {
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->redirect_admin_term() );
+	}
+
+	/**
+	 * redirect_admin_edit_tags()
+	 */
+
+	public function test_redirect_admin_edit_tags_true_when_taxonomy_not_used_elsewhere() {
+		$_GET['taxonomy'] = 'post_tag';
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $admin->redirect_admin_edit_tags() );
+	}
+
+	public function test_redirect_admin_edit_tags_false_when_taxonomy_used_elsewhere() {
+		$_GET['taxonomy'] = 'post_tag';
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', array( 'book' ) );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->redirect_admin_edit_tags() );
+	}
+
+	public function test_redirect_admin_edit_tags_false_when_taxonomy_not_set() {
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->redirect_admin_edit_tags() );
+	}
+
+	/**
+	 * redirect_admin_edit_comments()
+	 */
+
+	public function test_redirect_admin_edit_comments_true_when_no_other_post_type_supports_comments() {
+		$this->stub_feature_cache_hit( 'comments', false );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $admin->redirect_admin_edit_comments() );
+	}
+
+	public function test_redirect_admin_edit_comments_false_when_another_post_type_supports_comments() {
+		$this->stub_feature_cache_hit( 'comments', array( 'book' ) );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->redirect_admin_edit_comments() );
+	}
+
+	/**
+	 * redirect_admin_options_discussion() -- a thin wrapper around redirect_admin_edit_comments().
+	 */
+
+	public function test_redirect_admin_options_discussion_true_when_no_other_post_type_supports_comments() {
+		$this->stub_feature_cache_hit( 'comments', false );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $admin->redirect_admin_options_discussion() );
+	}
+
+	public function test_redirect_admin_options_discussion_false_when_another_post_type_supports_comments() {
+		$this->stub_feature_cache_hit( 'comments', array( 'book' ) );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->redirect_admin_options_discussion() );
+	}
+
+	/**
+	 * redirect_admin_options_writing()
+	 */
+
+	public function test_redirect_admin_options_writing_redirects_when_writing_options_removed() {
+		$url = 'https://example.test/wp-admin/options-general.php';
+		WP_Mock::onFilter( 'dwpb_remove_options_writing' )->with( false )->reply( true );
+		WP_Mock::userFunction( 'admin_url' )->once()->with( 'options-general.php' )->andReturn( $url );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( $url, $admin->redirect_admin_options_writing() );
+	}
+
+	public function test_redirect_admin_options_writing_false_when_writing_options_kept() {
+		WP_Mock::onFilter( 'dwpb_remove_options_writing' )->with( false )->reply( false );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->redirect_admin_options_writing() );
+	}
+
+	/**
+	 * redirect_admin_tools()
+	 */
+
+	public function test_redirect_admin_tools_true_when_page_not_set() {
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $admin->redirect_admin_tools() );
+	}
+
+	public function test_redirect_admin_tools_false_when_page_set() {
+		$_GET['page'] = 'some-plugin-page';
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $admin->redirect_admin_tools() );
+	}
+}

--- a/tests/php/AdminUsersTest.php
+++ b/tests/php/AdminUsersTest.php
@@ -1,0 +1,424 @@
+<?php
+/**
+ * Tests for Disable_Blog_Admin's user-table surface: manage_users_columns(),
+ * manage_users_custom_column(), its private user_column_post_types() helper, and
+ * user_row_actions().
+ *
+ * @package DisableBlog
+ */
+
+// Not required by tests/php/bootstrap.php on purpose (see ConstructorInjectionTest.php's note;
+// LoaderTest's autoloader test needs Disable_Blog_Functions to remain undefined until its own
+// isolated process). require_once is safe regardless of which test file happens to load first.
+require_once __DIR__ . '/../../includes/class-disable-blog-functions.php';
+
+/**
+ * @covers Disable_Blog_Admin::manage_users_columns
+ * @covers Disable_Blog_Admin::manage_users_custom_column
+ * @covers Disable_Blog_Admin::user_column_post_types
+ * @covers Disable_Blog_Admin::user_row_actions
+ */
+class AdminUsersTest extends TestCase {
+
+	/**
+	 * The global $current_screen as it stood before the test, so it can be restored in
+	 * tear_down().
+	 *
+	 * @var mixed
+	 */
+	private $original_current_screen;
+
+	protected function set_up() {
+		parent::set_up();
+
+		global $current_screen;
+		$this->original_current_screen = $current_screen ?? null;
+	}
+
+	protected function tear_down() {
+		global $current_screen;
+		$current_screen = $this->original_current_screen;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Invokes the private user_column_post_types() method via Reflection.
+	 *
+	 * @param Disable_Blog_Admin $admin Instance to invoke on.
+	 * @return array
+	 */
+	private function invoke_user_column_post_types( Disable_Blog_Admin $admin ) {
+		$reflection = new ReflectionMethod( $admin, 'user_column_post_types' );
+		$reflection->setAccessible( true );
+
+		return $reflection->invoke( $admin );
+	}
+
+	/**
+	 * Forces user_column_post_types() to resolve to array( 'page' ): an empty
+	 * dwpb_author_archive_post_types reply (real Disable_Blog_Functions::author_archive_post_types()
+	 * default), merged with 'page', passed through dwpb_admin_user_post_types unchanged.
+	 *
+	 * @return void
+	 */
+	private function stub_default_user_column_post_types() {
+		WP_Mock::onFilter( 'dwpb_author_archive_post_types' )->with( array() )->reply( array() );
+		WP_Mock::onFilter( 'dwpb_admin_user_post_types' )->with( array( 'page' ) )->reply( array( 'page' ) );
+	}
+
+	/**
+	 * manage_users_columns()
+	 */
+
+	public function test_manage_users_columns_removes_posts_column_and_adds_page_column_by_default() {
+		WP_Mock::onFilter( 'dwpb_disable_user_post_column' )->with( true )->reply( true );
+		WP_Mock::userFunction( 'apply_filters_deprecated' )
+			->once()
+			->with( 'dpwb_disable_user_post_column', array( true ), '0.5.6', 'dwpb_disable_user_post_column' )
+			->andReturn( true );
+
+		global $current_screen;
+		$current_screen     = new stdClass();
+		$current_screen->id = 'users';
+		WP_Mock::userFunction( 'get_current_screen' )->once()->andReturn( $current_screen );
+
+		$this->stub_default_user_column_post_types();
+
+		WP_Mock::onFilter( 'dwpb_create_user_page_column' )->with( true )->reply( true );
+		WP_Mock::userFunction( 'apply_filters_deprecated' )
+			->once()
+			->with( 'dpwb_create_user_page_column', array( true ), '0.5.6', 'dwpb_create_user_page_column' )
+			->andReturn( true );
+
+		$page_type          = new stdClass();
+		$page_type->labels  = new stdClass();
+		$page_type->labels->name = 'Pages';
+		WP_Mock::userFunction( 'get_post_type_object' )->once()->with( 'page' )->andReturn( $page_type );
+
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$result = $admin->manage_users_columns(
+			array(
+				'cb'    => '<input type="checkbox" />',
+				'posts' => 'Posts',
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'posts', $result );
+		$this->assertSame( 'Pages', $result['page'] );
+	}
+
+	/**
+	 * Proves the deprecated dpwb_disable_user_post_column alias actually takes effect:
+	 * overriding the primary filter's reply back to false keeps the posts column.
+	 */
+	public function test_manage_users_columns_deprecated_disable_alias_can_keep_posts_column() {
+		WP_Mock::onFilter( 'dwpb_disable_user_post_column' )->with( true )->reply( true );
+		WP_Mock::userFunction( 'apply_filters_deprecated' )
+			->once()
+			->with( 'dpwb_disable_user_post_column', array( true ), '0.5.6', 'dwpb_disable_user_post_column' )
+			->andReturn( false );
+
+		global $current_screen;
+		$current_screen     = new stdClass();
+		$current_screen->id = 'users';
+		WP_Mock::userFunction( 'get_current_screen' )->once()->andReturn( $current_screen );
+
+		$this->stub_default_user_column_post_types();
+
+		WP_Mock::onFilter( 'dwpb_create_user_page_column' )->with( true )->reply( false );
+		WP_Mock::userFunction( 'apply_filters_deprecated' )
+			->once()
+			->with( 'dpwb_create_user_page_column', array( false ), '0.5.6', 'dwpb_create_user_page_column' )
+			->andReturn( false );
+
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$result = $admin->manage_users_columns( array( 'posts' => 'Posts' ) );
+
+		$this->assertArrayHasKey( 'posts', $result );
+		$this->assertArrayNotHasKey( 'page', $result );
+	}
+
+	/**
+	 * Proves the deprecated dpwb_create_user_{$post_type}_column alias actually takes
+	 * effect: the primary filter says yes, but the deprecated alias overrides to no.
+	 */
+	public function test_manage_users_columns_deprecated_create_alias_can_disable_page_column() {
+		WP_Mock::onFilter( 'dwpb_disable_user_post_column' )->with( true )->reply( true );
+		WP_Mock::userFunction( 'apply_filters_deprecated' )
+			->once()
+			->with( 'dpwb_disable_user_post_column', array( true ), '0.5.6', 'dwpb_disable_user_post_column' )
+			->andReturn( true );
+
+		global $current_screen;
+		$current_screen     = new stdClass();
+		$current_screen->id = 'users';
+		WP_Mock::userFunction( 'get_current_screen' )->once()->andReturn( $current_screen );
+
+		$this->stub_default_user_column_post_types();
+
+		WP_Mock::onFilter( 'dwpb_create_user_page_column' )->with( true )->reply( true );
+		WP_Mock::userFunction( 'apply_filters_deprecated' )
+			->once()
+			->with( 'dpwb_create_user_page_column', array( true ), '0.5.6', 'dwpb_create_user_page_column' )
+			->andReturn( false );
+
+		// get_post_type_object() must never be reached: nothing further is stubbed.
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$result = $admin->manage_users_columns( array( 'posts' => 'Posts' ) );
+
+		$this->assertArrayNotHasKey( 'page', $result );
+	}
+
+	public function test_manage_users_columns_skips_column_on_site_users_network_screen() {
+		WP_Mock::onFilter( 'dwpb_disable_user_post_column' )->with( true )->reply( true );
+		WP_Mock::userFunction( 'apply_filters_deprecated' )
+			->once()
+			->with( 'dpwb_disable_user_post_column', array( true ), '0.5.6', 'dwpb_disable_user_post_column' )
+			->andReturn( true );
+
+		global $current_screen;
+		$current_screen     = new stdClass();
+		$current_screen->id = 'site-users-network';
+		WP_Mock::userFunction( 'get_current_screen' )->once()->andReturn( $current_screen );
+
+		$this->stub_default_user_column_post_types();
+
+		WP_Mock::onFilter( 'dwpb_create_user_page_column' )->with( true )->reply( true );
+		WP_Mock::userFunction( 'apply_filters_deprecated' )
+			->once()
+			->with( 'dpwb_create_user_page_column', array( true ), '0.5.6', 'dwpb_create_user_page_column' )
+			->andReturn( true );
+
+		// get_post_type_object() must never be reached: nothing further is stubbed.
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$result = $admin->manage_users_columns( array() );
+
+		$this->assertArrayNotHasKey( 'page', $result );
+	}
+
+	public function test_manage_users_columns_skips_column_when_post_type_labels_missing() {
+		WP_Mock::onFilter( 'dwpb_disable_user_post_column' )->with( true )->reply( true );
+		WP_Mock::userFunction( 'apply_filters_deprecated' )
+			->once()
+			->with( 'dpwb_disable_user_post_column', array( true ), '0.5.6', 'dwpb_disable_user_post_column' )
+			->andReturn( true );
+
+		global $current_screen;
+		$current_screen     = new stdClass();
+		$current_screen->id = 'users';
+		WP_Mock::userFunction( 'get_current_screen' )->once()->andReturn( $current_screen );
+
+		$this->stub_default_user_column_post_types();
+
+		WP_Mock::onFilter( 'dwpb_create_user_page_column' )->with( true )->reply( true );
+		WP_Mock::userFunction( 'apply_filters_deprecated' )
+			->once()
+			->with( 'dpwb_create_user_page_column', array( true ), '0.5.6', 'dwpb_create_user_page_column' )
+			->andReturn( true );
+
+		// No 'labels' property at all -- isset( $post_type_obj->labels->name ) is false.
+		WP_Mock::userFunction( 'get_post_type_object' )->once()->with( 'page' )->andReturn( new stdClass() );
+
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$result = $admin->manage_users_columns( array() );
+
+		$this->assertArrayNotHasKey( 'page', $result );
+	}
+
+	public function test_manage_users_columns_adds_columns_for_additional_author_archive_post_types() {
+		WP_Mock::onFilter( 'dwpb_disable_user_post_column' )->with( true )->reply( true );
+		WP_Mock::userFunction( 'apply_filters_deprecated' )
+			->once()
+			->with( 'dpwb_disable_user_post_column', array( true ), '0.5.6', 'dwpb_disable_user_post_column' )
+			->andReturn( true );
+
+		global $current_screen;
+		$current_screen     = new stdClass();
+		$current_screen->id = 'users';
+		WP_Mock::userFunction( 'get_current_screen' )->once()->andReturn( $current_screen );
+
+		WP_Mock::onFilter( 'dwpb_author_archive_post_types' )->with( array() )->reply( array( 'book' ) );
+		WP_Mock::onFilter( 'dwpb_admin_user_post_types' )
+			->with( array( 'page', 'book' ) )
+			->reply( array( 'page', 'book' ) );
+
+		foreach ( array( 'page', 'book' ) as $post_type ) {
+			WP_Mock::onFilter( "dwpb_create_user_{$post_type}_column" )->with( true )->reply( true );
+			WP_Mock::userFunction( 'apply_filters_deprecated' )
+				->once()
+				->with( "dpwb_create_user_{$post_type}_column", array( true ), '0.5.6', "dwpb_create_user_{$post_type}_column" )
+				->andReturn( true );
+
+			$type_obj                 = new stdClass();
+			$type_obj->labels         = new stdClass();
+			$type_obj->labels->name   = ucfirst( $post_type ) . 's';
+			WP_Mock::userFunction( 'get_post_type_object' )->once()->with( $post_type )->andReturn( $type_obj );
+		}
+
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$result = $admin->manage_users_columns( array() );
+
+		$this->assertSame( 'Pages', $result['page'] );
+		$this->assertSame( 'Books', $result['book'] );
+	}
+
+	/**
+	 * manage_users_custom_column()
+	 */
+
+	public function test_manage_users_custom_column_builds_output_for_matching_post_type() {
+		$this->stub_default_user_column_post_types();
+
+		$page_type                     = new stdClass();
+		$page_type->labels             = new stdClass();
+		$page_type->labels->name       = 'Pages';
+		$page_type->labels->singular_name = 'Page';
+		WP_Mock::userFunction( 'get_post_type_object' )->once()->with( 'page' )->andReturn( $page_type );
+
+		WP_Mock::userFunction( 'count_many_users_posts' )->once()->with(
+			Mockery::on(
+				function ( $user_ids ) {
+					$this->assertSame( array( 42 ), $user_ids );
+					return true;
+				}
+			),
+			'page'
+		)->andReturn( array( 42 => '3' ) );
+		WP_Mock::userFunction( 'absint' )->once()->with( '3' )->andReturn( 3 );
+		WP_Mock::userFunction( 'number_format_i18n' )->once()->with( 3 )->andReturn( '3' );
+
+		// _n() is one of WP_Mock's hard-coded predefined functions (see
+		// vendor/10up/wp_mock/php/WP_Mock/API/function-mocks.php): it runs its own real
+		// singular/plural selection logic unconditionally and is never routed through
+		// WP_Mock::userFunction(), so it is deliberately left unstubbed here.
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$output = $admin->manage_users_custom_column( 'original', 'page', 42 );
+
+		$this->assertStringContainsString( 'edit.php?post_type=page&author=42', $output );
+		$this->assertStringContainsString( '3 Pages by this author', $output );
+	}
+
+	/**
+	 * A count of 1 selects _n()'s singular string ( using labels->singular_name ) rather
+	 * than the plural ( using labels->name ), proving both labels are threaded through
+	 * correctly rather than one being used for both.
+	 */
+	public function test_manage_users_custom_column_uses_singular_label_for_count_of_one() {
+		$this->stub_default_user_column_post_types();
+
+		$page_type                     = new stdClass();
+		$page_type->labels             = new stdClass();
+		$page_type->labels->name       = 'Pages';
+		$page_type->labels->singular_name = 'Page';
+		WP_Mock::userFunction( 'get_post_type_object' )->once()->with( 'page' )->andReturn( $page_type );
+
+		WP_Mock::userFunction( 'count_many_users_posts' )->once()->with(
+			Mockery::on(
+				function ( $user_ids ) {
+					$this->assertSame( array( 7 ), $user_ids );
+					return true;
+				}
+			),
+			'page'
+		)->andReturn( array( 7 => '1' ) );
+		WP_Mock::userFunction( 'absint' )->once()->with( '1' )->andReturn( 1 );
+		WP_Mock::userFunction( 'number_format_i18n' )->once()->with( 1 )->andReturn( '1' );
+
+		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$output = $admin->manage_users_custom_column( 'original', 'page', 7 );
+
+		$this->assertStringContainsString( '1 Page by this author', $output );
+		$this->assertStringNotContainsString( '1 Pages by this author', $output );
+	}
+
+	public function test_manage_users_custom_column_returns_output_unchanged_for_non_matching_column() {
+		$this->stub_default_user_column_post_types();
+
+		// get_post_type_object()/count_many_users_posts() must never be reached: nothing
+		// further is stubbed.
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( 'original', $admin->manage_users_custom_column( 'original', 'unrelated-column', 7 ) );
+	}
+
+	public function test_manage_users_custom_column_skips_when_post_type_labels_missing() {
+		WP_Mock::onFilter( 'dwpb_author_archive_post_types' )->with( array() )->reply( array( 'book' ) );
+		WP_Mock::onFilter( 'dwpb_admin_user_post_types' )
+			->with( array( 'page', 'book' ) )
+			->reply( array( 'page', 'book' ) );
+
+		// Missing singular_name -- isset()'s second argument fails, so continue is hit.
+		$book_type           = new stdClass();
+		$book_type->labels   = new stdClass();
+		$book_type->labels->name = 'Books';
+		WP_Mock::userFunction( 'get_post_type_object' )->once()->with( 'book' )->andReturn( $book_type );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( 'original', $admin->manage_users_custom_column( 'original', 'book', 7 ) );
+	}
+
+	/**
+	 * user_column_post_types()
+	 */
+
+	public function test_user_column_post_types_defaults_to_page_only() {
+		$this->stub_default_user_column_post_types();
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( array( 'page' ), $this->invoke_user_column_post_types( $admin ) );
+	}
+
+	public function test_user_column_post_types_merges_author_archive_post_types_with_page() {
+		WP_Mock::onFilter( 'dwpb_author_archive_post_types' )->with( array() )->reply( array( 'book' ) );
+		WP_Mock::onFilter( 'dwpb_admin_user_post_types' )
+			->with( array( 'page', 'book' ) )
+			->reply( array( 'page', 'book' ) );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( array( 'page', 'book' ), $this->invoke_user_column_post_types( $admin ) );
+	}
+
+	public function test_user_column_post_types_filter_can_override_the_whole_list() {
+		WP_Mock::onFilter( 'dwpb_author_archive_post_types' )->with( array() )->reply( array() );
+		WP_Mock::onFilter( 'dwpb_admin_user_post_types' )->with( array( 'page' ) )->reply( array( 'custom-cpt' ) );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( array( 'custom-cpt' ), $this->invoke_user_column_post_types( $admin ) );
+	}
+
+	/**
+	 * user_row_actions()
+	 */
+
+	public function test_user_row_actions_removes_view_link_when_author_archives_disabled() {
+		WP_Mock::onFilter( 'dwpb_disable_author_archives' )->with( false )->reply( true );
+
+		$admin   = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$actions = array( 'view' => '<a>View</a>' );
+
+		$this->assertSame( array(), $admin->user_row_actions( $actions, new stdClass() ) );
+	}
+
+	public function test_user_row_actions_keeps_view_link_when_author_archives_enabled() {
+		WP_Mock::onFilter( 'dwpb_disable_author_archives' )->with( false )->reply( false );
+
+		$admin   = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$actions = array( 'view' => '<a>View</a>' );
+
+		$this->assertSame( $actions, $admin->user_row_actions( $actions, new stdClass() ) );
+	}
+
+	public function test_user_row_actions_no_op_when_view_link_already_absent() {
+		WP_Mock::onFilter( 'dwpb_disable_author_archives' )->with( false )->reply( true );
+
+		$admin   = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$actions = array( 'edit' => '<a>Edit</a>' );
+
+		$this->assertSame( $actions, $admin->user_row_actions( $actions, new stdClass() ) );
+	}
+}

--- a/tests/php/ConstructorInjectionTest.php
+++ b/tests/php/ConstructorInjectionTest.php
@@ -38,6 +38,10 @@ class ConstructorInjectionTest extends TestCase {
 
 		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $double );
 
+		WP_Mock::onFilter( 'dwpb_admin_user_post_types' )
+			->with( array( 'page', 'injected_cpt' ) )
+			->reply( array( 'page', 'injected_cpt' ) );
+
 		$reflection = new ReflectionMethod( $admin, 'user_column_post_types' );
 		$reflection->setAccessible( true );
 
@@ -79,6 +83,8 @@ class ConstructorInjectionTest extends TestCase {
 
 		$public   = new Disable_Blog_Public( 'disable-blog', '0.5.6', $double );
 		$provider = new stdClass();
+
+		WP_Mock::onFilter( 'dwpb_disable_user_sitemap' )->with( false )->reply( false );
 
 		$this->assertSame( $provider, $public->wp_author_sitemaps( $provider, 'users' ) );
 	}

--- a/tests/php/ConstructorInjectionTest.php
+++ b/tests/php/ConstructorInjectionTest.php
@@ -27,7 +27,10 @@ class ConstructorInjectionTest extends TestCase {
 	 * value and driving a real method that calls through it.
 	 */
 	public function test_admin_constructor_uses_the_injected_functions_instance() {
-		$double = new class() {
+		$double = new class() extends Disable_Blog_Functions {
+			/**
+			 * @return string[]
+			 */
 			public function author_archive_post_types() {
 				return array( 'injected_cpt' );
 			}
@@ -62,10 +65,13 @@ class ConstructorInjectionTest extends TestCase {
 	 * is the only way $provider (not false) can come back out.
 	 */
 	public function test_public_constructor_uses_the_injected_functions_instance() {
-		$double = new class() {
+		$double = new class() extends Disable_Blog_Functions {
 			public function disable_author_archives() {
 				return false;
 			}
+			/**
+			 * @return string[]
+			 */
 			public function author_archive_post_types() {
 				return array( 'book' );
 			}

--- a/tests/php/ConstructorInjectionTest.php
+++ b/tests/php/ConstructorInjectionTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Tests for the optional $functions constructor parameter on Disable_Blog_Admin and
+ * Disable_Blog_Public.
+ *
+ * @package DisableBlog
+ */
+
+// Not required by tests/php/bootstrap.php on purpose (see LoaderTest's autoloader test,
+// which needs Disable_Blog_Functions specifically to remain undefined until its own
+// isolated process); load them here instead. require_once is safe regardless of which
+// test file happens to load first.
+require_once __DIR__ . '/../../includes/class-disable-blog-functions.php';
+require_once __DIR__ . '/../../includes/class-disable-blog-admin.php';
+require_once __DIR__ . '/../../includes/class-disable-blog-public.php';
+
+/**
+ * @covers Disable_Blog_Admin::__construct
+ * @covers Disable_Blog_Public::__construct
+ */
+class ConstructorInjectionTest extends TestCase {
+
+	/**
+	 * Both classes' third constructor argument must be the instance actually used at
+	 * runtime, not just stored and ignored in favor of a fresh internally-constructed
+	 * Disable_Blog_Functions. Proven by injecting a double with a distinctive return
+	 * value and driving a real method that calls through it.
+	 */
+	public function test_admin_constructor_uses_the_injected_functions_instance() {
+		$double = new class() {
+			public function author_archive_post_types() {
+				return array( 'injected_cpt' );
+			}
+		};
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $double );
+
+		$reflection = new ReflectionMethod( $admin, 'user_column_post_types' );
+		$reflection->setAccessible( true );
+
+		$this->assertSame( array( 'page', 'injected_cpt' ), $reflection->invoke( $admin ) );
+	}
+
+	/**
+	 * Omitting the third argument must fall back to a real Disable_Blog_Functions
+	 * instance, exactly as at both real call sites in includes/class-disable-blog.php.
+	 */
+	public function test_admin_constructor_defaults_to_a_real_functions_instance_when_omitted() {
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$property = new ReflectionProperty( $admin, 'functions' );
+		$property->setAccessible( true );
+
+		$this->assertInstanceOf( Disable_Blog_Functions::class, $property->getValue( $admin ) );
+	}
+
+	/**
+	 * Same proof as the admin test above, for Disable_Blog_Public. The double's answers
+	 * are chosen to diverge from a real, unfiltered Disable_Blog_Functions: a fresh
+	 * instance's author_archive_post_types() defaults to empty, which alone is already
+	 * enough to disable the sitemap, so a double that instead reports a non-empty list
+	 * is the only way $provider (not false) can come back out.
+	 */
+	public function test_public_constructor_uses_the_injected_functions_instance() {
+		$double = new class() {
+			public function disable_author_archives() {
+				return false;
+			}
+			public function author_archive_post_types() {
+				return array( 'book' );
+			}
+		};
+
+		$public   = new Disable_Blog_Public( 'disable-blog', '0.5.6', $double );
+		$provider = new stdClass();
+
+		$this->assertSame( $provider, $public->wp_author_sitemaps( $provider, 'users' ) );
+	}
+
+	/**
+	 * Omitting the third argument must fall back to a real Disable_Blog_Functions
+	 * instance, exactly as at both real call sites in includes/class-disable-blog.php.
+	 */
+	public function test_public_constructor_defaults_to_a_real_functions_instance_when_omitted() {
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$property = new ReflectionProperty( $public, 'functions' );
+		$property->setAccessible( true );
+
+		$this->assertInstanceOf( Disable_Blog_Functions::class, $property->getValue( $public ) );
+	}
+}

--- a/tests/php/DeactivatorTest.php
+++ b/tests/php/DeactivatorTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Tests for includes/class-disable-blog-deactivator.php.
+ *
+ * @package DisableBlog
+ */
+
+/**
+ * @covers Disable_Blog_Deactivator
+ */
+class DeactivatorTest extends PluginLifecycleTestCase {
+
+	protected function target_class(): string {
+		return Disable_Blog_Deactivator::class;
+	}
+
+	protected function lifecycle_method(): string {
+		return 'deactivate';
+	}
+
+	protected function single_nonce_action_prefix(): string {
+		return 'deactivate-plugin_';
+	}
+
+	protected function single_action_value(): string {
+		return 'deactivate';
+	}
+
+	protected function bulk_action_value(): string {
+		return 'deactivate-selected';
+	}
+}

--- a/tests/php/DisableBlogFunctionsTest.php
+++ b/tests/php/DisableBlogFunctionsTest.php
@@ -112,6 +112,10 @@ class DisableBlogFunctionsTest extends TestCase {
 		$redirect_url = 'https://example.test/wp-admin/options-general.php';
 
 		WP_Mock::userFunction( 'esc_url_raw' )->with( $redirect_url )->andReturn( $redirect_url );
+		WP_Mock::onFilter( 'dwpb_pass_query_string_on_redirect' )->with( false )->reply( false );
+		WP_Mock::onFilter( 'dwpb_redirect_status_code' )
+			->with( 301, 'https://example.test/wp-admin/edit.php', $redirect_url )
+			->reply( 301 );
 		$this->stub_real_absint();
 
 		WP_Mock::userFunction( 'wp_safe_redirect' )
@@ -153,6 +157,10 @@ class DisableBlogFunctionsTest extends TestCase {
 		$redirect_url = 'https://example.test/other-page/';
 
 		WP_Mock::userFunction( 'esc_url_raw' )->with( $redirect_url )->andReturn( $redirect_url );
+		WP_Mock::onFilter( 'dwpb_pass_query_string_on_redirect' )->with( false )->reply( false );
+		WP_Mock::onFilter( 'dwpb_redirect_status_code' )
+			->with( 301, 'https://example.test/current-page/?foo=bar', $redirect_url )
+			->reply( 301 );
 		$this->stub_real_absint();
 
 		WP_Mock::userFunction( 'wp_safe_redirect' )
@@ -217,6 +225,13 @@ class DisableBlogFunctionsTest extends TestCase {
 			->with( '/current-page/' )
 			->andReturn( 'https://example.test/current-page/' );
 
+		WP_Mock::expectFilterAdded(
+			'wp_safe_redirect_fallback',
+			array( $functions, 'wp_safe_redirect_fallback' ),
+			9,
+			1
+		);
+
 		WP_Mock::userFunction( 'esc_url_raw' )->with( '' )->andReturn( '' );
 
 		WP_Mock::userFunction( 'wp_safe_redirect' )->never();
@@ -243,6 +258,13 @@ class DisableBlogFunctionsTest extends TestCase {
 			->with( '/current-page/' )
 			->andReturn( 'https://example.test/current-page/' );
 
+		WP_Mock::expectFilterAdded(
+			'wp_safe_redirect_fallback',
+			array( $functions, 'wp_safe_redirect_fallback' ),
+			9,
+			1
+		);
+
 		$redirect_url         = 'https://example.test/target/';
 		$redirect_url_with_qs = 'https://example.test/target/?foo=bar';
 
@@ -258,6 +280,9 @@ class DisableBlogFunctionsTest extends TestCase {
 			->with( array( 'foo' => 'bar' ), $redirect_url )
 			->andReturn( $redirect_url_with_qs );
 
+		WP_Mock::onFilter( 'dwpb_redirect_status_code' )
+			->with( 301, 'https://example.test/current-page/', $redirect_url_with_qs )
+			->reply( 301 );
 		$this->stub_real_absint();
 
 		WP_Mock::userFunction( 'wp_safe_redirect' )
@@ -290,11 +315,22 @@ class DisableBlogFunctionsTest extends TestCase {
 			->with( '/current-page/' )
 			->andReturn( 'https://example.test/current-page/' );
 
+		WP_Mock::expectFilterAdded(
+			'wp_safe_redirect_fallback',
+			array( $functions, 'wp_safe_redirect_fallback' ),
+			9,
+			1
+		);
+
 		$redirect_url = 'https://example.test/target/';
 
 		WP_Mock::userFunction( 'esc_url_raw' )->with( $redirect_url )->andReturn( $redirect_url );
+		WP_Mock::onFilter( 'dwpb_pass_query_string_on_redirect' )->with( false )->reply( false );
 		WP_Mock::userFunction( 'add_query_arg' )->never();
 
+		WP_Mock::onFilter( 'dwpb_redirect_status_code' )
+			->with( 301, 'https://example.test/current-page/', $redirect_url )
+			->reply( 301 );
 		$this->stub_real_absint();
 
 		WP_Mock::userFunction( 'wp_safe_redirect' )
@@ -325,9 +361,17 @@ class DisableBlogFunctionsTest extends TestCase {
 			->with( '/current-page/' )
 			->andReturn( 'https://example.test/current-page/' );
 
+		WP_Mock::expectFilterAdded(
+			'wp_safe_redirect_fallback',
+			array( $functions, 'wp_safe_redirect_fallback' ),
+			9,
+			1
+		);
+
 		$redirect_url = 'https://example.test/target/';
 
 		WP_Mock::userFunction( 'esc_url_raw' )->with( $redirect_url )->andReturn( $redirect_url );
+		WP_Mock::onFilter( 'dwpb_pass_query_string_on_redirect' )->with( false )->reply( false );
 
 		WP_Mock::onFilter( 'dwpb_redirect_status_code' )
 			->with( 301, 'https://example.test/current-page/', $redirect_url )
@@ -377,14 +421,15 @@ class DisableBlogFunctionsTest extends TestCase {
 	}
 
 	/**
-	 * dwpb_allowed_query_vars is left unstubbed here: it defaults to an empty array, so
-	 * the outer `! empty( $allowed_query_vars )` guard must skip everything below it.
+	 * dwpb_allowed_query_vars replies with its own default (an empty array) here, so the
+	 * outer `! empty( $allowed_query_vars )` guard must skip everything below it.
 	 */
 	public function test_parse_query_string_returns_url_unchanged_when_no_allowed_query_vars() {
 		$_SERVER['QUERY_STRING'] = 'foo=bar';
 
 		$functions = new Disable_Blog_Functions();
 
+		WP_Mock::onFilter( 'dwpb_allowed_query_vars' )->with( array() )->reply( array() );
 		WP_Mock::userFunction( 'add_query_arg' )->never();
 
 		$this->assertSame(
@@ -442,6 +487,7 @@ class DisableBlogFunctionsTest extends TestCase {
 	public function test_get_allowed_query_vars_returns_empty_array_by_default() {
 		$functions = new Disable_Blog_Functions();
 
+		WP_Mock::onFilter( 'dwpb_allowed_query_vars' )->with( array() )->reply( array() );
 		WP_Mock::userFunction( 'sanitize_key' )->never();
 
 		$this->assertSame( array(), $this->invoke_private( $functions, 'get_allowed_query_vars' ) );
@@ -559,6 +605,8 @@ class DisableBlogFunctionsTest extends TestCase {
 	public function test_author_archive_post_types_returns_false_when_empty_by_default() {
 		$functions = new Disable_Blog_Functions();
 
+		WP_Mock::onFilter( 'dwpb_author_archive_post_types' )->with( array() )->reply( array() );
+
 		$this->assertFalse( $functions->author_archive_post_types() );
 	}
 
@@ -568,6 +616,8 @@ class DisableBlogFunctionsTest extends TestCase {
 
 	public function test_disable_author_archives_defaults_to_false() {
 		$functions = new Disable_Blog_Functions();
+
+		WP_Mock::onFilter( 'dwpb_disable_author_archives' )->with( false )->reply( false );
 
 		$this->assertFalse( $functions->disable_author_archives() );
 	}

--- a/tests/php/DisableBlogFunctionsTest.php
+++ b/tests/php/DisableBlogFunctionsTest.php
@@ -1,0 +1,604 @@
+<?php
+/**
+ * Tests for includes/class-disable-blog-functions.php.
+ *
+ * @package DisableBlog
+ */
+
+// Not required by tests/php/bootstrap.php on purpose (see LoaderTest's autoloader test,
+// which needs this class to remain undefined until its own isolated process); load it
+// here instead. require_once is safe regardless of which test file happens to load first.
+require_once __DIR__ . '/../../includes/class-disable-blog-functions.php';
+
+/**
+ * @covers Disable_Blog_Functions
+ */
+class DisableBlogFunctionsTest extends TestCase {
+
+	/**
+	 * $_SERVER as it stood before the test, so it can be restored in tear_down().
+	 *
+	 * @var array
+	 */
+	private $original_server;
+
+	/**
+	 * The global $wp as it stood before the test, so it can be restored in tear_down().
+	 *
+	 * @var mixed
+	 */
+	private $original_wp;
+
+	protected function set_up() {
+		parent::set_up();
+
+		$this->original_server = $_SERVER;
+
+		global $wp;
+		$this->original_wp = $wp ?? null;
+	}
+
+	protected function tear_down() {
+		$_SERVER = $this->original_server;
+
+		global $wp;
+		$wp = $this->original_wp;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Invokes a private instance method via Reflection.
+	 *
+	 * @param Disable_Blog_Functions $functions Instance to invoke on.
+	 * @param string                 $method    Method name.
+	 * @param array                  $args      Positional arguments.
+	 * @return mixed
+	 */
+	private function invoke_private( Disable_Blog_Functions $functions, $method, array $args = array() ) {
+		$reflection = new ReflectionMethod( $functions, $method );
+		$reflection->setAccessible( true );
+
+		return $reflection->invokeArgs( $functions, $args );
+	}
+
+	/**
+	 * Registers a generic absint() stub that mirrors WordPress core's real behavior
+	 * (abs(intval())), used by every test that reaches get_redirect_status_code().
+	 *
+	 * @return void
+	 */
+	private function stub_real_absint() {
+		WP_Mock::userFunction( 'absint' )->andReturnUsing(
+			static function ( $value ) {
+				return abs( intval( $value ) );
+			}
+		);
+	}
+
+	/**
+	 * redirect()
+	 */
+
+	/**
+	 * In the admin, the current url is derived from admin_url( add_query_arg( array(),
+	 * $wp->request ) ), and the wp_safe_redirect_fallback filter must never be added on
+	 * this branch. wp_safe_redirect() is stubbed to throw so the exit; right after it can
+	 * be observed without terminating the test process.
+	 */
+	public function test_redirect_in_admin_derives_current_url_from_admin_url_and_redirects() {
+		global $wp;
+		$wp = (object) array( 'request' => 'wp-admin/edit.php' );
+
+		$functions = new Disable_Blog_Functions();
+
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( true );
+		WP_Mock::userFunction( 'add_query_arg' )
+			->once()
+			->with( array(), 'wp-admin/edit.php' )
+			->andReturn( 'wp-admin/edit.php' );
+		WP_Mock::userFunction( 'admin_url' )
+			->once()
+			->with( 'wp-admin/edit.php' )
+			->andReturn( 'https://example.test/wp-admin/edit.php' );
+
+		WP_Mock::expectFilterNotAdded(
+			'wp_safe_redirect_fallback',
+			array( $functions, 'wp_safe_redirect_fallback' ),
+			9,
+			1
+		);
+
+		$redirect_url = 'https://example.test/wp-admin/options-general.php';
+
+		WP_Mock::userFunction( 'esc_url_raw' )->with( $redirect_url )->andReturn( $redirect_url );
+		$this->stub_real_absint();
+
+		WP_Mock::userFunction( 'wp_safe_redirect' )
+			->once()
+			->with( $redirect_url, 301 )
+			->andThrow( new Exception( 'halted' ) );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'halted' );
+
+		$functions->redirect( $redirect_url );
+	}
+
+	/**
+	 * Outside the admin, the current url is derived from home_url() plus the raw
+	 * REQUEST_URI (not $wp->request, which is path-only -- see the @since 0.5.6 note on
+	 * the source), and the wp_safe_redirect_fallback filter must be added.
+	 */
+	public function test_redirect_not_admin_derives_current_url_from_home_url_and_request_uri_and_adds_fallback_filter() {
+		$_SERVER['REQUEST_URI'] = '/current-page/?foo=bar';
+
+		$functions = new Disable_Blog_Functions();
+
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'wp_unslash' )->with( '/current-page/?foo=bar' )->andReturn( '/current-page/?foo=bar' );
+		WP_Mock::userFunction( 'esc_url_raw' )->with( '/current-page/?foo=bar' )->andReturn( '/current-page/?foo=bar' );
+		WP_Mock::userFunction( 'home_url' )
+			->once()
+			->with( '/current-page/?foo=bar' )
+			->andReturn( 'https://example.test/current-page/?foo=bar' );
+
+		WP_Mock::expectFilterAdded(
+			'wp_safe_redirect_fallback',
+			array( $functions, 'wp_safe_redirect_fallback' ),
+			9,
+			1
+		);
+
+		$redirect_url = 'https://example.test/other-page/';
+
+		WP_Mock::userFunction( 'esc_url_raw' )->with( $redirect_url )->andReturn( $redirect_url );
+		$this->stub_real_absint();
+
+		WP_Mock::userFunction( 'wp_safe_redirect' )
+			->once()
+			->with( $redirect_url, 301 )
+			->andThrow( new Exception( 'halted' ) );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'halted' );
+
+		$functions->redirect( $redirect_url );
+	}
+
+	/**
+	 * The loop guard: when the redirect url matches the current url, redirect() must
+	 * return without calling wp_safe_redirect() at all. The fallback filter is added
+	 * unconditionally before this guard runs (it's the first statement in the non-admin
+	 * branch), so it's still expected here.
+	 */
+	public function test_redirect_returns_without_redirecting_when_redirect_url_equals_current_url() {
+		$_SERVER['REQUEST_URI'] = '/same-page/';
+
+		$functions = new Disable_Blog_Functions();
+
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'wp_unslash' )->with( '/same-page/' )->andReturn( '/same-page/' );
+		WP_Mock::userFunction( 'esc_url_raw' )->with( '/same-page/' )->andReturn( '/same-page/' );
+		WP_Mock::userFunction( 'home_url' )
+			->once()
+			->with( '/same-page/' )
+			->andReturn( 'https://example.test/same-page/' );
+
+		WP_Mock::expectFilterAdded(
+			'wp_safe_redirect_fallback',
+			array( $functions, 'wp_safe_redirect_fallback' ),
+			9,
+			1
+		);
+
+		WP_Mock::userFunction( 'wp_safe_redirect' )->never();
+
+		$this->assertNull( $functions->redirect( 'https://example.test/same-page/' ) );
+
+		WP_Mock::assertHooksAdded();
+	}
+
+	/**
+	 * An invalid (here: empty) redirect url fails esc_url_raw()'s truthiness check in the
+	 * loop guard's second clause, so redirect() must return without calling
+	 * wp_safe_redirect().
+	 */
+	public function test_redirect_returns_without_redirecting_when_redirect_url_is_invalid() {
+		$_SERVER['REQUEST_URI'] = '/current-page/';
+
+		$functions = new Disable_Blog_Functions();
+
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'wp_unslash' )->with( '/current-page/' )->andReturn( '/current-page/' );
+		WP_Mock::userFunction( 'esc_url_raw' )->with( '/current-page/' )->andReturn( '/current-page/' );
+		WP_Mock::userFunction( 'home_url' )
+			->once()
+			->with( '/current-page/' )
+			->andReturn( 'https://example.test/current-page/' );
+
+		WP_Mock::userFunction( 'esc_url_raw' )->with( '' )->andReturn( '' );
+
+		WP_Mock::userFunction( 'wp_safe_redirect' )->never();
+
+		$this->assertNull( $functions->redirect( '' ) );
+	}
+
+	/**
+	 * When the dwpb_pass_query_string_on_redirect filter returns true, parse_query_string()
+	 * must run and its result (allowed query vars appended via add_query_arg()) must be
+	 * what actually reaches wp_safe_redirect() -- not the original url.
+	 */
+	public function test_redirect_appends_allowed_query_vars_when_pass_query_string_filter_is_true() {
+		$_SERVER['REQUEST_URI']  = '/current-page/';
+		$_SERVER['QUERY_STRING'] = 'foo=bar';
+
+		$functions = new Disable_Blog_Functions();
+
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'wp_unslash' )->with( '/current-page/' )->andReturn( '/current-page/' );
+		WP_Mock::userFunction( 'esc_url_raw' )->with( '/current-page/' )->andReturn( '/current-page/' );
+		WP_Mock::userFunction( 'home_url' )
+			->once()
+			->with( '/current-page/' )
+			->andReturn( 'https://example.test/current-page/' );
+
+		$redirect_url         = 'https://example.test/target/';
+		$redirect_url_with_qs = 'https://example.test/target/?foo=bar';
+
+		WP_Mock::userFunction( 'esc_url_raw' )->with( $redirect_url )->andReturn( $redirect_url );
+		WP_Mock::userFunction( 'esc_url_raw' )->with( $redirect_url_with_qs )->andReturn( $redirect_url_with_qs );
+
+		WP_Mock::onFilter( 'dwpb_pass_query_string_on_redirect' )->with( false )->reply( true );
+		WP_Mock::onFilter( 'dwpb_allowed_query_vars' )->with( array() )->reply( array( 'foo' ) );
+		WP_Mock::userFunction( 'sanitize_key' )->with( 'foo' )->andReturn( 'foo' );
+
+		WP_Mock::userFunction( 'add_query_arg' )
+			->once()
+			->with( array( 'foo' => 'bar' ), $redirect_url )
+			->andReturn( $redirect_url_with_qs );
+
+		$this->stub_real_absint();
+
+		WP_Mock::userFunction( 'wp_safe_redirect' )
+			->once()
+			->with( $redirect_url_with_qs, 301 )
+			->andThrow( new Exception( 'halted' ) );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'halted' );
+
+		$functions->redirect( $redirect_url );
+	}
+
+	/**
+	 * dwpb_pass_query_string_on_redirect defaults to false: parse_query_string() (and
+	 * therefore add_query_arg()) must never run, even when a real QUERY_STRING is present
+	 * in the environment.
+	 */
+	public function test_redirect_does_not_append_query_string_when_pass_query_string_filter_is_false_by_default() {
+		$_SERVER['REQUEST_URI']  = '/current-page/';
+		$_SERVER['QUERY_STRING'] = 'foo=bar';
+
+		$functions = new Disable_Blog_Functions();
+
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'wp_unslash' )->with( '/current-page/' )->andReturn( '/current-page/' );
+		WP_Mock::userFunction( 'esc_url_raw' )->with( '/current-page/' )->andReturn( '/current-page/' );
+		WP_Mock::userFunction( 'home_url' )
+			->once()
+			->with( '/current-page/' )
+			->andReturn( 'https://example.test/current-page/' );
+
+		$redirect_url = 'https://example.test/target/';
+
+		WP_Mock::userFunction( 'esc_url_raw' )->with( $redirect_url )->andReturn( $redirect_url );
+		WP_Mock::userFunction( 'add_query_arg' )->never();
+
+		$this->stub_real_absint();
+
+		WP_Mock::userFunction( 'wp_safe_redirect' )
+			->once()
+			->with( $redirect_url, 301 )
+			->andThrow( new Exception( 'halted' ) );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'halted' );
+
+		$functions->redirect( $redirect_url );
+	}
+
+	/**
+	 * The status code get_redirect_status_code() computes must be exactly what reaches
+	 * wp_safe_redirect(), not just the 301 default.
+	 */
+	public function test_redirect_passes_filtered_status_code_through_to_wp_safe_redirect() {
+		$_SERVER['REQUEST_URI'] = '/current-page/';
+
+		$functions = new Disable_Blog_Functions();
+
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'wp_unslash' )->with( '/current-page/' )->andReturn( '/current-page/' );
+		WP_Mock::userFunction( 'esc_url_raw' )->with( '/current-page/' )->andReturn( '/current-page/' );
+		WP_Mock::userFunction( 'home_url' )
+			->once()
+			->with( '/current-page/' )
+			->andReturn( 'https://example.test/current-page/' );
+
+		$redirect_url = 'https://example.test/target/';
+
+		WP_Mock::userFunction( 'esc_url_raw' )->with( $redirect_url )->andReturn( $redirect_url );
+
+		WP_Mock::onFilter( 'dwpb_redirect_status_code' )
+			->with( 301, 'https://example.test/current-page/', $redirect_url )
+			->reply( 302 );
+
+		$this->stub_real_absint();
+
+		WP_Mock::userFunction( 'wp_safe_redirect' )
+			->once()
+			->with( $redirect_url, 302 )
+			->andThrow( new Exception( 'halted' ) );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'halted' );
+
+		$functions->redirect( $redirect_url );
+	}
+
+	/**
+	 * parse_query_string() (private)
+	 */
+
+	public function test_parse_query_string_returns_url_unchanged_when_query_string_not_set() {
+		unset( $_SERVER['QUERY_STRING'] );
+
+		$functions = new Disable_Blog_Functions();
+
+		WP_Mock::userFunction( 'add_query_arg' )->never();
+
+		$this->assertSame(
+			'https://example.test/target/',
+			$this->invoke_private( $functions, 'parse_query_string', array( 'https://example.test/target/' ) )
+		);
+	}
+
+	public function test_parse_query_string_returns_url_unchanged_when_query_string_empty() {
+		$_SERVER['QUERY_STRING'] = '';
+
+		$functions = new Disable_Blog_Functions();
+
+		WP_Mock::userFunction( 'add_query_arg' )->never();
+
+		$this->assertSame(
+			'https://example.test/target/',
+			$this->invoke_private( $functions, 'parse_query_string', array( 'https://example.test/target/' ) )
+		);
+	}
+
+	/**
+	 * dwpb_allowed_query_vars is left unstubbed here: it defaults to an empty array, so
+	 * the outer `! empty( $allowed_query_vars )` guard must skip everything below it.
+	 */
+	public function test_parse_query_string_returns_url_unchanged_when_no_allowed_query_vars() {
+		$_SERVER['QUERY_STRING'] = 'foo=bar';
+
+		$functions = new Disable_Blog_Functions();
+
+		WP_Mock::userFunction( 'add_query_arg' )->never();
+
+		$this->assertSame(
+			'https://example.test/target/',
+			$this->invoke_private( $functions, 'parse_query_string', array( 'https://example.test/target/' ) )
+		);
+	}
+
+	/**
+	 * Only allowed query vars present in the real, parsed QUERY_STRING are appended;
+	 * an allowed-but-empty value ('empty=') is dropped by the inner array_filter().
+	 */
+	public function test_parse_query_string_filters_to_allowed_vars_and_appends_to_url() {
+		$_SERVER['QUERY_STRING'] = 'foo=bar&baz=qux&empty=';
+
+		$functions = new Disable_Blog_Functions();
+
+		WP_Mock::onFilter( 'dwpb_allowed_query_vars' )->with( array() )->reply( array( 'foo', 'empty' ) );
+		WP_Mock::userFunction( 'sanitize_key' )->with( 'foo' )->andReturn( 'foo' );
+		WP_Mock::userFunction( 'sanitize_key' )->with( 'empty' )->andReturn( 'empty' );
+
+		WP_Mock::userFunction( 'add_query_arg' )
+			->once()
+			->with( array( 'foo' => 'bar' ), 'https://example.test/target/' )
+			->andReturn( 'https://example.test/target/?foo=bar' );
+
+		$result = $this->invoke_private( $functions, 'parse_query_string', array( 'https://example.test/target/' ) );
+
+		$this->assertSame( 'https://example.test/target/?foo=bar', $result );
+	}
+
+	/**
+	 * Allowed query vars are configured, but none of them appear in the actual query
+	 * string: the inner `! empty( $query_vars )` guard must skip add_query_arg() too.
+	 */
+	public function test_parse_query_string_returns_url_unchanged_when_none_of_the_query_string_vars_are_allowed() {
+		$_SERVER['QUERY_STRING'] = 'foo=bar';
+
+		$functions = new Disable_Blog_Functions();
+
+		WP_Mock::onFilter( 'dwpb_allowed_query_vars' )->with( array() )->reply( array( 'zzz' ) );
+		WP_Mock::userFunction( 'sanitize_key' )->with( 'zzz' )->andReturn( 'zzz' );
+
+		WP_Mock::userFunction( 'add_query_arg' )->never();
+
+		$result = $this->invoke_private( $functions, 'parse_query_string', array( 'https://example.test/target/' ) );
+
+		$this->assertSame( 'https://example.test/target/', $result );
+	}
+
+	/**
+	 * get_allowed_query_vars() (private)
+	 */
+
+	public function test_get_allowed_query_vars_returns_empty_array_by_default() {
+		$functions = new Disable_Blog_Functions();
+
+		WP_Mock::userFunction( 'sanitize_key' )->never();
+
+		$this->assertSame( array(), $this->invoke_private( $functions, 'get_allowed_query_vars' ) );
+	}
+
+	/**
+	 * array_filter() preserves keys, so the dropped empty entry at index 1 leaves a gap
+	 * in the result instead of the array being reindexed.
+	 */
+	public function test_get_allowed_query_vars_sanitizes_keys_and_drops_empty_values() {
+		$functions = new Disable_Blog_Functions();
+
+		WP_Mock::onFilter( 'dwpb_allowed_query_vars' )->with( array() )->reply( array( 'Foo', '', 'Bar_Baz' ) );
+		WP_Mock::userFunction( 'sanitize_key' )->with( 'Foo' )->andReturn( 'foo' );
+		WP_Mock::userFunction( 'sanitize_key' )->with( '' )->andReturn( '' );
+		WP_Mock::userFunction( 'sanitize_key' )->with( 'Bar_Baz' )->andReturn( 'bar_baz' );
+
+		$result = $this->invoke_private( $functions, 'get_allowed_query_vars' );
+
+		$this->assertSame( array( 0 => 'foo', 2 => 'bar_baz' ), $result );
+	}
+
+	/**
+	 * get_redirect_status_code() (private)
+	 */
+
+	/**
+	 * Invokes get_redirect_status_code() with the dwpb_redirect_status_code filter
+	 * replying $filtered_value, and asserts the result is $expected.
+	 *
+	 * @param mixed $filtered_value The value the filter should reply with.
+	 * @param int   $expected       The expected return value.
+	 * @return void
+	 */
+	private function assert_redirect_status_code( $filtered_value, $expected ) {
+		$functions    = new Disable_Blog_Functions();
+		$current_url  = 'https://example.test/current/';
+		$redirect_url = 'https://example.test/redirect/';
+
+		WP_Mock::onFilter( 'dwpb_redirect_status_code' )
+			->with( 301, $current_url, $redirect_url )
+			->reply( $filtered_value );
+
+		$this->stub_real_absint();
+
+		$result = $this->invoke_private( $functions, 'get_redirect_status_code', array( $current_url, $redirect_url ) );
+
+		$this->assertSame( $expected, $result );
+	}
+
+	public function test_get_redirect_status_code_clamps_299_to_301() {
+		$this->assert_redirect_status_code( 299, 301 );
+	}
+
+	public function test_get_redirect_status_code_allows_300_boundary() {
+		$this->assert_redirect_status_code( 300, 300 );
+	}
+
+	public function test_get_redirect_status_code_allows_399_boundary() {
+		$this->assert_redirect_status_code( 399, 399 );
+	}
+
+	public function test_get_redirect_status_code_clamps_400_to_301() {
+		$this->assert_redirect_status_code( 400, 301 );
+	}
+
+	public function test_get_redirect_status_code_clamps_zero_to_301() {
+		$this->assert_redirect_status_code( 0, 301 );
+	}
+
+	public function test_get_redirect_status_code_clamps_non_numeric_value_to_301() {
+		$this->assert_redirect_status_code( 'not-a-number', 301 );
+	}
+
+	/**
+	 * wp_safe_redirect_fallback()
+	 */
+
+	public function test_wp_safe_redirect_fallback_returns_original_url_when_in_admin() {
+		$functions = new Disable_Blog_Functions();
+
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( true );
+		WP_Mock::userFunction( 'home_url' )->never();
+
+		$this->assertSame(
+			'https://example.test/wp-login.php',
+			$functions->wp_safe_redirect_fallback( 'https://example.test/wp-login.php' )
+		);
+	}
+
+	public function test_wp_safe_redirect_fallback_returns_home_url_when_not_admin() {
+		$functions = new Disable_Blog_Functions();
+
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'home_url' )->once()->andReturn( 'https://example.test/' );
+
+		$this->assertSame(
+			'https://example.test/',
+			$functions->wp_safe_redirect_fallback( 'https://example.test/wp-login.php' )
+		);
+	}
+
+	/**
+	 * author_archive_post_types()
+	 */
+
+	public function test_author_archive_post_types_returns_filtered_post_types_when_non_empty() {
+		$functions = new Disable_Blog_Functions();
+
+		WP_Mock::onFilter( 'dwpb_author_archive_post_types' )->with( array() )->reply( array( 'book' ) );
+
+		$this->assertSame( array( 'book' ), $functions->author_archive_post_types() );
+	}
+
+	public function test_author_archive_post_types_returns_false_when_empty_by_default() {
+		$functions = new Disable_Blog_Functions();
+
+		$this->assertFalse( $functions->author_archive_post_types() );
+	}
+
+	/**
+	 * disable_author_archives()
+	 */
+
+	public function test_disable_author_archives_defaults_to_false() {
+		$functions = new Disable_Blog_Functions();
+
+		$this->assertFalse( $functions->disable_author_archives() );
+	}
+
+	public function test_disable_author_archives_true_when_filtered() {
+		$functions = new Disable_Blog_Functions();
+
+		WP_Mock::onFilter( 'dwpb_disable_author_archives' )->with( false )->reply( true );
+
+		$this->assertTrue( $functions->disable_author_archives() );
+	}
+
+	/**
+	 * disable_feeds()
+	 */
+
+	public function test_disable_feeds_defaults_to_true_and_passes_post_and_comment_feed_flag_to_filter() {
+		$functions = new Disable_Blog_Functions();
+		$post      = (object) array( 'ID' => 1 );
+
+		WP_Mock::onFilter( 'dwpb_disable_feed' )->with( true, $post, true )->reply( true );
+
+		$this->assertTrue( $functions->disable_feeds( $post, true ) );
+	}
+
+	public function test_disable_feeds_false_when_filtered() {
+		$functions = new Disable_Blog_Functions();
+		$post      = (object) array( 'ID' => 1 );
+
+		WP_Mock::onFilter( 'dwpb_disable_feed' )->with( true, $post, false )->reply( false );
+
+		$this->assertFalse( $functions->disable_feeds( $post, false ) );
+	}
+}

--- a/tests/php/DisableBlogTest.php
+++ b/tests/php/DisableBlogTest.php
@@ -1,0 +1,444 @@
+<?php
+/**
+ * Tests for includes/class-disable-blog.php.
+ *
+ * @package DisableBlog
+ */
+
+// None of these four are required by tests/php/bootstrap.php on purpose (see LoaderTest's
+// autoloader test, which needs Disable_Blog_Functions specifically to remain undefined
+// until its own isolated process); load them here instead. require_once is safe regardless
+// of which test file happens to load first.
+require_once __DIR__ . '/../../includes/class-disable-blog-functions.php';
+require_once __DIR__ . '/../../includes/class-disable-blog-admin.php';
+require_once __DIR__ . '/../../includes/class-disable-blog-public.php';
+require_once __DIR__ . '/../../includes/class-disable-blog.php';
+
+/**
+ * @covers Disable_Blog
+ */
+class DisableBlogTest extends TestCase {
+
+	/**
+	 * Builds a Disable_Blog instance without running its constructor.
+	 *
+	 * The real constructor is not exercised here: it calls load_dependencies(), which uses
+	 * Disable_Blog_Loader::autoloader() to `include` (not `include_once`) the source files
+	 * for Disable_Blog_I18n and Disable_Blog_Integrations -- both of which
+	 * tests/php/bootstrap.php already `require`s unconditionally for every other test file in
+	 * this suite. Calling the constructor for real would therefore fatal on class
+	 * redeclaration in this process, every time, with no isolation trick available (a fresh
+	 * @runInSeparateProcess still runs the same bootstrap.php first). See
+	 * test_upgrade_check_*, plugin_integrations() and the define_*_hooks() tests below for
+	 * what's covered instead by driving the class's methods directly via Reflection.
+	 *
+	 * @param string               $plugin_name The plugin name.
+	 * @param string               $version     The plugin version.
+	 * @param Disable_Blog_Loader|null $loader  The loader to inject. Defaults to a new instance.
+	 * @return Disable_Blog
+	 */
+	private function make_disable_blog( $plugin_name = 'disable-blog', $version = '0.5.6', $loader = null ) {
+		$reflection = new ReflectionClass( Disable_Blog::class );
+		$instance   = $reflection->newInstanceWithoutConstructor();
+
+		$this->set_property( $instance, 'plugin_name', $plugin_name );
+		$this->set_property( $instance, 'version', $version );
+		$this->set_property( $instance, 'loader', $loader ? $loader : new Disable_Blog_Loader() );
+
+		return $instance;
+	}
+
+	/**
+	 * @param object $object Target object.
+	 * @param string $name   Property name.
+	 * @param mixed  $value  Value to assign.
+	 * @return void
+	 */
+	private function set_property( $object, $name, $value ) {
+		$property = new ReflectionProperty( Disable_Blog::class, $name );
+		$property->setAccessible( true );
+		$property->setValue( $object, $value );
+	}
+
+	/**
+	 * @param object $object Target object.
+	 * @param string $name   Property name.
+	 * @return mixed
+	 */
+	private function get_property( $object, $name ) {
+		$property = new ReflectionProperty( Disable_Blog::class, $name );
+		$property->setAccessible( true );
+
+		return $property->getValue( $object );
+	}
+
+	/**
+	 * Invokes a private instance method via Reflection.
+	 *
+	 * @param object $object Target object.
+	 * @param string $method Method name.
+	 * @param array  $args   Positional arguments.
+	 * @return mixed
+	 */
+	private function invoke_private( $object, $method, array $args = array() ) {
+		$reflection = new ReflectionMethod( $object, $method );
+		$reflection->setAccessible( true );
+
+		return $reflection->invokeArgs( $object, $args );
+	}
+
+	/**
+	 * Invokes Disable_Blog's private static upgrade_check() via Reflection.
+	 *
+	 * @param string $method Method name.
+	 * @param array  $args   Positional arguments.
+	 * @return mixed
+	 */
+	private function invoke_private_static( $method, array $args = array() ) {
+		$reflection = new ReflectionMethod( Disable_Blog::class, $method );
+		$reflection->setAccessible( true );
+
+		return $reflection->invokeArgs( null, $args );
+	}
+
+	/**
+	 * Reads a protected property (actions/filters) off a Disable_Blog_Loader via Reflection.
+	 *
+	 * @param Disable_Blog_Loader $loader The loader instance.
+	 * @param string               $name  'actions' or 'filters'.
+	 * @return array
+	 */
+	private function get_loader_hooks( Disable_Blog_Loader $loader, $name ) {
+		$property = new ReflectionProperty( Disable_Blog_Loader::class, $name );
+		$property->setAccessible( true );
+
+		return $property->getValue( $loader );
+	}
+
+	/**
+	 * Reduces a loader's raw hook entries to deterministic [hook, component class,
+	 * callback, priority, accepted_args] tuples, so they can be compared with assertSame()
+	 * without relying on object identity.
+	 *
+	 * @param array $hooks Raw entries as stored by Disable_Blog_Loader::add().
+	 * @return array
+	 */
+	private function reduce_hooks( array $hooks ) {
+		return array_map(
+			static function ( $hook ) {
+				return array(
+					$hook['hook'],
+					get_class( $hook['component'] ),
+					$hook['callback'],
+					$hook['priority'],
+					$hook['accepted_args'],
+				);
+			},
+			$hooks
+		);
+	}
+
+	/**
+	 * define_admin_hooks() / define_public_hooks()
+	 */
+
+	/**
+	 * Drives both hook-registration methods against a real, unmocked Disable_Blog_Loader
+	 * and asserts the exact wiring they buffer into it -- including the two raw add_filter()
+	 * calls in define_admin_hooks() that bypass the loader entirely. The comments-supported
+	 * branch is forced on (via a cache-hit stub for dwpb_post_types_with_feature('comments'))
+	 * so all 49 hooks between the two methods are exercised; the conditional block is
+	 * covered separately below with it forced off.
+	 */
+	public function test_define_admin_and_public_hooks_register_expected_wiring_when_comments_supported() {
+		WP_Mock::userFunction( 'esc_attr' )->with( 'comments' )->andReturn( 'comments' );
+		WP_Mock::userFunction( 'wp_cache_get' )
+			->once()
+			->with( 'post-types-supporting-comments', 'post-types-by-feature' )
+			->andReturn( array( 'page' ) );
+
+		WP_Mock::expectFilterAdded( 'enable_update_services_configuration', '__return_false' );
+		WP_Mock::expectFilterAdded( 'enable_post_by_email_configuration', '__return_false' );
+
+		$disable_blog = $this->make_disable_blog();
+
+		$this->invoke_private( $disable_blog, 'define_admin_hooks' );
+		$this->invoke_private( $disable_blog, 'define_public_hooks' );
+
+		WP_Mock::assertHooksAdded();
+
+		$loader  = $this->get_property( $disable_blog, 'loader' );
+		$actions = $this->reduce_hooks( $this->get_loader_hooks( $loader, 'actions' ) );
+		$filters = $this->reduce_hooks( $this->get_loader_hooks( $loader, 'filters' ) );
+
+		$admin  = Disable_Blog_Admin::class;
+		$public = Disable_Blog_Public::class;
+
+		$expected_actions = array(
+			// define_admin_hooks().
+			array( 'admin_enqueue_scripts', $admin, 'enqueue_styles', 10, 1 ),
+			array( 'admin_enqueue_scripts', $admin, 'enqueue_scripts', 100, 1 ),
+			array( 'admin_menu', $admin, 'remove_menu_pages', 10, 1 ),
+			array( 'init', $admin, 'modify_post_type_arguments', 25, 1 ),
+			array( 'init', $admin, 'modify_taxonomies_arguments', 25, 1 ),
+			array( 'current_screen', $admin, 'redirect_admin_pages', 10, 1 ),
+			array( 'pings_open', $admin, 'filter_comment_status', 20, 2 ),
+			array( 'wp_before_admin_bar_render', $admin, 'remove_admin_bar_links', 10, 1 ),
+			array( 'admin_init', $admin, 'remove_dashboard_widgets', 10, 1 ),
+			array( 'admin_notices', $admin, 'admin_notices', 10, 1 ),
+			array( 'load-press-this.php', $admin, 'disable_press_this', 10, 1 ),
+			array( 'widgets_init', $admin, 'remove_widgets', 10, 1 ),
+			array( 'manage_users_columns', $admin, 'manage_users_columns', 10, 1 ),
+			array( 'customize_controls_print_styles', $admin, 'customizer_styles', 999, 1 ),
+			array( 'customize_controls_enqueue_scripts', $admin, 'customizer_scripts', 999, 1 ),
+			array( 'post_edit_form_tag', $admin, 'update_posts_page_notice', 10, 1 ),
+			// comments-supported conditional block.
+			array( 'comments_open', $admin, 'filter_comment_status', 20, 2 ),
+			array( 'pre_get_comments', $admin, 'comment_filter', 10, 1 ),
+			// define_public_hooks().
+			array( 'template_redirect', $public, 'redirect_public_pages', 10, 1 ),
+			array( 'pre_get_posts', $public, 'modify_query', 9, 1 ),
+			array( 'do_feed', $public, 'disable_feed', 1, 2 ),
+			array( 'do_feed_rdf', $public, 'disable_feed', 1, 2 ),
+			array( 'do_feed_rss', $public, 'disable_feed', 1, 2 ),
+			array( 'do_feed_rss2', $public, 'disable_feed', 1, 2 ),
+			array( 'do_feed_atom', $public, 'disable_feed', 1, 2 ),
+			array( 'wp_loaded', $public, 'header_feeds', 1, 1 ),
+			array( 'wp', $public, 'remove_pingback_header_fallback', 10, 1 ),
+			array( 'template_redirect', $public, 'disable_removed_sitemaps', 9, 1 ),
+		);
+
+		$expected_filters = array(
+			// define_admin_hooks().
+			array( 'plugin_row_meta', $admin, 'plugin_links', 10, 2 ),
+			array( 'admin_body_class', $admin, 'admin_body_class', 10, 1 ),
+			array( 'dwpb_unregister_widgets', $admin, 'filter_widget_removal', 10, 2 ),
+			array( 'display_post_states', $admin, 'page_post_states', 10, 2 ),
+			array( 'site_status_tests', $admin, 'site_status_tests', 10, 1 ),
+			array( 'manage_users_custom_column', $admin, 'manage_users_custom_column', 10, 3 ),
+			array( 'user_row_actions', $admin, 'user_row_actions', 10, 2 ),
+			array( 'post_tag_row_actions', $admin, 'filter_taxonomy_count', 10, 2 ),
+			array( 'category_row_actions', $admin, 'filter_taxonomy_count', 10, 2 ),
+			array( 'available_permalink_structure_tags', $admin, 'available_permalink_structure_tags', 10, 1 ),
+			array( 'block_type_metadata', $admin, 'filter_block_type_metadata', 10, 1 ),
+			// comments-supported conditional block.
+			array( 'views_edit-comments', $admin, 'filter_admin_table_comment_count', 20, 1 ),
+			array( 'wp_count_comments', $admin, 'filter_wp_count_comments', 10, 2 ),
+			array( 'comments_array', $admin, 'filter_existing_comments', 20, 2 ),
+			// define_public_hooks().
+			array( 'wp_headers', $public, 'filter_wp_headers', 10, 1 ),
+			array( 'feed_links_show_posts_feed', $public, 'feed_links_show_posts_feed', 10, 1 ),
+			array( 'feed_links_show_comments_feed', $public, 'feed_links_show_comments_feed', 10, 1 ),
+			array( 'xmlrpc_methods', $public, 'xmlrpc_methods', 10, 1 ),
+			array( 'wp_sitemaps_post_types', $public, 'wp_sitemaps_post_types', 10, 1 ),
+			array( 'wp_sitemaps_taxonomies', $public, 'wp_sitemaps_taxonomies', 10, 1 ),
+			array( 'wp_sitemaps_add_provider', $public, 'wp_author_sitemaps', 100, 2 ),
+		);
+
+		$this->assertSame( $expected_actions, $actions );
+		$this->assertSame( $expected_filters, $filters );
+		$this->assertCount( 49, array_merge( $actions, $filters ) );
+	}
+
+	/**
+	 * With no post type supporting comments, the five comment-specific hooks (two actions,
+	 * three filters) inside define_admin_hooks()'s conditional block must be absent, while
+	 * everything else registers as usual.
+	 */
+	public function test_define_admin_hooks_skips_comment_related_hooks_when_no_post_type_supports_comments() {
+		WP_Mock::userFunction( 'esc_attr' )->with( 'comments' )->andReturn( 'comments' );
+		WP_Mock::userFunction( 'wp_cache_get' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'get_post_types' )->once()->with( array(), 'names' )->andReturn( array( 'post' ) );
+		WP_Mock::userFunction( 'post_type_supports' )->with( 'post', 'comments' )->andReturn( true );
+		WP_Mock::userFunction( 'wp_cache_set' )->once();
+
+		$disable_blog = $this->make_disable_blog();
+
+		$this->invoke_private( $disable_blog, 'define_admin_hooks' );
+
+		$loader  = $this->get_property( $disable_blog, 'loader' );
+		$actions = $this->reduce_hooks( $this->get_loader_hooks( $loader, 'actions' ) );
+		$filters = $this->reduce_hooks( $this->get_loader_hooks( $loader, 'filters' ) );
+
+		$this->assertCount( 16, $actions );
+		$this->assertCount( 11, $filters );
+
+		foreach ( array( 'comments_open', 'pre_get_comments' ) as $hook ) {
+			$this->assertNotContains( $hook, array_column( $actions, 0 ) );
+		}
+		foreach ( array( 'views_edit-comments', 'wp_count_comments', 'comments_array' ) as $hook ) {
+			$this->assertNotContains( $hook, array_column( $filters, 0 ) );
+		}
+	}
+
+	/**
+	 * plugin_integrations()
+	 */
+
+	public function test_plugin_integrations_disables_comments_filter_when_disable_comments_plugin_active() {
+		WP_Mock::userFunction( 'is_plugin_active' )->with( 'disable-comments/disable-comments.php' )->andReturn( true );
+		WP_Mock::userFunction( 'is_plugin_active' )->with( 'woocommerce/woocommerce.php' )->andReturn( false );
+
+		WP_Mock::expectFilterAdded( 'dwpb_post_types_supporting_comments', '__return_false' );
+
+		$disable_blog = $this->make_disable_blog();
+
+		$disable_blog->plugin_integrations();
+
+		WP_Mock::assertHooksAdded();
+
+		// The WooCommerce branch never runs, so nothing reaches the loader.
+		$loader = $this->get_property( $disable_blog, 'loader' );
+		$this->assertSame( array(), $this->get_loader_hooks( $loader, 'filters' ) );
+	}
+
+	public function test_plugin_integrations_registers_woocommerce_comment_count_filter_when_active_and_comments_supported() {
+		WP_Mock::userFunction( 'is_plugin_active' )->with( 'disable-comments/disable-comments.php' )->andReturn( false );
+		WP_Mock::userFunction( 'is_plugin_active' )->with( 'woocommerce/woocommerce.php' )->andReturn( true );
+
+		WP_Mock::userFunction( 'esc_attr' )->with( 'comments' )->andReturn( 'comments' );
+		WP_Mock::userFunction( 'wp_cache_get' )
+			->once()
+			->with( 'post-types-supporting-comments', 'post-types-by-feature' )
+			->andReturn( array( 'page' ) );
+
+		$disable_blog = $this->make_disable_blog();
+
+		$disable_blog->plugin_integrations();
+
+		$loader  = $this->get_property( $disable_blog, 'loader' );
+		$filters = $this->reduce_hooks( $this->get_loader_hooks( $loader, 'filters' ) );
+
+		$this->assertSame(
+			array(
+				array( 'wp_count_comments', Disable_Blog_Integrations::class, 'filter_woocommerce_comment_count', 15, 2 ),
+			),
+			$filters
+		);
+	}
+
+	public function test_plugin_integrations_does_nothing_when_neither_integration_active() {
+		WP_Mock::userFunction( 'is_plugin_active' )->with( 'disable-comments/disable-comments.php' )->andReturn( false );
+		WP_Mock::userFunction( 'is_plugin_active' )->with( 'woocommerce/woocommerce.php' )->andReturn( false );
+
+		$disable_blog = $this->make_disable_blog();
+
+		$disable_blog->plugin_integrations();
+
+		$loader = $this->get_property( $disable_blog, 'loader' );
+		$this->assertSame( array(), $this->get_loader_hooks( $loader, 'filters' ) );
+	}
+
+	/**
+	 * upgrade_check() (private static)
+	 */
+
+	/**
+	 * DWPB_VERSION is never referenced on this path: the function returns before that line
+	 * is reached, so this is the one upgrade_check() test that needs no isolation.
+	 */
+	public function test_upgrade_check_bails_when_not_admin() {
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'get_option' )->never();
+		WP_Mock::userFunction( 'update_option' )->never();
+
+		$this->assertNull( $this->invoke_private_static( 'upgrade_check' ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_upgrade_check_sets_version_option_on_fresh_install() {
+		define( 'DWPB_VERSION', '0.5.6' );
+
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( true );
+		WP_Mock::userFunction( 'get_option' )->once()->with( 'dwpb_version', false )->andReturn( false );
+		WP_Mock::userFunction( 'update_option' )->once()->with( 'dwpb_version', '0.5.6', false );
+
+		$this->assertNull( $this->invoke_private_static( 'upgrade_check' ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_upgrade_check_does_nothing_when_version_matches() {
+		define( 'DWPB_VERSION', '0.5.6' );
+
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( true );
+		WP_Mock::userFunction( 'get_option' )->once()->with( 'dwpb_version', false )->andReturn( '0.5.6' );
+		WP_Mock::userFunction( 'update_option' )->never();
+
+		$this->assertNull( $this->invoke_private_static( 'upgrade_check' ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_upgrade_check_records_previous_version_and_updates_when_upgrading() {
+		define( 'DWPB_VERSION', '0.5.6' );
+
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( true );
+		WP_Mock::userFunction( 'get_option' )->once()->with( 'dwpb_version', false )->andReturn( '0.5.4' );
+
+		WP_Mock::userFunction( 'update_option' )->once()->with( 'dwpb_previous_version', '0.5.4', false );
+		WP_Mock::userFunction( 'update_option' )->once()->with( 'dwpb_version', '0.5.6', false );
+
+		$this->assertNull( $this->invoke_private_static( 'upgrade_check' ) );
+	}
+
+	/**
+	 * get_plugin_name() / get_loader() / get_version()
+	 */
+
+	public function test_getters_return_constructor_assigned_properties() {
+		$loader       = new Disable_Blog_Loader();
+		$disable_blog = $this->make_disable_blog( 'disable-blog', '9.9.9', $loader );
+
+		$this->assertSame( 'disable-blog', $disable_blog->get_plugin_name() );
+		$this->assertSame( '9.9.9', $disable_blog->get_version() );
+		$this->assertSame( $loader, $disable_blog->get_loader() );
+	}
+
+	/**
+	 * set_locale()
+	 */
+
+	public function test_set_locale_registers_i18n_load_plugin_textdomain_on_plugins_loaded() {
+		$disable_blog = $this->make_disable_blog();
+
+		$this->invoke_private( $disable_blog, 'set_locale' );
+
+		$loader  = $this->get_property( $disable_blog, 'loader' );
+		$actions = $this->reduce_hooks( $this->get_loader_hooks( $loader, 'actions' ) );
+
+		$this->assertSame(
+			array(
+				array( 'plugins_loaded', Disable_Blog_I18n::class, 'load_plugin_textdomain', 10, 1 ),
+			),
+			$actions
+		);
+	}
+
+	/**
+	 * run()
+	 */
+
+	public function test_run_delegates_to_the_loader() {
+		$disable_blog = $this->make_disable_blog();
+		$loader       = $this->get_property( $disable_blog, 'loader' );
+
+		// A hook buffered directly on the real loader, so run() can be proven to flush it
+		// through to WordPress for real, not just call some mock's run() method.
+		$component = new stdClass();
+		$loader->add_action( 'init', $component, 'noop' );
+
+		WP_Mock::expectActionAdded( 'init', array( $component, 'noop' ), 10, 1 );
+
+		$disable_blog->run();
+
+		WP_Mock::assertHooksAdded();
+	}
+}

--- a/tests/php/DisableBlogTest.php
+++ b/tests/php/DisableBlogTest.php
@@ -156,6 +156,9 @@ class DisableBlogTest extends TestCase {
 			->once()
 			->with( 'post-types-supporting-comments', 'post-types-by-feature' )
 			->andReturn( array( 'page' ) );
+		WP_Mock::onFilter( 'dwpb_post_types_supporting_comments' )
+			->with( array( 'page' ), array() )
+			->reply( array( 'page' ) );
 
 		WP_Mock::expectFilterAdded( 'enable_update_services_configuration', '__return_false' );
 		WP_Mock::expectFilterAdded( 'enable_post_by_email_configuration', '__return_false' );
@@ -251,6 +254,10 @@ class DisableBlogTest extends TestCase {
 		WP_Mock::userFunction( 'get_post_types' )->once()->with( array(), 'names' )->andReturn( array( 'post' ) );
 		WP_Mock::userFunction( 'post_type_supports' )->with( 'post', 'comments' )->andReturn( true );
 		WP_Mock::userFunction( 'wp_cache_set' )->once();
+		WP_Mock::onFilter( 'dwpb_post_types_supporting_comments' )->with( false, array() )->reply( false );
+
+		WP_Mock::expectFilterAdded( 'enable_update_services_configuration', '__return_false' );
+		WP_Mock::expectFilterAdded( 'enable_post_by_email_configuration', '__return_false' );
 
 		$disable_blog = $this->make_disable_blog();
 
@@ -301,6 +308,9 @@ class DisableBlogTest extends TestCase {
 			->once()
 			->with( 'post-types-supporting-comments', 'post-types-by-feature' )
 			->andReturn( array( 'page' ) );
+		WP_Mock::onFilter( 'dwpb_post_types_supporting_comments' )
+			->with( array( 'page' ), array() )
+			->reply( array( 'page' ) );
 
 		$disable_blog = $this->make_disable_blog();
 

--- a/tests/php/DisableBlogTest.php
+++ b/tests/php/DisableBlogTest.php
@@ -431,8 +431,13 @@ class DisableBlogTest extends TestCase {
 		$loader       = $this->get_property( $disable_blog, 'loader' );
 
 		// A hook buffered directly on the real loader, so run() can be proven to flush it
-		// through to WordPress for real, not just call some mock's run() method.
-		$component = new stdClass();
+		// through to WordPress for real, not just call some mock's run() method. A real
+		// object with a real method, because the tuple passed to
+		// WP_Mock::expectActionAdded() below must be a genuine callable per its docblock
+		// type; WP_Mock never actually invokes it.
+		$component = new class() {
+			public function noop() {}
+		};
 		$loader->add_action( 'init', $component, 'noop' );
 
 		WP_Mock::expectActionAdded( 'init', array( $component, 'noop' ), 10, 1 );

--- a/tests/php/HelperFunctionsTest.php
+++ b/tests/php/HelperFunctionsTest.php
@@ -12,6 +12,33 @@
 class HelperFunctionsTest extends TestCase {
 
 	/**
+	 * Stubs esc_attr() and maybe_serialize() as identity-like passthroughs matching the
+	 * exact $taxonomy/$args dwpb_post_types_with_tax() builds its cache key from, so
+	 * tax_cache_key() below computes the same string the source will.
+	 *
+	 * @param string $taxonomy The taxonomy slug.
+	 * @param array  $args     The $args passed to dwpb_post_types_with_tax().
+	 * @return void
+	 */
+	private function stub_tax_cache_key_helpers( $taxonomy, $args = array() ) {
+		WP_Mock::userFunction( 'esc_attr' )->with( $taxonomy )->andReturn( $taxonomy );
+		WP_Mock::userFunction( 'maybe_serialize' )->with( $args )->andReturn( serialize( $args ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+	}
+
+	/**
+	 * Computes the same cache key dwpb_post_types_with_tax() builds, given
+	 * stub_tax_cache_key_helpers() has stubbed esc_attr()/maybe_serialize() as passthroughs.
+	 *
+	 * @param string $taxonomy The taxonomy slug.
+	 * @param array  $args     The $args passed to dwpb_post_types_with_tax().
+	 * @param string $output   The $output passed to dwpb_post_types_with_tax().
+	 * @return string
+	 */
+	private function tax_cache_key( $taxonomy, $args = array(), $output = 'names' ) {
+		return 'post-types-with-tax-' . md5( $taxonomy ) . '-' . md5( $output ) . '-' . md5( serialize( $args ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+	}
+
+	/**
 	 * A falsy feature must short-circuit before any WordPress function is touched.
 	 *
 	 * @return void
@@ -188,6 +215,15 @@ class HelperFunctionsTest extends TestCase {
 	public function test_post_types_with_tax_taxonomy_object_uses_name_property() {
 		$taxonomy = (object) array( 'name' => 'category' );
 
+		$this->stub_tax_cache_key_helpers( 'category' );
+		WP_Mock::userFunction( 'wp_cache_get' )
+			->once()
+			->with( $this->tax_cache_key( 'category' ), 'post-types-by-tax' )
+			->andReturn( false );
+		WP_Mock::userFunction( 'wp_cache_set' )
+			->once()
+			->with( $this->tax_cache_key( 'category' ), array( 'page' ), 'post-types-by-tax' );
+
 		WP_Mock::userFunction( 'get_post_types' )
 			->once()
 			->with( array(), 'names' )
@@ -211,6 +247,12 @@ class HelperFunctionsTest extends TestCase {
 	 * @return void
 	 */
 	public function test_post_types_with_tax_matching_post_types_returned_excluding_post() {
+		$this->stub_tax_cache_key_helpers( 'category' );
+		WP_Mock::userFunction( 'wp_cache_get' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'wp_cache_set' )
+			->once()
+			->with( $this->tax_cache_key( 'category' ), array( 'page' ), 'post-types-by-tax' );
+
 		WP_Mock::userFunction( 'get_post_types' )
 			->once()
 			->with( array(), 'names' )
@@ -225,11 +267,18 @@ class HelperFunctionsTest extends TestCase {
 	}
 
 	/**
-	 * When no post type (other than 'post') carries the taxonomy, the result is false.
+	 * When no post type (other than 'post') carries the taxonomy, the result is false --
+	 * both what gets cached and what gets returned.
 	 *
 	 * @return void
 	 */
 	public function test_post_types_with_tax_no_matches_returns_false() {
+		$this->stub_tax_cache_key_helpers( 'category' );
+		WP_Mock::userFunction( 'wp_cache_get' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'wp_cache_set' )
+			->once()
+			->with( $this->tax_cache_key( 'category' ), false, 'post-types-by-tax' );
+
 		WP_Mock::userFunction( 'get_post_types' )
 			->once()
 			->with( array(), 'names' )
@@ -247,7 +296,7 @@ class HelperFunctionsTest extends TestCase {
 
 	/**
 	 * The dwpb_taxonomy_support filter short-circuits and overrides the result whenever
-	 * it returns a non-null value.
+	 * it returns a non-null value, and is passed the full unfiltered $post_types list.
 	 *
 	 * @return void
 	 */
@@ -255,6 +304,10 @@ class HelperFunctionsTest extends TestCase {
 		$args     = array();
 		$output   = 'names';
 		$override = array( 'custom_cpt' );
+
+		$this->stub_tax_cache_key_helpers( 'category', $args );
+		WP_Mock::userFunction( 'wp_cache_get' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'wp_cache_set' )->once();
 
 		WP_Mock::userFunction( 'get_post_types' )
 			->once()
@@ -273,5 +326,173 @@ class HelperFunctionsTest extends TestCase {
 		$result = dwpb_post_types_with_tax( 'category', $args, $output );
 
 		$this->assertSame( $override, $result );
+	}
+
+	/**
+	 * Cache miss: the function must query get_post_types(), narrow the result down to post
+	 * types carrying the taxonomy (excluding 'post'), and populate the cache with that
+	 * narrowed result -- mirrors test_post_types_with_feature_cache_miss_queries_and_populates_cache().
+	 *
+	 * @return void
+	 */
+	public function test_post_types_with_tax_cache_miss_queries_and_populates_cache() {
+		$taxonomy = 'category';
+		$args     = array( 'public' => true );
+		$output   = 'names';
+
+		$this->stub_tax_cache_key_helpers( $taxonomy, $args );
+
+		WP_Mock::userFunction( 'wp_cache_get' )
+			->once()
+			->with( $this->tax_cache_key( $taxonomy, $args, $output ), 'post-types-by-tax' )
+			->andReturn( false );
+
+		WP_Mock::userFunction( 'get_post_types' )
+			->once()
+			->with( $args, $output )
+			->andReturn( array( 'post', 'page', 'book' ) );
+
+		// 'post' is skipped before get_object_taxonomies() would ever be called for it.
+		WP_Mock::userFunction( 'get_object_taxonomies' )->with( 'page', 'names' )->andReturn( array( 'category' ) );
+		WP_Mock::userFunction( 'get_object_taxonomies' )->with( 'book', 'names' )->andReturn( array( 'genre' ) );
+
+		WP_Mock::userFunction( 'wp_cache_set' )
+			->once()
+			->with( $this->tax_cache_key( $taxonomy, $args, $output ), array( 'page' ), 'post-types-by-tax' );
+
+		$result = dwpb_post_types_with_tax( $taxonomy, $args, $output );
+
+		$this->assertSame( array( 'page' ), $result );
+	}
+
+	/**
+	 * Cache hit: the cached value is returned as-is and get_object_taxonomies()/
+	 * wp_cache_set() must never run. Unlike dwpb_post_types_with_feature(), get_post_types()
+	 * still runs on a hit -- its result is one of the documented arguments the
+	 * dwpb_taxonomy_support filter receives on every call, cached or not, so it can't be
+	 * skipped just because the taxonomy-matching work was cached.
+	 *
+	 * @return void
+	 */
+	public function test_post_types_with_tax_cache_hit_returns_cached_value_without_querying_taxonomies() {
+		$taxonomy = 'category';
+		$cached   = array( 'page', 'book' );
+
+		$this->stub_tax_cache_key_helpers( $taxonomy );
+
+		WP_Mock::userFunction( 'wp_cache_get' )
+			->once()
+			->with( $this->tax_cache_key( $taxonomy ), 'post-types-by-tax' )
+			->andReturn( $cached );
+
+		WP_Mock::userFunction( 'get_post_types' )->once()->with( array(), 'names' )->andReturn( array( 'page' ) );
+		WP_Mock::userFunction( 'get_object_taxonomies' )->never();
+		WP_Mock::userFunction( 'wp_cache_set' )->never();
+
+		$result = dwpb_post_types_with_tax( $taxonomy );
+
+		$this->assertSame( $cached, $result );
+	}
+
+	/**
+	 * The dwpb_taxonomy_support filter must run on a cache HIT too, not only on a miss --
+	 * it documents $post_types (get_post_types()'s unfiltered result) as one of its
+	 * arguments "on every call" regardless of whether the taxonomy-matching work itself
+	 * was cached. Asserting on the filtered return value (rather than a call-count
+	 * expectation) means this fails if the filter is ever skipped on the hit path: with
+	 * no filter reply applied, dwpb_post_types_with_tax() would return the raw cached
+	 * value instead of $override.
+	 *
+	 * @return void
+	 */
+	public function test_post_types_with_tax_cache_hit_still_runs_dwpb_taxonomy_support_filter() {
+		$taxonomy = 'category';
+		$cached   = array( 'page', 'book' );
+		$override = array( 'custom_cpt' );
+
+		$this->stub_tax_cache_key_helpers( $taxonomy );
+
+		WP_Mock::userFunction( 'wp_cache_get' )
+			->once()
+			->with( $this->tax_cache_key( $taxonomy ), 'post-types-by-tax' )
+			->andReturn( $cached );
+
+		WP_Mock::userFunction( 'get_post_types' )->once()->with( array(), 'names' )->andReturn( array( 'page' ) );
+		WP_Mock::userFunction( 'get_object_taxonomies' )->never();
+		WP_Mock::userFunction( 'wp_cache_set' )->never();
+
+		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
+			->with( null, $taxonomy, array( 'page' ), array(), 'names' )
+			->reply( $override );
+
+		$result = dwpb_post_types_with_tax( $taxonomy );
+
+		$this->assertSame( $override, $result );
+	}
+
+	/**
+	 * Regression: naively concatenating $taxonomy and $output with a single '-' delimiter
+	 * (no per-component hashing) lets two calls whose values straddle the delimiter
+	 * identically collide onto the same cache key -- e.g. ('cat', 'single-tag') and
+	 * ('cat-single', 'tag') would both naively produce 'post-types-with-tax-cat-single-tag-...'.
+	 * Hashing $taxonomy and $output independently before concatenating rules this out,
+	 * since each hash is a fixed-length, unambiguous token.
+	 *
+	 * @return void
+	 */
+	public function test_post_types_with_tax_cache_key_does_not_collide_across_taxonomy_output_boundary() {
+		WP_Mock::userFunction( 'esc_attr' )->with( 'cat' )->andReturn( 'cat' );
+		WP_Mock::userFunction( 'esc_attr' )->with( 'cat-single' )->andReturn( 'cat-single' );
+		WP_Mock::userFunction( 'maybe_serialize' )->with( array() )->andReturn( serialize( array() ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+
+		WP_Mock::userFunction( 'get_post_types' )->with( array(), 'single-tag' )->andReturn( array() );
+		WP_Mock::userFunction( 'get_post_types' )->with( array(), 'tag' )->andReturn( array() );
+
+		$seen_keys = array();
+		WP_Mock::userFunction( 'wp_cache_get' )
+			->twice()
+			->andReturnUsing(
+				function ( $key ) use ( &$seen_keys ) {
+					$seen_keys[] = $key;
+
+					return false;
+				}
+			);
+		WP_Mock::userFunction( 'wp_cache_set' )->twice();
+
+		dwpb_post_types_with_tax( 'cat', array(), 'single-tag' );
+		dwpb_post_types_with_tax( 'cat-single', array(), 'tag' );
+
+		$this->assertCount( 2, array_unique( $seen_keys ) );
+	}
+
+	/**
+	 * The cache key must incorporate $output: two calls that differ only in $output must
+	 * not collide and read each other's cached result.
+	 *
+	 * @return void
+	 */
+	public function test_post_types_with_tax_cache_key_distinguishes_calls_that_differ_only_by_output() {
+		$this->stub_tax_cache_key_helpers( 'category' );
+
+		WP_Mock::userFunction( 'get_post_types' )->with( array(), 'names' )->andReturn( array() );
+		WP_Mock::userFunction( 'get_post_types' )->with( array(), 'objects' )->andReturn( array() );
+
+		$seen_keys = array();
+		WP_Mock::userFunction( 'wp_cache_get' )
+			->twice()
+			->andReturnUsing(
+				function ( $key ) use ( &$seen_keys ) {
+					$seen_keys[] = $key;
+
+					return false;
+				}
+			);
+		WP_Mock::userFunction( 'wp_cache_set' )->twice();
+
+		dwpb_post_types_with_tax( 'category', array(), 'names' );
+		dwpb_post_types_with_tax( 'category', array(), 'objects' );
+
+		$this->assertCount( 2, array_unique( $seen_keys ) );
 	}
 }

--- a/tests/php/HelperFunctionsTest.php
+++ b/tests/php/HelperFunctionsTest.php
@@ -94,6 +94,10 @@ class HelperFunctionsTest extends TestCase {
 			->once()
 			->with( 'post-types-supporting-comments', array( 'page' ), 'post-types-by-feature' );
 
+		WP_Mock::onFilter( 'dwpb_post_types_supporting_comments' )
+			->with( array( 'page' ), $args )
+			->reply( array( 'page' ) );
+
 		$result = dwpb_post_types_with_feature( $feature, $args );
 
 		$this->assertSame( array( 'page' ), $result );
@@ -122,6 +126,8 @@ class HelperFunctionsTest extends TestCase {
 		WP_Mock::userFunction( 'get_post_types' )->never();
 		WP_Mock::userFunction( 'post_type_supports' )->never();
 		WP_Mock::userFunction( 'wp_cache_set' )->never();
+
+		WP_Mock::onFilter( 'dwpb_post_types_supporting_comments' )->with( $cached, array() )->reply( $cached );
 
 		$result = dwpb_post_types_with_feature( $feature );
 
@@ -154,6 +160,8 @@ class HelperFunctionsTest extends TestCase {
 		WP_Mock::userFunction( 'wp_cache_set' )
 			->once()
 			->with( 'post-types-supporting-comments', false, 'post-types-by-feature' );
+
+		WP_Mock::onFilter( 'dwpb_post_types_supporting_comments' )->with( false, array() )->reply( false );
 
 		$result = dwpb_post_types_with_feature( $feature );
 
@@ -235,6 +243,10 @@ class HelperFunctionsTest extends TestCase {
 			->with( 'page', 'names' )
 			->andReturn( array( 'category', 'post_tag' ) );
 
+		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
+			->with( null, 'category', array( 'post', 'page' ), array(), 'names' )
+			->reply( null );
+
 		$result = dwpb_post_types_with_tax( $taxonomy );
 
 		$this->assertSame( array( 'page' ), $result );
@@ -260,6 +272,10 @@ class HelperFunctionsTest extends TestCase {
 
 		WP_Mock::userFunction( 'get_object_taxonomies' )->with( 'page', 'names' )->andReturn( array( 'category' ) );
 		WP_Mock::userFunction( 'get_object_taxonomies' )->with( 'book', 'names' )->andReturn( array( 'genre' ) );
+
+		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
+			->with( null, 'category', array( 'post', 'page', 'book' ), array(), 'names' )
+			->reply( null );
 
 		$result = dwpb_post_types_with_tax( 'category' );
 
@@ -288,6 +304,10 @@ class HelperFunctionsTest extends TestCase {
 			->once()
 			->with( 'page', 'names' )
 			->andReturn( array( 'post_tag' ) );
+
+		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
+			->with( null, 'category', array( 'page' ), array(), 'names' )
+			->reply( null );
 
 		$result = dwpb_post_types_with_tax( 'category' );
 
@@ -360,6 +380,10 @@ class HelperFunctionsTest extends TestCase {
 			->once()
 			->with( $this->tax_cache_key( $taxonomy, $args, $output ), array( 'page' ), 'post-types-by-tax' );
 
+		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
+			->with( null, $taxonomy, array( 'post', 'page', 'book' ), $args, $output )
+			->reply( null );
+
 		$result = dwpb_post_types_with_tax( $taxonomy, $args, $output );
 
 		$this->assertSame( array( 'page' ), $result );
@@ -388,6 +412,10 @@ class HelperFunctionsTest extends TestCase {
 		WP_Mock::userFunction( 'get_post_types' )->once()->with( array(), 'names' )->andReturn( array( 'page' ) );
 		WP_Mock::userFunction( 'get_object_taxonomies' )->never();
 		WP_Mock::userFunction( 'wp_cache_set' )->never();
+
+		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
+			->with( null, $taxonomy, array( 'page' ), array(), 'names' )
+			->reply( null );
 
 		$result = dwpb_post_types_with_tax( $taxonomy );
 
@@ -460,6 +488,9 @@ class HelperFunctionsTest extends TestCase {
 			);
 		WP_Mock::userFunction( 'wp_cache_set' )->twice();
 
+		WP_Mock::onFilter( 'dwpb_taxonomy_support' )->with( null, 'cat', array(), array(), 'single-tag' )->reply( null );
+		WP_Mock::onFilter( 'dwpb_taxonomy_support' )->with( null, 'cat-single', array(), array(), 'tag' )->reply( null );
+
 		dwpb_post_types_with_tax( 'cat', array(), 'single-tag' );
 		dwpb_post_types_with_tax( 'cat-single', array(), 'tag' );
 
@@ -489,6 +520,9 @@ class HelperFunctionsTest extends TestCase {
 				}
 			);
 		WP_Mock::userFunction( 'wp_cache_set' )->twice();
+
+		WP_Mock::onFilter( 'dwpb_taxonomy_support' )->with( null, 'category', array(), array(), 'names' )->reply( null );
+		WP_Mock::onFilter( 'dwpb_taxonomy_support' )->with( null, 'category', array(), array(), 'objects' )->reply( null );
 
 		dwpb_post_types_with_tax( 'category', array(), 'names' );
 		dwpb_post_types_with_tax( 'category', array(), 'objects' );

--- a/tests/php/HelperFunctionsTest.php
+++ b/tests/php/HelperFunctionsTest.php
@@ -1,0 +1,277 @@
+<?php
+/**
+ * Tests for includes/functions.php.
+ *
+ * @package DisableBlog
+ */
+
+/**
+ * @covers ::dwpb_post_types_with_feature
+ * @covers ::dwpb_post_types_with_tax
+ */
+class HelperFunctionsTest extends TestCase {
+
+	/**
+	 * A falsy feature must short-circuit before any WordPress function is touched.
+	 *
+	 * @return void
+	 */
+	public function test_post_types_with_feature_falsy_feature_returns_false() {
+		$this->assertFalse( dwpb_post_types_with_feature( '' ) );
+		$this->assertFalse( dwpb_post_types_with_feature( 0 ) );
+		$this->assertFalse( dwpb_post_types_with_feature( false ) );
+		$this->assertFalse( dwpb_post_types_with_feature( null ) );
+	}
+
+	/**
+	 * A non-string feature must also short-circuit before any WordPress function is touched.
+	 *
+	 * @return void
+	 */
+	public function test_post_types_with_feature_non_string_feature_returns_false() {
+		$this->assertFalse( dwpb_post_types_with_feature( array( 'comments' ) ) );
+		$this->assertFalse( dwpb_post_types_with_feature( 42 ) );
+	}
+
+	/**
+	 * Cache miss: the function must query get_post_types(), filter by post_type_supports(),
+	 * exclude 'post', and populate the cache with the result.
+	 *
+	 * @return void
+	 */
+	public function test_post_types_with_feature_cache_miss_queries_and_populates_cache() {
+		$feature = 'comments';
+		$args    = array( 'public' => true );
+
+		WP_Mock::userFunction( 'esc_attr' )
+			->once()
+			->with( $feature )
+			->andReturn( $feature );
+
+		WP_Mock::userFunction( 'wp_cache_get' )
+			->once()
+			->with( 'post-types-supporting-comments', 'post-types-by-feature' )
+			->andReturn( false );
+
+		WP_Mock::userFunction( 'get_post_types' )
+			->once()
+			->with( $args, 'names' )
+			->andReturn( array( 'post', 'page', 'attachment' ) );
+
+		// 'post' supports the feature too, but must be excluded regardless.
+		WP_Mock::userFunction( 'post_type_supports' )->with( 'post', $feature )->andReturn( true );
+		WP_Mock::userFunction( 'post_type_supports' )->with( 'page', $feature )->andReturn( true );
+		WP_Mock::userFunction( 'post_type_supports' )->with( 'attachment', $feature )->andReturn( false );
+
+		WP_Mock::userFunction( 'wp_cache_set' )
+			->once()
+			->with( 'post-types-supporting-comments', array( 'page' ), 'post-types-by-feature' );
+
+		$result = dwpb_post_types_with_feature( $feature, $args );
+
+		$this->assertSame( array( 'page' ), $result );
+	}
+
+	/**
+	 * Cache hit: a populated cached value must be returned as-is, and get_post_types()/
+	 * post_type_supports()/wp_cache_set() must never run.
+	 *
+	 * @return void
+	 */
+	public function test_post_types_with_feature_cache_hit_returns_cached_value_without_querying() {
+		$feature = 'comments';
+		$cached  = array( 'page', 'book' );
+
+		WP_Mock::userFunction( 'esc_attr' )
+			->once()
+			->with( $feature )
+			->andReturn( $feature );
+
+		WP_Mock::userFunction( 'wp_cache_get' )
+			->once()
+			->with( 'post-types-supporting-comments', 'post-types-by-feature' )
+			->andReturn( $cached );
+
+		WP_Mock::userFunction( 'get_post_types' )->never();
+		WP_Mock::userFunction( 'post_type_supports' )->never();
+		WP_Mock::userFunction( 'wp_cache_set' )->never();
+
+		$result = dwpb_post_types_with_feature( $feature );
+
+		$this->assertSame( $cached, $result );
+	}
+
+	/**
+	 * When nothing supports the feature (other than the excluded 'post' type), the
+	 * empty result array must normalise to false, both in what gets cached and returned.
+	 *
+	 * @return void
+	 */
+	public function test_post_types_with_feature_no_matches_normalises_to_false() {
+		$feature = 'comments';
+
+		WP_Mock::userFunction( 'esc_attr' )->with( $feature )->andReturn( $feature );
+
+		WP_Mock::userFunction( 'wp_cache_get' )
+			->once()
+			->with( 'post-types-supporting-comments', 'post-types-by-feature' )
+			->andReturn( false );
+
+		WP_Mock::userFunction( 'get_post_types' )
+			->once()
+			->with( array(), 'names' )
+			->andReturn( array( 'post' ) );
+
+		WP_Mock::userFunction( 'post_type_supports' )->with( 'post', $feature )->andReturn( true );
+
+		WP_Mock::userFunction( 'wp_cache_set' )
+			->once()
+			->with( 'post-types-supporting-comments', false, 'post-types-by-feature' );
+
+		$result = dwpb_post_types_with_feature( $feature );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * The dwpb_post_types_supporting_{$feature} filter can override the computed result.
+	 *
+	 * @return void
+	 */
+	public function test_post_types_with_feature_filter_overrides_result() {
+		$feature  = 'comments';
+		$args     = array();
+		$override = array( 'custom_cpt' );
+
+		WP_Mock::userFunction( 'esc_attr' )->with( $feature )->andReturn( $feature );
+		WP_Mock::userFunction( 'wp_cache_get' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'get_post_types' )->once()->with( $args, 'names' )->andReturn( array( 'page' ) );
+		WP_Mock::userFunction( 'post_type_supports' )->with( 'page', $feature )->andReturn( true );
+		WP_Mock::userFunction( 'wp_cache_set' )->once();
+
+		WP_Mock::onFilter( "dwpb_post_types_supporting_{$feature}" )
+			->with( array( 'page' ), $args )
+			->reply( $override );
+
+		$result = dwpb_post_types_with_feature( $feature, $args );
+
+		$this->assertSame( $override, $result );
+	}
+
+	/**
+	 * A falsy taxonomy must short-circuit before any WordPress function is touched.
+	 *
+	 * @return void
+	 */
+	public function test_post_types_with_tax_falsy_taxonomy_returns_false() {
+		$this->assertFalse( dwpb_post_types_with_tax( '' ) );
+		$this->assertFalse( dwpb_post_types_with_tax( 0 ) );
+		$this->assertFalse( dwpb_post_types_with_tax( null ) );
+		$this->assertFalse( dwpb_post_types_with_tax( false ) );
+	}
+
+	/**
+	 * A taxonomy that is neither an object nor a string must also short-circuit.
+	 *
+	 * @return void
+	 */
+	public function test_post_types_with_tax_non_string_non_object_taxonomy_returns_false() {
+		$this->assertFalse( dwpb_post_types_with_tax( array( 'category' ) ) );
+		$this->assertFalse( dwpb_post_types_with_tax( 42 ) );
+	}
+
+	/**
+	 * A taxonomy object must be resolved through its ->name property.
+	 *
+	 * @return void
+	 */
+	public function test_post_types_with_tax_taxonomy_object_uses_name_property() {
+		$taxonomy = (object) array( 'name' => 'category' );
+
+		WP_Mock::userFunction( 'get_post_types' )
+			->once()
+			->with( array(), 'names' )
+			->andReturn( array( 'post', 'page' ) );
+
+		// 'post' is skipped before get_object_taxonomies() would ever be called for it.
+		WP_Mock::userFunction( 'get_object_taxonomies' )
+			->once()
+			->with( 'page', 'names' )
+			->andReturn( array( 'category', 'post_tag' ) );
+
+		$result = dwpb_post_types_with_tax( $taxonomy );
+
+		$this->assertSame( array( 'page' ), $result );
+	}
+
+	/**
+	 * Post types with the taxonomy are returned; 'post' is always excluded even
+	 * when it supports the taxonomy.
+	 *
+	 * @return void
+	 */
+	public function test_post_types_with_tax_matching_post_types_returned_excluding_post() {
+		WP_Mock::userFunction( 'get_post_types' )
+			->once()
+			->with( array(), 'names' )
+			->andReturn( array( 'post', 'page', 'book' ) );
+
+		WP_Mock::userFunction( 'get_object_taxonomies' )->with( 'page', 'names' )->andReturn( array( 'category' ) );
+		WP_Mock::userFunction( 'get_object_taxonomies' )->with( 'book', 'names' )->andReturn( array( 'genre' ) );
+
+		$result = dwpb_post_types_with_tax( 'category' );
+
+		$this->assertSame( array( 'page' ), $result );
+	}
+
+	/**
+	 * When no post type (other than 'post') carries the taxonomy, the result is false.
+	 *
+	 * @return void
+	 */
+	public function test_post_types_with_tax_no_matches_returns_false() {
+		WP_Mock::userFunction( 'get_post_types' )
+			->once()
+			->with( array(), 'names' )
+			->andReturn( array( 'page' ) );
+
+		WP_Mock::userFunction( 'get_object_taxonomies' )
+			->once()
+			->with( 'page', 'names' )
+			->andReturn( array( 'post_tag' ) );
+
+		$result = dwpb_post_types_with_tax( 'category' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * The dwpb_taxonomy_support filter short-circuits and overrides the result whenever
+	 * it returns a non-null value.
+	 *
+	 * @return void
+	 */
+	public function test_post_types_with_tax_filter_overrides_result_when_non_null() {
+		$args     = array();
+		$output   = 'names';
+		$override = array( 'custom_cpt' );
+
+		WP_Mock::userFunction( 'get_post_types' )
+			->once()
+			->with( $args, $output )
+			->andReturn( array( 'page' ) );
+
+		WP_Mock::userFunction( 'get_object_taxonomies' )
+			->once()
+			->with( 'page', 'names' )
+			->andReturn( array() );
+
+		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
+			->with( null, 'category', array( 'page' ), $args, $output )
+			->reply( $override );
+
+		$result = dwpb_post_types_with_tax( 'category', $args, $output );
+
+		$this->assertSame( $override, $result );
+	}
+}

--- a/tests/php/I18nTest.php
+++ b/tests/php/I18nTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Tests for includes/class-disable-blog-i18n.php.
+ *
+ * @package DisableBlog
+ */
+
+/**
+ * @covers Disable_Blog_I18n
+ */
+class I18nTest extends TestCase {
+
+	/**
+	 * load_plugin_textdomain() must be called with the plugin's text domain, a false
+	 * "plugin_rel_path" (deprecated WP argument, kept false), and the languages/ path
+	 * resolved relative to the plugin root (two directories up from this class file).
+	 */
+	public function test_load_plugin_textdomain_calls_wp_with_domain_and_languages_path() {
+		WP_Mock::userFunction( 'plugin_basename' )
+			->once()
+			->andReturn( 'disable-blog/includes/class-disable-blog-i18n.php' );
+
+		$captured_args = null;
+
+		WP_Mock::userFunction( 'load_plugin_textdomain' )
+			->once()
+			->andReturnUsing(
+				function ( $domain, $plugin_rel_path, $languages_path ) use ( &$captured_args ) {
+					$captured_args = array( $domain, $plugin_rel_path, $languages_path );
+
+					return true;
+				}
+			);
+
+		$i18n = new Disable_Blog_I18n();
+		$i18n->load_plugin_textdomain();
+
+		$this->assertSame(
+			array( 'disable-blog', false, 'disable-blog/languages/' ),
+			$captured_args
+		);
+	}
+}

--- a/tests/php/IntegrationsTest.php
+++ b/tests/php/IntegrationsTest.php
@@ -1,0 +1,302 @@
+<?php
+/**
+ * Tests for includes/class-disable-blog-integrations.php.
+ *
+ * @package DisableBlog
+ */
+
+/**
+ * @covers Disable_Blog_Integrations
+ */
+class IntegrationsTest extends TestCase {
+
+	/**
+	 * Invokes the private woocommerce_version_check() method via Reflection.
+	 *
+	 * @param Disable_Blog_Integrations $integrations Instance to invoke on.
+	 * @param array                     $args         Positional arguments.
+	 * @return mixed
+	 */
+	private function invoke_woocommerce_version_check( Disable_Blog_Integrations $integrations, array $args ) {
+		$method = new ReflectionMethod( $integrations, 'woocommerce_version_check' );
+		$method->setAccessible( true );
+
+		return $method->invokeArgs( $integrations, $args );
+	}
+
+	/**
+	 * is_plugin_active()
+	 */
+
+	public function test_is_plugin_active_returns_true_when_wp_reports_active() {
+		WP_Mock::userFunction( 'is_plugin_active' )
+			->once()
+			->with( 'woocommerce/woocommerce.php' )
+			->andReturn( true );
+
+		$integrations = new Disable_Blog_Integrations();
+
+		$this->assertTrue( $integrations->is_plugin_active( 'woocommerce/woocommerce.php' ) );
+	}
+
+	public function test_is_plugin_active_returns_false_when_wp_reports_inactive() {
+		WP_Mock::userFunction( 'is_plugin_active' )
+			->once()
+			->with( 'woocommerce/woocommerce.php' )
+			->andReturn( false );
+
+		$integrations = new Disable_Blog_Integrations();
+
+		$this->assertFalse( $integrations->is_plugin_active( 'woocommerce/woocommerce.php' ) );
+	}
+
+	/**
+	 * Isolated: is_plugin_active() only reaches the include_once() when the WP function
+	 * is_plugin_active is not yet defined. Once any test defines it (via WP_Mock::userFunction,
+	 * which eval()s a global function the first time it's mocked), PHP can never undefine it
+	 * for the rest of the process. A fresh process guarantees the function is genuinely absent.
+	 * bootstrap.php points ABSPATH at tests/php/Support/fixtures/, which holds a fixture
+	 * wp-admin/includes/plugin.php that defines a real is_plugin_active() to be included
+	 * and called.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_is_plugin_active_includes_core_file_when_function_not_yet_defined() {
+		$integrations = new Disable_Blog_Integrations();
+
+		$this->assertTrue( $integrations->is_plugin_active( 'fixture-plugin/fixture-plugin.php' ) );
+		$this->assertFalse( $integrations->is_plugin_active( 'something-else/something-else.php' ) );
+	}
+
+	/**
+	 * is_disable_comments_active()
+	 */
+
+	public function test_is_disable_comments_active_true_when_plugin_reports_active() {
+		WP_Mock::userFunction( 'is_plugin_active' )
+			->once()
+			->with( 'disable-comments/disable-comments.php' )
+			->andReturn( true );
+
+		$integrations = new Disable_Blog_Integrations();
+
+		$this->assertTrue( $integrations->is_disable_comments_active() );
+	}
+
+	public function test_is_disable_comments_active_false_when_plugin_inactive_and_class_missing() {
+		WP_Mock::userFunction( 'is_plugin_active' )
+			->once()
+			->with( 'disable-comments/disable-comments.php' )
+			->andReturn( false );
+
+		$integrations = new Disable_Blog_Integrations();
+
+		$this->assertFalse( $integrations->is_disable_comments_active() );
+	}
+
+	/**
+	 * Isolated: declaring class Disable_Comments cannot be undone within the process, and
+	 * would otherwise make class_exists('Disable_Comments') permanently true for every
+	 * later test (including the "class missing" case above). The class lives in a fixture
+	 * file rather than inline because PHP disallows nesting a class declaration inside
+	 * another class's method body ("Class declarations may not be nested").
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_is_disable_comments_active_true_when_class_exists_even_if_plugin_inactive() {
+		require __DIR__ . '/Support/fixtures/class-disable-comments-stub.php';
+
+		WP_Mock::userFunction( 'is_plugin_active' )
+			->once()
+			->with( 'disable-comments/disable-comments.php' )
+			->andReturn( false );
+
+		$integrations = new Disable_Blog_Integrations();
+
+		$this->assertTrue( $integrations->is_disable_comments_active() );
+	}
+
+	/**
+	 * is_woocommerce_active()
+	 */
+
+	public function test_is_woocommerce_active_true_when_plugin_reports_active() {
+		WP_Mock::userFunction( 'is_plugin_active' )
+			->once()
+			->with( 'woocommerce/woocommerce.php' )
+			->andReturn( true );
+
+		$integrations = new Disable_Blog_Integrations();
+
+		$this->assertTrue( $integrations->is_woocommerce_active() );
+	}
+
+	public function test_is_woocommerce_active_false_when_plugin_inactive_and_function_missing() {
+		WP_Mock::userFunction( 'is_plugin_active' )
+			->once()
+			->with( 'woocommerce/woocommerce.php' )
+			->andReturn( false );
+
+		$integrations = new Disable_Blog_Integrations();
+
+		$this->assertFalse( $integrations->is_woocommerce_active() );
+	}
+
+	/**
+	 * Isolated: declaring function WC() cannot be undone within the process, and would
+	 * otherwise make function_exists('WC') permanently true for every later test.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_is_woocommerce_active_true_when_wc_function_exists_even_if_plugin_inactive() {
+		function WC() {}
+
+		WP_Mock::userFunction( 'is_plugin_active' )
+			->once()
+			->with( 'woocommerce/woocommerce.php' )
+			->andReturn( false );
+
+		$integrations = new Disable_Blog_Integrations();
+
+		$this->assertTrue( $integrations->is_woocommerce_active() );
+	}
+
+	/**
+	 * filter_woocommerce_comment_count()
+	 */
+
+	public function test_filter_woocommerce_comment_count_skips_when_post_id_is_not_zero() {
+		$comments = (object) array( 'foo' => 'bar' );
+
+		$integrations = new Disable_Blog_Integrations();
+
+		// The 0 === $post_id check must short-circuit before woocommerce_version_check()
+		// (and therefore is_plugin_active()) is ever reached. Asserting ->never() catches
+		// the call directly instead of relying on an unstubbed call happening to error out.
+		WP_Mock::userFunction( 'is_plugin_active' )->never();
+
+		$result = $integrations->filter_woocommerce_comment_count( $comments, 5 );
+
+		$this->assertSame( $comments, $result );
+	}
+
+	public function test_filter_woocommerce_comment_count_unchanged_when_woocommerce_inactive() {
+		$comments = (object) array( 'foo' => 'bar' );
+
+		WP_Mock::userFunction( 'is_plugin_active' )
+			->once()
+			->with( 'woocommerce/woocommerce.php' )
+			->andReturn( false );
+
+		$integrations = new Disable_Blog_Integrations();
+
+		$result = $integrations->filter_woocommerce_comment_count( $comments, 0 );
+
+		$this->assertSame( $comments, $result );
+	}
+
+	/**
+	 * Isolated: needs WC_VERSION defined below the 2.6.2 threshold, which would otherwise
+	 * leak into every later woocommerce_version_check()-dependent test.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_filter_woocommerce_comment_count_casts_to_array_when_old_woocommerce_active() {
+		define( 'WC_VERSION', '2.6.0' );
+
+		WP_Mock::userFunction( 'is_plugin_active' )
+			->once()
+			->with( 'woocommerce/woocommerce.php' )
+			->andReturn( true );
+
+		$comments = (object) array( 'foo' => 'bar' );
+
+		$integrations = new Disable_Blog_Integrations();
+
+		$result = $integrations->filter_woocommerce_comment_count( $comments, 0 );
+
+		$this->assertSame( array( 'foo' => 'bar' ), $result );
+	}
+
+	/**
+	 * woocommerce_version_check() (private)
+	 */
+
+	public function test_woocommerce_version_check_false_when_woocommerce_inactive() {
+		WP_Mock::userFunction( 'is_plugin_active' )
+			->once()
+			->with( 'woocommerce/woocommerce.php' )
+			->andReturn( false );
+
+		$integrations = new Disable_Blog_Integrations();
+
+		$this->assertFalse( $this->invoke_woocommerce_version_check( $integrations, array( '2.6.2' ) ) );
+	}
+
+	/**
+	 * Relies on WC_VERSION/WOOCOMMERCE_VERSION never being defined outside the isolated
+	 * tests below, so this can safely assert the "neither constant defined" branch without
+	 * isolation of its own.
+	 */
+	public function test_woocommerce_version_check_false_when_active_but_no_version_constant_defined() {
+		WP_Mock::userFunction( 'is_plugin_active' )
+			->once()
+			->with( 'woocommerce/woocommerce.php' )
+			->andReturn( true );
+
+		$integrations = new Disable_Blog_Integrations();
+
+		$this->assertFalse( $this->invoke_woocommerce_version_check( $integrations, array( '2.6.2' ) ) );
+	}
+
+	/**
+	 * Isolated: defines WC_VERSION, which cannot be undefined afterward. Also exercises the
+	 * optional $check comparison operator argument in the same process.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_woocommerce_version_check_uses_wc_version_constant_when_defined() {
+		define( 'WC_VERSION', '2.6.0' );
+
+		WP_Mock::userFunction( 'is_plugin_active' )
+			->twice()
+			->with( 'woocommerce/woocommerce.php' )
+			->andReturn( true );
+
+		$integrations = new Disable_Blog_Integrations();
+
+		// Default $check is '<=': 2.6.0 <= 2.6.2 is true.
+		$this->assertTrue( $this->invoke_woocommerce_version_check( $integrations, array( '2.6.2' ) ) );
+
+		// Explicit $check '>': 2.6.0 > 2.6.2 is false.
+		$this->assertFalse( $this->invoke_woocommerce_version_check( $integrations, array( '2.6.2', '>' ) ) );
+	}
+
+	/**
+	 * Isolated: defines WOOCOMMERCE_VERSION (and deliberately not WC_VERSION) to exercise the
+	 * elseif fallback branch; the constant cannot be undefined afterward.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_woocommerce_version_check_falls_back_to_woocommerce_version_constant() {
+		define( 'WOOCOMMERCE_VERSION', '2.0.0' );
+
+		WP_Mock::userFunction( 'is_plugin_active' )
+			->once()
+			->with( 'woocommerce/woocommerce.php' )
+			->andReturn( true );
+
+		$integrations = new Disable_Blog_Integrations();
+
+		// 2.0.0 <= 2.6.2 is true -- chosen deliberately so this diverges from the fallthrough
+		// `return false;` a skipped elseif would produce, unlike a WOOCOMMERCE_VERSION that
+		// also compares false against the checked version.
+		$this->assertTrue( $this->invoke_woocommerce_version_check( $integrations, array( '2.6.2' ) ) );
+	}
+}

--- a/tests/php/LoaderTest.php
+++ b/tests/php/LoaderTest.php
@@ -234,8 +234,15 @@ class LoaderTest extends TestCase {
 	 */
 
 	public function test_run_flushes_buffered_hooks_through_wordpress() {
-		$filter_component = new stdClass();
-		$action_component = new stdClass();
+		// Real objects with real methods, because the [object, method] tuples passed to
+		// WP_Mock::expectFilterAdded()/expectActionAdded() below must be genuine callables
+		// per their docblock type; WP_Mock never actually invokes them.
+		$filter_component = new class() {
+			public function filter_cb() {}
+		};
+		$action_component = new class() {
+			public function action_cb() {}
+		};
 
 		$this->loader->add_filter( 'the_content', $filter_component, 'filter_cb', 20, 2 );
 		$this->loader->add_action( 'init', $action_component, 'action_cb' );

--- a/tests/php/LoaderTest.php
+++ b/tests/php/LoaderTest.php
@@ -1,0 +1,350 @@
+<?php
+/**
+ * Tests for includes/class-disable-blog-loader.php.
+ *
+ * @package DisableBlog
+ */
+
+/**
+ * A minimal stand-in for the real WP_Hook object that Disable_Blog_Loader::remove_filter()
+ * reads via the global $wp_filter. Only exposes what the source actually touches:
+ * a $callbacks array keyed by priority, and a remove_filter() method.
+ */
+class LoaderTestFakeWpHook {
+
+	/**
+	 * Callbacks keyed by priority, each shaped like WP_Hook::callbacks.
+	 *
+	 * @var array
+	 */
+	public $callbacks = array();
+
+	/**
+	 * Arguments captured from every remove_filter() call made against this fake.
+	 *
+	 * @var array
+	 */
+	public $remove_filter_calls = array();
+
+	/**
+	 * The value remove_filter() should report back.
+	 *
+	 * @var bool
+	 */
+	private $remove_filter_return;
+
+	/**
+	 * @param bool $remove_filter_return The value remove_filter() should report back.
+	 */
+	public function __construct( $remove_filter_return = true ) {
+		$this->remove_filter_return = $remove_filter_return;
+	}
+
+	/**
+	 * Records the call and reports back the configured result, like WP_Hook::remove_filter().
+	 *
+	 * @param string $tag                The hook name.
+	 * @param array  $function_to_remove The [object, method] callback being removed.
+	 * @param int    $priority           The priority it was registered at.
+	 * @return bool
+	 */
+	public function remove_filter( $tag, $function_to_remove, $priority ) {
+		$this->remove_filter_calls[] = array( $tag, $function_to_remove, $priority );
+
+		return $this->remove_filter_return;
+	}
+}
+
+/**
+ * A throwaway component class used only so remove_filter()'s instanceof check has
+ * something concrete to compare against.
+ */
+class LoaderTestFakeComponent {
+
+	/**
+	 * A stand-in callback method; never actually invoked by the tests.
+	 */
+	public function my_method() {}
+}
+
+/**
+ * @covers Disable_Blog_Loader
+ */
+class LoaderTest extends TestCase {
+
+	/**
+	 * The loader instance under test.
+	 *
+	 * @var Disable_Blog_Loader
+	 */
+	private $loader;
+
+	/**
+	 * $wp_filter as it stood before the test, so it can be restored in tear_down().
+	 *
+	 * @var mixed
+	 */
+	private $original_wp_filter;
+
+	protected function set_up() {
+		parent::set_up();
+
+		$this->loader = new Disable_Blog_Loader();
+
+		global $wp_filter;
+		$this->original_wp_filter = $wp_filter ?? null;
+	}
+
+	protected function tear_down() {
+		global $wp_filter;
+		$wp_filter = $this->original_wp_filter;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Reads a protected property off the loader via Reflection.
+	 *
+	 * @param string $name Property name.
+	 * @return mixed
+	 */
+	private function get_loader_property( $name ) {
+		$property = new ReflectionProperty( Disable_Blog_Loader::class, $name );
+		$property->setAccessible( true );
+
+		return $property->getValue( $this->loader );
+	}
+
+	/**
+	 * The directory the real class-disable-blog-loader.php file lives in, computed the
+	 * same way __DIR__ resolves inside that file, so the plugin_dir_path() stub can be
+	 * asserted against the exact argument the source passes.
+	 *
+	 * @return string
+	 */
+	private function includes_dir() {
+		return dirname( __DIR__, 2 ) . '/includes';
+	}
+
+	/**
+	 * autoloader()
+	 */
+
+	/**
+	 * A requested class whose mapped filename exists in includes/ must be included, making
+	 * the class available. Disable_Blog_Functions is deliberately not required by the test
+	 * bootstrap so this is the first and only place it gets loaded (a second autoloader()
+	 * call for the same class would fatal on redeclaration).
+	 */
+	public function test_autoloader_includes_file_for_a_class_it_should_load() {
+		$includes_dir = $this->includes_dir();
+
+		WP_Mock::userFunction( 'plugin_dir_path' )
+			->once()
+			->with( $includes_dir )
+			->andReturn( dirname( $includes_dir ) . '/' );
+
+		$this->assertFalse( class_exists( 'Disable_Blog_Functions', false ) );
+
+		$this->loader->autoloader( 'Disable_Blog_Functions' );
+
+		$this->assertTrue( class_exists( 'Disable_Blog_Functions', false ) );
+	}
+
+	/**
+	 * A class name that maps to no file under includes/ must be silently ignored: no error,
+	 * and the class never becomes defined.
+	 */
+	public function test_autoloader_ignores_a_class_with_no_matching_file() {
+		$includes_dir = $this->includes_dir();
+
+		WP_Mock::userFunction( 'plugin_dir_path' )
+			->once()
+			->with( $includes_dir )
+			->andReturn( dirname( $includes_dir ) . '/' );
+
+		$this->loader->autoloader( 'Totally_Unrelated_Non_Plugin_Class' );
+
+		$this->assertFalse( class_exists( 'Totally_Unrelated_Non_Plugin_Class', false ) );
+	}
+
+	/**
+	 * add_action() / add_filter()
+	 */
+
+	public function test_add_action_buffers_the_tuple_with_default_priority_and_args() {
+		$component = new stdClass();
+
+		$this->loader->add_action( 'init', $component, 'my_callback' );
+
+		$this->assertSame(
+			array(
+				array(
+					'hook'          => 'init',
+					'component'     => $component,
+					'callback'      => 'my_callback',
+					'priority'      => 10,
+					'accepted_args' => 1,
+				),
+			),
+			$this->get_loader_property( 'actions' )
+		);
+	}
+
+	public function test_add_filter_buffers_the_tuple_with_explicit_priority_and_args() {
+		$component = new stdClass();
+
+		$this->loader->add_filter( 'the_content', $component, 'my_filter', 20, 3 );
+
+		$this->assertSame(
+			array(
+				array(
+					'hook'          => 'the_content',
+					'component'     => $component,
+					'callback'      => 'my_filter',
+					'priority'      => 20,
+					'accepted_args' => 3,
+				),
+			),
+			$this->get_loader_property( 'filters' )
+		);
+	}
+
+	public function test_add_action_and_add_filter_append_independently_without_disturbing_each_other() {
+		$component = new stdClass();
+
+		$this->loader->add_filter( 'the_content', $component, 'filter_one' );
+		$this->loader->add_action( 'init', $component, 'action_one' );
+		$this->loader->add_filter( 'the_title', $component, 'filter_two', 5, 2 );
+
+		$this->assertCount( 2, $this->get_loader_property( 'filters' ) );
+		$this->assertCount( 1, $this->get_loader_property( 'actions' ) );
+	}
+
+	/**
+	 * run()
+	 */
+
+	public function test_run_flushes_buffered_hooks_through_wordpress() {
+		$filter_component = new stdClass();
+		$action_component = new stdClass();
+
+		$this->loader->add_filter( 'the_content', $filter_component, 'filter_cb', 20, 2 );
+		$this->loader->add_action( 'init', $action_component, 'action_cb' );
+
+		WP_Mock::expectFilterAdded( 'the_content', array( $filter_component, 'filter_cb' ), 20, 2 );
+		WP_Mock::expectActionAdded( 'init', array( $action_component, 'action_cb' ), 10, 1 );
+
+		$this->loader->run();
+
+		WP_Mock::assertHooksAdded();
+	}
+
+	/**
+	 * remove_filter() / remove_action()
+	 */
+
+	public function test_remove_filter_removes_matching_callback_at_matching_priority() {
+		$component = new LoaderTestFakeComponent();
+		$hook      = new LoaderTestFakeWpHook( true );
+		$hook->callbacks[10] = array(
+			array( 'function' => array( $component, 'my_method' ) ),
+		);
+
+		global $wp_filter;
+		$wp_filter = array( 'some_tag' => $hook );
+
+		$result = $this->loader->remove_filter( 'some_tag', LoaderTestFakeComponent::class, 'my_method', 10 );
+
+		$this->assertTrue( $result );
+		$this->assertSame(
+			array( array( 'some_tag', array( $component, 'my_method' ), 10 ) ),
+			$hook->remove_filter_calls
+		);
+	}
+
+	public function test_remove_filter_defaults_to_priority_ten() {
+		$component = new LoaderTestFakeComponent();
+		$hook      = new LoaderTestFakeWpHook( true );
+		$hook->callbacks[10] = array(
+			array( 'function' => array( $component, 'my_method' ) ),
+		);
+
+		global $wp_filter;
+		$wp_filter = array( 'some_tag' => $hook );
+
+		// Priority omitted: must still match the default-priority-10 callback.
+		$result = $this->loader->remove_filter( 'some_tag', LoaderTestFakeComponent::class, 'my_method' );
+
+		$this->assertTrue( $result );
+		$this->assertCount( 1, $hook->remove_filter_calls );
+	}
+
+	public function test_remove_filter_returns_false_when_priority_does_not_match() {
+		$component = new LoaderTestFakeComponent();
+		$hook      = new LoaderTestFakeWpHook( true );
+		$hook->callbacks[20] = array(
+			array( 'function' => array( $component, 'my_method' ) ),
+		);
+
+		global $wp_filter;
+		$wp_filter = array( 'some_tag' => $hook );
+
+		$result = $this->loader->remove_filter( 'some_tag', LoaderTestFakeComponent::class, 'my_method', 10 );
+
+		$this->assertFalse( $result );
+		$this->assertSame( array(), $hook->remove_filter_calls );
+	}
+
+	public function test_remove_filter_returns_false_when_method_name_does_not_match() {
+		$component = new LoaderTestFakeComponent();
+		$hook      = new LoaderTestFakeWpHook( true );
+		$hook->callbacks[10] = array(
+			array( 'function' => array( $component, 'a_different_method' ) ),
+		);
+
+		global $wp_filter;
+		$wp_filter = array( 'some_tag' => $hook );
+
+		$result = $this->loader->remove_filter( 'some_tag', LoaderTestFakeComponent::class, 'my_method', 10 );
+
+		$this->assertFalse( $result );
+		$this->assertSame( array(), $hook->remove_filter_calls );
+	}
+
+	public function test_remove_filter_returns_false_when_component_is_not_instance_of_class_name() {
+		$component = new LoaderTestFakeComponent();
+		$hook      = new LoaderTestFakeWpHook( true );
+		$hook->callbacks[10] = array(
+			array( 'function' => array( $component, 'my_method' ) ),
+		);
+
+		global $wp_filter;
+		$wp_filter = array( 'some_tag' => $hook );
+
+		// stdClass is unrelated to LoaderTestFakeComponent, so the instanceof check fails.
+		$result = $this->loader->remove_filter( 'some_tag', stdClass::class, 'my_method', 10 );
+
+		$this->assertFalse( $result );
+		$this->assertSame( array(), $hook->remove_filter_calls );
+	}
+
+	public function test_remove_action_delegates_to_remove_filter_with_the_same_arguments() {
+		$component = new LoaderTestFakeComponent();
+		$hook      = new LoaderTestFakeWpHook( true );
+		$hook->callbacks[10] = array(
+			array( 'function' => array( $component, 'my_method' ) ),
+		);
+
+		global $wp_filter;
+		$wp_filter = array( 'some_tag' => $hook );
+
+		$result = $this->loader->remove_action( 'some_tag', LoaderTestFakeComponent::class, 'my_method', 10 );
+
+		$this->assertTrue( $result );
+		$this->assertSame(
+			array( array( 'some_tag', array( $component, 'my_method' ), 10 ) ),
+			$hook->remove_filter_calls
+		);
+	}
+}

--- a/tests/php/LoaderTest.php
+++ b/tests/php/LoaderTest.php
@@ -133,8 +133,16 @@ class LoaderTest extends TestCase {
 	/**
 	 * A requested class whose mapped filename exists in includes/ must be included, making
 	 * the class available. Disable_Blog_Functions is deliberately not required by the test
-	 * bootstrap so this is the first and only place it gets loaded (a second autoloader()
-	 * call for the same class would fatal on redeclaration).
+	 * bootstrap, so it starts undefined in a fresh process -- but DisableBlogFunctionsTest.php
+	 * and DisableBlogTest.php both require it directly (outside bootstrap.php) to exercise it,
+	 * and PHPUnit's suite discovery loads every *Test.php file up front regardless of run
+	 * order. Isolated so this test's "not yet defined" assumption holds regardless: the
+	 * child process only re-runs bootstrap.php plus this file, neither of which loads it (a
+	 * second, non-include_once autoloader() include of an already-declared class would fatal
+	 * on redeclaration).
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
 	public function test_autoloader_includes_file_for_a_class_it_should_load() {
 		$includes_dir = $this->includes_dir();

--- a/tests/php/PublicFeedsTest.php
+++ b/tests/php/PublicFeedsTest.php
@@ -1,0 +1,401 @@
+<?php
+/**
+ * Tests for Disable_Blog_Public's feed surface: disable_feed(), its private
+ * is_post_feed_request() helper, feed_links_show_posts_feed(),
+ * feed_links_show_comments_feed() and header_feeds().
+ *
+ * @package DisableBlog
+ */
+
+// Not required by tests/php/bootstrap.php on purpose (see ConstructorInjectionTest.php's note;
+// LoaderTest's autoloader test needs Disable_Blog_Functions to remain undefined until its own
+// isolated process). require_once is safe regardless of which test file happens to load first.
+require_once __DIR__ . '/../../includes/class-disable-blog-functions.php';
+require_once __DIR__ . '/Support/fixtures/class-public-functions-double.php';
+
+/**
+ * @covers Disable_Blog_Public::disable_feed
+ * @covers Disable_Blog_Public::is_post_feed_request
+ * @covers Disable_Blog_Public::feed_links_show_posts_feed
+ * @covers Disable_Blog_Public::feed_links_show_comments_feed
+ * @covers Disable_Blog_Public::header_feeds
+ */
+class PublicFeedsTest extends TestCase {
+
+	/**
+	 * The global $post as it stood before the test, so it can be restored in tear_down().
+	 *
+	 * @var mixed
+	 */
+	private $original_post;
+
+	/**
+	 * The global $wp as it stood before the test, so it can be restored in tear_down().
+	 *
+	 * @var mixed
+	 */
+	private $original_wp;
+
+	protected function set_up() {
+		parent::set_up();
+
+		global $post, $wp;
+		$this->original_post = $post ?? null;
+		$this->original_wp   = $wp ?? null;
+		$post                = null;
+	}
+
+	protected function tear_down() {
+		global $post, $wp;
+		$post = $this->original_post;
+		$wp   = $this->original_wp;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Invokes the private is_post_feed_request() method via Reflection.
+	 *
+	 * @param Disable_Blog_Public $public Instance to invoke on.
+	 * @return bool
+	 */
+	private function invoke_is_post_feed_request( Disable_Blog_Public $public ) {
+		$reflection = new ReflectionMethod( $public, 'is_post_feed_request' );
+		$reflection->setAccessible( true );
+
+		return $reflection->invoke( $public );
+	}
+
+	/**
+	 * Forces dwpb_post_types_with_feature( $feature ) to return $return_value, via the
+	 * dwpb_post_types_supporting_{$feature} filter that always applies to its computed result.
+	 *
+	 * @param string     $feature      The feature slug (e.g. 'comments').
+	 * @param array|bool $return_value The value dwpb_post_types_with_feature() should return.
+	 * @return void
+	 */
+	private function stub_post_types_with_feature_result( $feature, $return_value ) {
+		WP_Mock::userFunction( 'esc_attr' )->with( $feature )->andReturn( $feature );
+		WP_Mock::userFunction( 'wp_cache_get' )->andReturn( false );
+		WP_Mock::userFunction( 'get_post_types' )->andReturn( array() );
+		WP_Mock::userFunction( 'wp_cache_set' )->andReturn( null );
+		WP_Mock::onFilter( "dwpb_post_types_supporting_{$feature}" )->with( false, array() )->reply( $return_value );
+	}
+
+	/**
+	 * The `$allowed_html` array wp_kses() is called with in the wp_die() message branch,
+	 * exactly as built in the source.
+	 *
+	 * @return array
+	 */
+	private function allowed_feed_html() {
+		return array(
+			'a' => array(
+				'href' => array(),
+				'name' => array(),
+				'id'   => array(),
+			),
+		);
+	}
+
+	/**
+	 * disable_feed()
+	 */
+
+	/**
+	 * A comment feed must bail before ever touching $this->functions when another post type
+	 * still supports comments.
+	 */
+	public function test_disable_feed_returns_early_for_comment_feed_when_other_post_types_support_comments() {
+		$this->stub_post_types_with_feature_result( 'comments', array( 'book' ) );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->disable_feed( true );
+
+		$this->assertSame( array(), $functions->redirect_calls );
+	}
+
+	/**
+	 * A post feed ($is_comment_feed = false) must never call dwpb_post_types_with_feature() at
+	 * all -- if it did, the un-mocked WordPress functions inside it would fatal here.
+	 */
+	public function test_disable_feed_post_feed_never_checks_post_types_with_feature() {
+		$functions                     = new Disable_Blog_Public_Functions_Double();
+		$functions->disable_feeds_return = false;
+		$public                         = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->disable_feed( false );
+
+		$this->assertSame( array(), $functions->redirect_calls );
+	}
+
+	public function test_disable_feed_does_nothing_when_functions_disable_feeds_returns_false() {
+		$this->stub_post_types_with_feature_result( 'comments', false );
+
+		$functions                     = new Disable_Blog_Public_Functions_Double();
+		$functions->disable_feeds_return = false;
+		$public                         = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->disable_feed( true );
+
+		$this->assertSame( array(), $functions->redirect_calls );
+	}
+
+	public function test_disable_feed_does_nothing_when_not_a_post_feed_request() {
+		global $wp;
+		// A singular query var makes is_post_feed_request() false.
+		$wp = (object) array( 'query_vars' => array( 'p' => 5 ) );
+
+		$functions                     = new Disable_Blog_Public_Functions_Double();
+		$functions->disable_feeds_return = true;
+		$public                         = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->disable_feed( false );
+
+		$this->assertSame( array(), $functions->redirect_calls );
+	}
+
+	/**
+	 * Default behaviour: redirect() is called with the unfiltered home_url(), and neither the
+	 * dwpb_feed_message toggle nor wp_die() is reached.
+	 */
+	public function test_disable_feed_redirects_to_home_url_by_default() {
+		global $wp;
+		// Non-empty, no singular query var, no post_type: is_post_feed_request() defaults true.
+		$wp = (object) array( 'query_vars' => array( 'feed' => 'feed' ) );
+
+		WP_Mock::userFunction( 'home_url' )->once()->andReturn( 'https://example.test/' );
+		WP_Mock::onFilter( 'dwpb_redirect_feeds' )->with( 'https://example.test/', null, false )->reply( 'https://example.test/' );
+		WP_Mock::onFilter( 'dwpb_feed_message' )->with( false, null, false )->reply( false );
+
+		$functions                     = new Disable_Blog_Public_Functions_Double();
+		$functions->disable_feeds_return = true;
+		$public                         = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->disable_feed( false );
+
+		$this->assertSame( array( 'https://example.test/' ), $functions->redirect_calls );
+	}
+
+	/**
+	 * The dwpb_redirect_feeds filter must be able to override the url that reaches redirect().
+	 */
+	public function test_disable_feed_dwpb_redirect_feeds_filter_overrides_url() {
+		$this->stub_post_types_with_feature_result( 'comments', false );
+
+		global $post, $wp;
+		$post = new WP_Post();
+		$wp   = (object) array( 'query_vars' => array( 'feed' => 'feed' ) );
+
+		WP_Mock::userFunction( 'home_url' )->once()->andReturn( 'https://example.test/' );
+		WP_Mock::onFilter( 'dwpb_redirect_feeds' )
+			->with( 'https://example.test/', $post, true )
+			->reply( 'https://example.test/custom-feed-redirect/' );
+		WP_Mock::onFilter( 'dwpb_feed_message' )->with( false, $post, true )->reply( false );
+
+		$functions                     = new Disable_Blog_Public_Functions_Double();
+		$functions->disable_feeds_return = true;
+		$public                         = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->disable_feed( true );
+
+		$this->assertSame( array( 'https://example.test/custom-feed-redirect/' ), $functions->redirect_calls );
+	}
+
+	/**
+	 * dwpb_feed_message toggled true: wp_die() is reached (via the globally-throwing wp_die()
+	 * polyfill) instead of a redirect, carrying the default constructed message.
+	 */
+	public function test_disable_feed_dwpb_feed_message_true_reaches_wp_die_with_default_message() {
+		global $wp;
+		$wp = (object) array( 'query_vars' => array( 'feed' => 'feed' ) );
+
+		WP_Mock::userFunction( 'home_url' )->once()->andReturn( 'https://example.test/' );
+		WP_Mock::onFilter( 'dwpb_redirect_feeds' )->with( 'https://example.test/', null, false )->reply( 'https://example.test/' );
+		WP_Mock::onFilter( 'dwpb_feed_message' )->with( false, null, false )->reply( true );
+		WP_Mock::userFunction( 'esc_url_raw' )->with( 'https://example.test/' )->andReturn( 'https://example.test/' );
+
+		$expected_message = 'No feed available, please visit our homepage:: <a href="https://example.test/">https://example.test/</a>';
+
+		WP_Mock::onFilter( 'dwpb_feed_die_message' )->with( $expected_message )->reply( $expected_message );
+
+		WP_Mock::userFunction( 'wp_kses' )
+			->once()
+			->with( $expected_message, $this->allowed_feed_html() )
+			->andReturn( $expected_message );
+
+		$functions                     = new Disable_Blog_Public_Functions_Double();
+		$functions->disable_feeds_return = true;
+		$public                         = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( $expected_message );
+
+		$public->disable_feed( false );
+	}
+
+	/**
+	 * The dwpb_feed_die_message filter must be able to override the message wp_die() receives.
+	 */
+	public function test_disable_feed_dwpb_feed_die_message_filter_overrides_message() {
+		global $wp;
+		$wp = (object) array( 'query_vars' => array( 'feed' => 'feed' ) );
+
+		WP_Mock::userFunction( 'home_url' )->once()->andReturn( 'https://example.test/' );
+		WP_Mock::onFilter( 'dwpb_redirect_feeds' )->with( 'https://example.test/', null, false )->reply( 'https://example.test/' );
+		WP_Mock::onFilter( 'dwpb_feed_message' )->with( false, null, false )->reply( true );
+		WP_Mock::userFunction( 'esc_url_raw' )->with( 'https://example.test/' )->andReturn( 'https://example.test/' );
+
+		$default_message  = 'No feed available, please visit our homepage:: <a href="https://example.test/">https://example.test/</a>';
+		$expected_message = 'Custom feed removal notice.';
+
+		WP_Mock::onFilter( 'dwpb_feed_die_message' )->with( $default_message )->reply( $expected_message );
+
+		WP_Mock::userFunction( 'wp_kses' )
+			->once()
+			->with( $expected_message, $this->allowed_feed_html() )
+			->andReturn( $expected_message );
+
+		$functions                     = new Disable_Blog_Public_Functions_Double();
+		$functions->disable_feeds_return = true;
+		$public                         = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( $expected_message );
+
+		$public->disable_feed( false );
+	}
+
+	/**
+	 * is_post_feed_request() (private)
+	 */
+
+	public function test_is_post_feed_request_false_when_query_vars_empty() {
+		global $wp;
+		$wp = (object) array( 'query_vars' => array() );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $this->invoke_is_post_feed_request( $public ) );
+	}
+
+	public function test_is_post_feed_request_false_when_query_vars_not_an_array() {
+		global $wp;
+		$wp = (object) array( 'query_vars' => 'not-an-array' );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $this->invoke_is_post_feed_request( $public ) );
+	}
+
+	/**
+	 * Any of the singular-object query vars present means this isn't the general 'post' feed.
+	 */
+	public function test_is_post_feed_request_false_when_any_singular_query_var_present() {
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		global $wp;
+		foreach ( array( 'p', 'name', 'pagename', 'page_id', 'attachment', 'attachment_id' ) as $var ) {
+			$wp = (object) array( 'query_vars' => array( $var => 'some-value' ) );
+
+			$this->assertFalse(
+				$this->invoke_is_post_feed_request( $public ),
+				"Expected false when the '{$var}' query var is present."
+			);
+		}
+	}
+
+	public function test_is_post_feed_request_true_when_post_type_query_var_absent() {
+		global $wp;
+		$wp = (object) array( 'query_vars' => array( 'paged' => 2 ) );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $this->invoke_is_post_feed_request( $public ) );
+	}
+
+	public function test_is_post_feed_request_true_when_post_type_array_contains_post() {
+		global $wp;
+		$wp = (object) array( 'query_vars' => array( 'post_type' => array( 'post', 'page' ) ) );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $this->invoke_is_post_feed_request( $public ) );
+	}
+
+	public function test_is_post_feed_request_false_when_post_type_array_does_not_contain_post() {
+		global $wp;
+		$wp = (object) array( 'query_vars' => array( 'post_type' => array( 'page', 'book' ) ) );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $this->invoke_is_post_feed_request( $public ) );
+	}
+
+	public function test_is_post_feed_request_true_when_post_type_string_is_post() {
+		global $wp;
+		$wp = (object) array( 'query_vars' => array( 'post_type' => 'post' ) );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $this->invoke_is_post_feed_request( $public ) );
+	}
+
+	public function test_is_post_feed_request_false_when_post_type_string_is_not_post() {
+		global $wp;
+		$wp = (object) array( 'query_vars' => array( 'post_type' => 'page' ) );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $this->invoke_is_post_feed_request( $public ) );
+	}
+
+	/**
+	 * feed_links_show_posts_feed()
+	 */
+
+	public function test_feed_links_show_posts_feed_always_returns_false() {
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $public->feed_links_show_posts_feed( true ) );
+		$this->assertFalse( $public->feed_links_show_posts_feed( false ) );
+	}
+
+	/**
+	 * feed_links_show_comments_feed()
+	 */
+
+	public function test_feed_links_show_comments_feed_disables_link_when_no_other_post_types_support_comments() {
+		$this->stub_post_types_with_feature_result( 'comments', false );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $public->feed_links_show_comments_feed( true ) );
+	}
+
+	public function test_feed_links_show_comments_feed_leaves_link_unchanged_when_other_post_types_support_comments() {
+		$this->stub_post_types_with_feature_result( 'comments', array( 'book' ) );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $public->feed_links_show_comments_feed( true ) );
+		$this->assertFalse( $public->feed_links_show_comments_feed( false ) );
+	}
+
+	/**
+	 * header_feeds()
+	 */
+
+	public function test_header_feeds_removes_all_four_feed_actions_from_wp_head() {
+		WP_Mock::userFunction( 'remove_action' )->once()->with( 'wp_head', 'feed_links', 2 );
+		WP_Mock::userFunction( 'remove_action' )->once()->with( 'wp_head', 'feed_links_extra', 3 );
+		WP_Mock::userFunction( 'remove_action' )->once()->with( 'wp_head', 'rsd_link', 10 );
+		WP_Mock::userFunction( 'remove_action' )->once()->with( 'wp_head', 'wlwmanifest_link', 10 );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertNull( $public->header_feeds() );
+	}
+}

--- a/tests/php/PublicMiscTest.php
+++ b/tests/php/PublicMiscTest.php
@@ -1,0 +1,704 @@
+<?php
+/**
+ * Tests for the remaining Disable_Blog_Public surface: xmlrpc_methods(), its private
+ * get_disabled_xmlrpc_methods() helper, filter_wp_headers(), remove_pingback_header_fallback(),
+ * wp_sitemaps_post_types(), wp_sitemaps_taxonomies(), wp_author_sitemaps() and
+ * disable_removed_sitemaps().
+ *
+ * @package DisableBlog
+ */
+
+// Not required by tests/php/bootstrap.php on purpose (see ConstructorInjectionTest.php's note;
+// LoaderTest's autoloader test needs Disable_Blog_Functions to remain undefined until its own
+// isolated process). require_once is safe regardless of which test file happens to load first.
+require_once __DIR__ . '/../../includes/class-disable-blog-functions.php';
+require_once __DIR__ . '/Support/fixtures/class-public-functions-double.php';
+
+/**
+ * @covers Disable_Blog_Public::xmlrpc_methods
+ * @covers Disable_Blog_Public::get_disabled_xmlrpc_methods
+ * @covers Disable_Blog_Public::filter_wp_headers
+ * @covers Disable_Blog_Public::remove_pingback_header_fallback
+ * @covers Disable_Blog_Public::wp_sitemaps_post_types
+ * @covers Disable_Blog_Public::wp_sitemaps_taxonomies
+ * @covers Disable_Blog_Public::wp_author_sitemaps
+ * @covers Disable_Blog_Public::disable_removed_sitemaps
+ */
+class PublicMiscTest extends TestCase {
+
+	/**
+	 * The global $wp_query as it stood before the test, so it can be restored in tear_down().
+	 *
+	 * @var mixed
+	 */
+	private $original_wp_query;
+
+	protected function set_up() {
+		parent::set_up();
+
+		global $wp_query;
+		$this->original_wp_query = $wp_query ?? null;
+	}
+
+	protected function tear_down() {
+		global $wp_query;
+		$wp_query = $this->original_wp_query;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Invokes the private get_disabled_xmlrpc_methods() method via Reflection.
+	 *
+	 * @param Disable_Blog_Public $public Instance to invoke on.
+	 * @return array|bool
+	 */
+	private function invoke_get_disabled_xmlrpc_methods( Disable_Blog_Public $public ) {
+		$reflection = new ReflectionMethod( $public, 'get_disabled_xmlrpc_methods' );
+		$reflection->setAccessible( true );
+
+		return $reflection->invoke( $public );
+	}
+
+	/**
+	 * The base, taxonomy-independent list of xmlrpc methods get_disabled_xmlrpc_methods()
+	 * always starts from.
+	 *
+	 * @return string[]
+	 */
+	private function base_xmlrpc_methods() {
+		return array(
+			'wp.getUsersBlogs',
+			'wp.newPost',
+			'wp.editPost',
+			'wp.deletePost',
+			'wp.getPost',
+			'wp.getPosts',
+			'blogger.getPost',
+			'blogger.getRecentPosts',
+			'blogger.newPost',
+			'blogger.editPost',
+			'blogger.deletePost',
+			'metaWeblog.newPost',
+			'metaWeblog.editPost',
+			'metaWeblog.getPost',
+			'metaWeblog.getRecentPosts',
+			'metaWeblog.deletePost',
+			'mt.getRecentPostTitles',
+			'mt.getTrackbackPings',
+			'mt.publishPost',
+			'pingback.ping',
+			'pingback.extensions.getPingbacks',
+			'demo.sayHello',
+			'demo.addTwoNumbers',
+		);
+	}
+
+	/**
+	 * The category-taxonomy-specific xmlrpc methods, added only when no other post type uses
+	 * the 'category' taxonomy.
+	 *
+	 * @return string[]
+	 */
+	private function category_xmlrpc_methods() {
+		return array(
+			'wp.newCategory',
+			'wp.deleteCategory',
+			'mt.getCategoryList',
+			'wp.suggestCategories',
+			'mt.getPostCategories',
+			'mt.setPostCategories',
+			'metaWeblog.getCategories',
+		);
+	}
+
+	/**
+	 * The full method list get_disabled_xmlrpc_methods() builds and passes to the
+	 * dwpb_disabled_xmlrpc_methods filter when neither taxonomy is used elsewhere -- the
+	 * category and post_tag stubs every test in this section that needs this uses.
+	 *
+	 * @return string[]
+	 */
+	private function all_xmlrpc_methods() {
+		return array_merge( $this->base_xmlrpc_methods(), $this->category_xmlrpc_methods(), array( 'wp.getTags' ) );
+	}
+
+	/**
+	 * Stubs the WordPress functions dwpb_post_types_with_tax() calls on every invocation,
+	 * regardless of taxonomy or cache state.
+	 *
+	 * @return void
+	 */
+	private function stub_tax_lookup_plumbing() {
+		WP_Mock::userFunction( 'get_post_types' )->with( array(), 'names' )->andReturn( array() );
+		WP_Mock::userFunction( 'wp_cache_get' )->andReturn( false );
+		WP_Mock::userFunction( 'wp_cache_set' )->andReturn( null );
+		WP_Mock::userFunction( 'maybe_serialize' )->with( array() )->andReturn( 'a:0:{}' );
+	}
+
+	/**
+	 * Forces dwpb_post_types_with_tax( $taxonomy ) to return $return_value, via the
+	 * dwpb_taxonomy_support short-circuit filter -- requires stub_tax_lookup_plumbing() to
+	 * have been called first in the same test.
+	 *
+	 * @param string     $taxonomy     The taxonomy slug ('post_tag' or 'category').
+	 * @param array|bool $return_value The value dwpb_post_types_with_tax() should return.
+	 * @return void
+	 */
+	private function stub_post_types_with_tax_result( $taxonomy, $return_value ) {
+		WP_Mock::userFunction( 'esc_attr' )->with( $taxonomy )->andReturn( $taxonomy );
+		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
+			->with( null, $taxonomy, array(), array(), 'names' )
+			->reply( $return_value );
+	}
+
+	/**
+	 * Asserts disable_removed_sitemaps() had no 404 side effect: sets up global $wp_query so a
+	 * set_404() call would fail the test, and rejects any status_header()/nocache_headers() call.
+	 *
+	 * @return void
+	 */
+	private function assert_no_404_side_effects() {
+		global $wp_query;
+		$wp_query = Mockery::mock( 'Disable_Blog_Public_Query_Double' );
+		$wp_query->shouldNotReceive( 'set_404' );
+
+		WP_Mock::userFunction( 'status_header' )->never();
+		WP_Mock::userFunction( 'nocache_headers' )->never();
+	}
+
+	/**
+	 * get_disabled_xmlrpc_methods() (private)
+	 */
+
+	public function test_get_disabled_xmlrpc_methods_includes_taxonomy_methods_when_neither_taxonomy_used_elsewhere() {
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', false );
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+
+		$expected = array_merge( $this->base_xmlrpc_methods(), $this->category_xmlrpc_methods(), array( 'wp.getTags' ) );
+		WP_Mock::onFilter( 'dwpb_disabled_xmlrpc_methods' )->with( $expected )->reply( $expected );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( $expected, $this->invoke_get_disabled_xmlrpc_methods( $public ) );
+	}
+
+	public function test_get_disabled_xmlrpc_methods_omits_category_methods_when_other_post_types_use_category() {
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', array( 'book' ) );
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+
+		$expected = array_merge( $this->base_xmlrpc_methods(), array( 'wp.getTags' ) );
+		WP_Mock::onFilter( 'dwpb_disabled_xmlrpc_methods' )->with( $expected )->reply( $expected );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( $expected, $this->invoke_get_disabled_xmlrpc_methods( $public ) );
+	}
+
+	public function test_get_disabled_xmlrpc_methods_omits_get_tags_when_other_post_types_use_post_tag() {
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', false );
+		$this->stub_post_types_with_tax_result( 'post_tag', array( 'book' ) );
+
+		$expected = array_merge( $this->base_xmlrpc_methods(), $this->category_xmlrpc_methods() );
+		WP_Mock::onFilter( 'dwpb_disabled_xmlrpc_methods' )->with( $expected )->reply( $expected );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( $expected, $this->invoke_get_disabled_xmlrpc_methods( $public ) );
+	}
+
+	public function test_get_disabled_xmlrpc_methods_omits_all_taxonomy_methods_when_both_taxonomies_used_elsewhere() {
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', array( 'book' ) );
+		$this->stub_post_types_with_tax_result( 'post_tag', array( 'book' ) );
+
+		WP_Mock::onFilter( 'dwpb_disabled_xmlrpc_methods' )->with( $this->base_xmlrpc_methods() )->reply( $this->base_xmlrpc_methods() );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( $this->base_xmlrpc_methods(), $this->invoke_get_disabled_xmlrpc_methods( $public ) );
+	}
+
+	/**
+	 * Returning false from dwpb_disabled_xmlrpc_methods disables the functionality entirely.
+	 */
+	public function test_get_disabled_xmlrpc_methods_filter_returning_false_disables_functionality() {
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', false );
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+
+		WP_Mock::onFilter( 'dwpb_disabled_xmlrpc_methods' )->with( $this->all_xmlrpc_methods() )->reply( false );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $this->invoke_get_disabled_xmlrpc_methods( $public ) );
+	}
+
+	/**
+	 * array_filter() preserves keys, so a non-string entry dropped from the middle leaves a gap
+	 * instead of the array being reindexed.
+	 */
+	public function test_get_disabled_xmlrpc_methods_filters_out_non_string_entries() {
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', false );
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+
+		WP_Mock::onFilter( 'dwpb_disabled_xmlrpc_methods' )->with( $this->all_xmlrpc_methods() )->reply( array( 'wp.newPost', 123, 'wp.editPost' ) );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertSame(
+			array( 0 => 'wp.newPost', 2 => 'wp.editPost' ),
+			$this->invoke_get_disabled_xmlrpc_methods( $public )
+		);
+	}
+
+	/**
+	 * xmlrpc_methods()
+	 */
+
+	public function test_xmlrpc_methods_removes_configured_methods_and_keeps_others() {
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', false );
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+
+		WP_Mock::onFilter( 'dwpb_disabled_xmlrpc_methods' )->with( $this->all_xmlrpc_methods() )->reply( array( 'wp.newPost', 'wp.getTags' ) );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$methods = array(
+			'wp.newPost'  => 'callback_a',
+			'wp.getTags'  => 'callback_b',
+			'wp.getUsers' => 'callback_c',
+		);
+
+		$this->assertSame(
+			array( 'wp.getUsers' => 'callback_c' ),
+			$public->xmlrpc_methods( $methods )
+		);
+	}
+
+	public function test_xmlrpc_methods_returns_methods_unchanged_when_none_to_remove_are_present() {
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', false );
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+
+		WP_Mock::onFilter( 'dwpb_disabled_xmlrpc_methods' )->with( $this->all_xmlrpc_methods() )->reply( array( 'wp.newPost' ) );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$methods = array( 'wp.getUsers' => 'callback_c' );
+
+		$this->assertSame( $methods, $public->xmlrpc_methods( $methods ) );
+	}
+
+	/**
+	 * filter_wp_headers()
+	 */
+
+	public function test_filter_wp_headers_removes_pingback_header_by_default() {
+		WP_Mock::onFilter( 'dwpb_remove_pingback_header' )->with( true )->reply( true );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$headers = array(
+			'X-Pingback' => 'https://example.test/xmlrpc.php',
+			'Other'      => 'value',
+		);
+
+		$this->assertSame( array( 'Other' => 'value' ), $public->filter_wp_headers( $headers ) );
+	}
+
+	public function test_filter_wp_headers_dwpb_remove_pingback_header_filter_false_keeps_header() {
+		WP_Mock::onFilter( 'dwpb_remove_pingback_header' )->with( true )->reply( false );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$headers = array( 'X-Pingback' => 'https://example.test/xmlrpc.php' );
+
+		$this->assertSame( $headers, $public->filter_wp_headers( $headers ) );
+	}
+
+	public function test_filter_wp_headers_noop_when_pingback_header_absent() {
+		WP_Mock::onFilter( 'dwpb_remove_pingback_header' )->with( true )->reply( true );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$headers = array( 'Other' => 'value' );
+
+		$this->assertSame( $headers, $public->filter_wp_headers( $headers ) );
+	}
+
+	/**
+	 * remove_pingback_header_fallback()
+	 */
+
+	public function test_remove_pingback_header_fallback_returns_early_when_filter_disables_it() {
+		WP_Mock::onFilter( 'dwpb_remove_pingback_header' )->with( true )->reply( false );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		// The early return means headers_sent()/header_remove() below it are never reached; both
+		// are genuine internal PHP functions WP_Mock/Patchwork refuses to override ("Cannot
+		// override internal PHP functions!"), so unlike every other WP function in this suite,
+		// they can't be stubbed with a ->never() expectation to prove that directly.
+		$this->assertNull( $public->remove_pingback_header_fallback() );
+	}
+
+	/**
+	 * headers_sent() and header_remove() are both genuine internal PHP functions, so neither can
+	 * be stubbed via WP_Mock (see the note above) -- there is no way, short of a source change
+	 * adding an injectable seam, to simulate the "not yet sent" branch that would call
+	 * header_remove(). By the time any PHPUnit test runs, PHPUnit's own CLI banner output has
+	 * already made the real headers_sent() report true for the rest of the process, so this
+	 * exercises the real "already sent" branch for real rather than simulating it.
+	 */
+	public function test_remove_pingback_header_fallback_skips_header_remove_once_headers_have_actually_been_sent() {
+		$this->assertTrue( headers_sent(), "Expected PHPUnit's own CLI output to have already marked headers as sent." );
+
+		WP_Mock::onFilter( 'dwpb_remove_pingback_header' )->with( true )->reply( true );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertNull( $public->remove_pingback_header_fallback() );
+	}
+
+	/**
+	 * Isolated: a fresh process has produced no output yet, so headers_sent() genuinely starts
+	 * false here -- unlike the shared-process test above, this reaches the real
+	 * header_remove( 'X-Pingback' ) call rather than skipping it. header_remove() is a real
+	 * internal PHP function with no observable return value or (in the CLI SAPI used by this
+	 * suite) any readable header list, so there is nothing further to assert about its effect;
+	 * this test's purpose is exercising that line for real, not proving its side effect.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_remove_pingback_header_fallback_calls_header_remove_when_headers_not_yet_sent() {
+		$this->assertFalse( headers_sent(), 'Expected a fresh process to not have sent headers yet.' );
+
+		WP_Mock::onFilter( 'dwpb_remove_pingback_header' )->with( true )->reply( true );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertNull( $public->remove_pingback_header_fallback() );
+	}
+
+	/**
+	 * wp_sitemaps_post_types()
+	 */
+
+	public function test_wp_sitemaps_post_types_removes_post_key() {
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$result = $public->wp_sitemaps_post_types(
+			array(
+				'post' => 'PostType',
+				'page' => 'PageType',
+			)
+		);
+
+		$this->assertSame( array( 'page' => 'PageType' ), $result );
+	}
+
+	public function test_wp_sitemaps_post_types_unchanged_when_post_key_absent() {
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$input = array( 'page' => 'PageType' );
+
+		$this->assertSame( $input, $public->wp_sitemaps_post_types( $input ) );
+	}
+
+	/**
+	 * wp_sitemaps_taxonomies()
+	 */
+
+	public function test_wp_sitemaps_taxonomies_removes_both_when_neither_used_by_other_post_types() {
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+		$this->stub_post_types_with_tax_result( 'category', false );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$result = $public->wp_sitemaps_taxonomies(
+			array(
+				'post_tag'    => 'a',
+				'category'    => 'b',
+				'post_format' => 'c',
+			)
+		);
+
+		$this->assertSame( array( 'post_format' => 'c' ), $result );
+	}
+
+	public function test_wp_sitemaps_taxonomies_keeps_category_when_other_post_types_use_it() {
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+		$this->stub_post_types_with_tax_result( 'category', array( 'book' ) );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$result = $public->wp_sitemaps_taxonomies(
+			array(
+				'post_tag' => 'a',
+				'category' => 'b',
+			)
+		);
+
+		$this->assertSame( array( 'category' => 'b' ), $result );
+	}
+
+	/**
+	 * The isset() guard must skip the lookup entirely for a taxonomy key not present in the
+	 * input -- if dwpb_post_types_with_tax( 'category' ) were called anyway, the un-mocked
+	 * esc_attr( 'category' ) call inside it would fatal here.
+	 */
+	public function test_wp_sitemaps_taxonomies_skips_lookup_for_taxonomy_key_not_present() {
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$result = $public->wp_sitemaps_taxonomies( array( 'post_tag' => 'a' ) );
+
+		$this->assertSame( array(), $result );
+	}
+
+	/**
+	 * wp_author_sitemaps()
+	 */
+
+	public function test_wp_author_sitemaps_returns_provider_unchanged_when_name_is_not_users() {
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+		$provider  = new stdClass();
+
+		$this->assertSame( $provider, $public->wp_author_sitemaps( $provider, 'posts' ) );
+	}
+
+	public function test_wp_author_sitemaps_returns_false_when_disable_author_archives_true() {
+		$functions                                   = new Disable_Blog_Public_Functions_Double();
+		$functions->disable_author_archives_return = true;
+		$public                                       = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		WP_Mock::onFilter( 'dwpb_disable_user_sitemap' )->with( true )->reply( true );
+
+		$this->assertFalse( $public->wp_author_sitemaps( new stdClass(), 'users' ) );
+	}
+
+	public function test_wp_author_sitemaps_returns_false_when_no_post_types_support_author_archives() {
+		$functions                                     = new Disable_Blog_Public_Functions_Double();
+		$functions->disable_author_archives_return   = false;
+		$functions->author_archive_post_types_return = false;
+		$public                                         = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		WP_Mock::onFilter( 'dwpb_disable_user_sitemap' )->with( true )->reply( true );
+
+		$this->assertFalse( $public->wp_author_sitemaps( new stdClass(), 'users' ) );
+	}
+
+	public function test_wp_author_sitemaps_returns_provider_when_post_types_support_author_archives() {
+		$functions                                     = new Disable_Blog_Public_Functions_Double();
+		$functions->disable_author_archives_return   = false;
+		$functions->author_archive_post_types_return = array( 'book' );
+		$public                                         = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		WP_Mock::onFilter( 'dwpb_disable_user_sitemap' )->with( false )->reply( false );
+
+		$provider = new stdClass();
+
+		$this->assertSame( $provider, $public->wp_author_sitemaps( $provider, 'users' ) );
+	}
+
+	/**
+	 * The dwpb_disable_user_sitemap filter must be able to force the sitemap off even though
+	 * the computed default would have kept it.
+	 */
+	public function test_wp_author_sitemaps_dwpb_disable_user_sitemap_filter_can_force_disable() {
+		$functions                                     = new Disable_Blog_Public_Functions_Double();
+		$functions->disable_author_archives_return   = false;
+		$functions->author_archive_post_types_return = array( 'book' );
+		$public                                         = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		WP_Mock::onFilter( 'dwpb_disable_user_sitemap' )->with( false )->reply( true );
+
+		$this->assertFalse( $public->wp_author_sitemaps( new stdClass(), 'users' ) );
+	}
+
+	/**
+	 * The dwpb_disable_user_sitemap filter must be able to force the sitemap back on even
+	 * though the computed default would have disabled it.
+	 */
+	public function test_wp_author_sitemaps_dwpb_disable_user_sitemap_filter_can_force_enable() {
+		$functions                                   = new Disable_Blog_Public_Functions_Double();
+		$functions->disable_author_archives_return = true;
+		$public                                       = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		WP_Mock::onFilter( 'dwpb_disable_user_sitemap' )->with( true )->reply( false );
+
+		$provider = new stdClass();
+
+		$this->assertSame( $provider, $public->wp_author_sitemaps( $provider, 'users' ) );
+	}
+
+	/**
+	 * disable_removed_sitemaps()
+	 */
+
+	public function test_disable_removed_sitemaps_returns_early_when_sitemap_query_var_empty() {
+		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap', '' )->andReturn( '' );
+		$this->assert_no_404_side_effects();
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertNull( $public->disable_removed_sitemaps() );
+	}
+
+	/**
+	 * Isolated, with a real registry in place (so a mutated guard would fall through all the
+	 * way to the provider check below): 'index' is never a registered provider name, so if the
+	 * 'index' exclusion itself were dropped, isset( $providers['index'] ) would be false and
+	 * this would 404 instead of returning early. Proves the 'index' check specifically, rather
+	 * than incidentally passing via the sibling "wp_sitemaps_get_server undefined" guard.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_disable_removed_sitemaps_returns_early_when_sitemap_is_index() {
+		require_once __DIR__ . '/Support/fixtures/class-wp-sitemaps-stub.php';
+
+		function wp_sitemaps_get_server() {
+			return new WP_Sitemaps( new WP_Sitemaps_Registry( array( 'posts' => new stdClass() ) ) );
+		}
+
+		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap', '' )->andReturn( 'index' );
+		$this->assert_no_404_side_effects();
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertNull( $public->disable_removed_sitemaps() );
+	}
+
+	/**
+	 * wp_sitemaps_get_server() is a WordPress core function this test environment never
+	 * defines, so function_exists() naturally reports false here.
+	 */
+	public function test_disable_removed_sitemaps_returns_early_when_wp_sitemaps_get_server_undefined() {
+		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap', '' )->andReturn( 'posts' );
+		WP_Mock::onFilter( 'dwpb_disable_removed_sitemaps' )->with( true )->reply( true );
+		$this->assert_no_404_side_effects();
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertNull( $public->disable_removed_sitemaps() );
+	}
+
+	/**
+	 * Isolated: declares the global wp_sitemaps_get_server() function, which cannot be
+	 * undeclared afterward and would otherwise make function_exists() report true for every
+	 * later test, including the "undefined" case above.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_disable_removed_sitemaps_returns_early_when_server_is_not_a_wp_sitemaps_instance() {
+		function wp_sitemaps_get_server() {
+			return new stdClass();
+		}
+
+		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap', '' )->andReturn( 'users' );
+		WP_Mock::onFilter( 'dwpb_disable_removed_sitemaps' )->with( true )->reply( true );
+		$this->assert_no_404_side_effects();
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertNull( $public->disable_removed_sitemaps() );
+	}
+
+	/**
+	 * Isolated: same permanence concern as above, plus requires the WP_Sitemaps/
+	 * WP_Sitemaps_Registry fixture, which -- like the WC() precedent in IntegrationsTest --
+	 * can't be declared inline in this method (PHP disallows nesting a class declaration
+	 * inside another class's method body) and so lives in its own file.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_disable_removed_sitemaps_returns_early_when_provider_still_registered() {
+		require_once __DIR__ . '/Support/fixtures/class-wp-sitemaps-stub.php';
+
+		function wp_sitemaps_get_server() {
+			return new WP_Sitemaps(
+				new WP_Sitemaps_Registry(
+					array(
+						'posts' => new stdClass(),
+						'users' => new stdClass(),
+					)
+				)
+			);
+		}
+
+		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap', '' )->andReturn( 'users' );
+		WP_Mock::onFilter( 'dwpb_disable_removed_sitemaps' )->with( true )->reply( true );
+		$this->assert_no_404_side_effects();
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertNull( $public->disable_removed_sitemaps() );
+	}
+
+	/**
+	 * Isolated: see the two notes above.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_disable_removed_sitemaps_404s_when_provider_was_removed() {
+		require_once __DIR__ . '/Support/fixtures/class-wp-sitemaps-stub.php';
+
+		function wp_sitemaps_get_server() {
+			return new WP_Sitemaps( new WP_Sitemaps_Registry( array( 'posts' => new stdClass() ) ) );
+		}
+
+		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap', '' )->andReturn( 'users' );
+		WP_Mock::onFilter( 'dwpb_disable_removed_sitemaps' )->with( true )->reply( true );
+
+		global $wp_query;
+		$wp_query = Mockery::mock( 'Disable_Blog_Public_Query_Double' );
+		$wp_query->shouldReceive( 'set_404' )->once();
+
+		WP_Mock::userFunction( 'status_header' )->once()->with( 404 );
+		WP_Mock::userFunction( 'nocache_headers' )->once();
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertNull( $public->disable_removed_sitemaps() );
+	}
+
+	/**
+	 * Isolated: see the two notes above. Proves the dwpb_disable_removed_sitemaps filter
+	 * actually changes the outcome, using the exact same "removed provider" setup as the 404
+	 * test above -- the only difference is the filter override.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_disable_removed_sitemaps_dwpb_disable_removed_sitemaps_filter_false_prevents_404() {
+		require_once __DIR__ . '/Support/fixtures/class-wp-sitemaps-stub.php';
+
+		function wp_sitemaps_get_server() {
+			return new WP_Sitemaps( new WP_Sitemaps_Registry( array( 'posts' => new stdClass() ) ) );
+		}
+
+		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap', '' )->andReturn( 'users' );
+		WP_Mock::onFilter( 'dwpb_disable_removed_sitemaps' )->with( true )->reply( false );
+		$this->assert_no_404_side_effects();
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertNull( $public->disable_removed_sitemaps() );
+	}
+}

--- a/tests/php/PublicRedirectsTest.php
+++ b/tests/php/PublicRedirectsTest.php
@@ -1,0 +1,936 @@
+<?php
+/**
+ * Tests for Disable_Blog_Public::redirect_public_pages(), its private archive-detection
+ * helpers, and the pre_get_posts query-modification methods.
+ *
+ * @package DisableBlog
+ */
+
+// Not required by tests/php/bootstrap.php on purpose (see ConstructorInjectionTest.php's note;
+// LoaderTest's autoloader test needs Disable_Blog_Functions to remain undefined until its own
+// isolated process). require_once is safe regardless of which test file happens to load first.
+require_once __DIR__ . '/../../includes/class-disable-blog-functions.php';
+require_once __DIR__ . '/Support/fixtures/class-public-functions-double.php';
+
+/**
+ * @covers Disable_Blog_Public::redirect_public_pages
+ * @covers Disable_Blog_Public::is_category_archive_request
+ * @covers Disable_Blog_Public::is_tag_archive_request
+ * @covers Disable_Blog_Public::modify_query
+ * @covers Disable_Blog_Public::set_post_types_in_query
+ */
+class PublicRedirectsTest extends TestCase {
+
+	/**
+	 * The global $post as it stood before the test, so it can be restored in tear_down().
+	 *
+	 * @var mixed
+	 */
+	private $original_post;
+
+	protected function set_up() {
+		parent::set_up();
+
+		global $post;
+		$this->original_post = $post ?? null;
+		$post                = null;
+	}
+
+	protected function tear_down() {
+		global $post;
+		$post = $this->original_post;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Invokes a private instance method via Reflection.
+	 *
+	 * @param Disable_Blog_Public $public Instance to invoke on.
+	 * @param string              $method Method name.
+	 * @param array               $args   Positional arguments.
+	 * @return mixed
+	 */
+	private function invoke_private( Disable_Blog_Public $public, $method, array $args = array() ) {
+		$reflection = new ReflectionMethod( $public, $method );
+		$reflection->setAccessible( true );
+
+		return $reflection->invokeArgs( $public, $args );
+	}
+
+	/**
+	 * redirect_public_pages()
+	 */
+
+	/**
+	 * Stubs get_query_var( 'sitemap'/'sitemap-stylesheet' ), is_admin() and
+	 * get_option( 'page_on_front' )/get_permalink() so the function's four early-return
+	 * guards all pass and execution reaches the $public_redirects map.
+	 *
+	 * @param int    $page_on_front_id The page_on_front option value.
+	 * @param string $homepage_url     The url get_permalink() should return for it.
+	 * @return void
+	 */
+	private function stub_guards_pass( $page_on_front_id = 5, $homepage_url = 'https://example.test/' ) {
+		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap', false )->andReturn( false );
+		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap-stylesheet', false )->andReturn( false );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( false );
+		WP_Mock::userFunction( 'get_option' )->with( 'page_on_front' )->andReturn( $page_on_front_id );
+		WP_Mock::userFunction( 'get_permalink' )->with( $page_on_front_id )->andReturn( $homepage_url );
+	}
+
+	/**
+	 * Stubs every WordPress function the six $public_redirects array entries call while being
+	 * built -- all six are evaluated unconditionally as part of constructing the array literal,
+	 * regardless of which one (if any) the foreach later breaks on. Defaults make every entry
+	 * false; pass $overrides to make specific ones true.
+	 *
+	 * @param array $overrides Values to override in the default (all-false) condition set.
+	 * @return void
+	 */
+	private function stub_redirect_conditions( array $overrides = array() ) {
+		$c = array_merge(
+			array(
+				'is_singular_post'        => false,
+				'is_tag'                  => false,
+				'is_category'             => false,
+				'is_feed'                 => false,
+				'queried_object'          => null,
+				'query_var_tag'           => '',
+				'query_var_tag_id'        => '',
+				'query_var_category_name' => '',
+				'query_var_cat'           => '',
+				'is_home'                 => false,
+				'is_date'                 => false,
+				'is_author'               => false,
+			),
+			$overrides
+		);
+
+		WP_Mock::userFunction( 'is_singular' )->with( 'post' )->andReturn( $c['is_singular_post'] );
+		WP_Mock::userFunction( 'is_tag' )->andReturn( $c['is_tag'] );
+		WP_Mock::userFunction( 'is_category' )->andReturn( $c['is_category'] );
+		WP_Mock::userFunction( 'is_feed' )->andReturn( $c['is_feed'] );
+		WP_Mock::userFunction( 'get_queried_object' )->andReturn( $c['queried_object'] );
+		WP_Mock::userFunction( 'get_query_var' )->with( 'tag' )->andReturn( $c['query_var_tag'] );
+		WP_Mock::userFunction( 'get_query_var' )->with( 'tag_id' )->andReturn( $c['query_var_tag_id'] );
+		WP_Mock::userFunction( 'get_query_var' )->with( 'category_name' )->andReturn( $c['query_var_category_name'] );
+		WP_Mock::userFunction( 'get_query_var' )->with( 'cat' )->andReturn( $c['query_var_cat'] );
+		WP_Mock::userFunction( 'is_home' )->andReturn( $c['is_home'] );
+		WP_Mock::userFunction( 'is_date' )->andReturn( $c['is_date'] );
+		WP_Mock::userFunction( 'is_author' )->andReturn( $c['is_author'] );
+	}
+
+	/**
+	 * Stubs the WordPress functions dwpb_post_types_with_tax() calls on every invocation,
+	 * regardless of taxonomy or cache state: get_post_types(), wp_cache_get()/wp_cache_set()
+	 * and maybe_serialize(), all called with the ( array(), 'names' ) arguments this file's
+	 * tests always use.
+	 *
+	 * @return void
+	 */
+	private function stub_tax_lookup_plumbing() {
+		WP_Mock::userFunction( 'get_post_types' )->with( array(), 'names' )->andReturn( array() );
+		WP_Mock::userFunction( 'wp_cache_get' )->andReturn( false );
+		WP_Mock::userFunction( 'wp_cache_set' )->andReturn( null );
+		WP_Mock::userFunction( 'maybe_serialize' )->with( array() )->andReturn( 'a:0:{}' );
+	}
+
+	/**
+	 * Forces dwpb_post_types_with_tax( $taxonomy ) to return $return_value, via the
+	 * dwpb_taxonomy_support short-circuit filter -- requires stub_tax_lookup_plumbing() to
+	 * have been called first in the same test.
+	 *
+	 * @param string     $taxonomy     The taxonomy slug ('post_tag' or 'category').
+	 * @param array|bool $return_value The value dwpb_post_types_with_tax() should return.
+	 * @return void
+	 */
+	private function stub_post_types_with_tax_result( $taxonomy, $return_value ) {
+		WP_Mock::userFunction( 'esc_attr' )->with( $taxonomy )->andReturn( $taxonomy );
+		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
+			->with( null, $taxonomy, array(), array(), 'names' )
+			->reply( $return_value );
+	}
+
+	/**
+	 * Stubs the two filters redirect_public_pages() applies, in order, after the
+	 * $public_redirects loop computes $redirect_url: dwpb_redirect_front_end (unfiltered
+	 * true, so the redirect isn't skipped) and dwpb_front_end_redirect_url (passthrough),
+	 * so $redirect_url reaches $functions->redirect() unmodified by either.
+	 *
+	 * @param string $redirect_url The url expected to reach redirect() unmodified.
+	 * @return void
+	 */
+	private function stub_front_end_redirect_passthrough( $redirect_url ) {
+		WP_Mock::onFilter( 'dwpb_redirect_front_end' )->with( true )->reply( true );
+		WP_Mock::onFilter( 'dwpb_front_end_redirect_url' )->with( $redirect_url )->reply( $redirect_url );
+	}
+
+	/**
+	 * is_admin() must short-circuit before any other guard, so nothing else can even be
+	 * stubbed for this test -- an unexpected call to an un-mocked WP function fatals.
+	 */
+	public function test_redirect_public_pages_returns_early_when_is_admin() {
+		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap', false )->andReturn( false );
+		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap-stylesheet', false )->andReturn( false );
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( true );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array(), $functions->redirect_calls );
+	}
+
+	public function test_redirect_public_pages_returns_early_when_no_page_on_front() {
+		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap', false )->andReturn( false );
+		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap-stylesheet', false )->andReturn( false );
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'get_option' )->with( 'page_on_front' )->andReturn( 0 );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array(), $functions->redirect_calls );
+	}
+
+	/**
+	 * The guard is a single `||` chain evaluated left to right, so is_admin() and
+	 * get_option( 'page_on_front' ) both run before the sitemap check is ever reached;
+	 * both must resolve false/truthy here so the early return is actually caused by the
+	 * sitemap query var, not by one of the earlier conditions.
+	 */
+	public function test_redirect_public_pages_returns_early_when_sitemap_query_var_present() {
+		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap', false )->andReturn( 'posts' );
+		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap-stylesheet', false )->andReturn( false );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( false );
+		WP_Mock::userFunction( 'get_option' )->with( 'page_on_front' )->andReturn( 5 );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array(), $functions->redirect_calls );
+	}
+
+	/**
+	 * Same guard-ordering note as the sitemap test above: is_admin() and
+	 * get_option( 'page_on_front' ) both run first, so both must resolve false/truthy
+	 * for the early return to be caused by the sitemap-stylesheet check specifically.
+	 */
+	public function test_redirect_public_pages_returns_early_when_sitemap_stylesheet_query_var_present() {
+		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap', false )->andReturn( false );
+		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap-stylesheet', false )->andReturn( 'xsl' );
+		WP_Mock::userFunction( 'is_admin' )->andReturn( false );
+		WP_Mock::userFunction( 'get_option' )->with( 'page_on_front' )->andReturn( 5 );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array(), $functions->redirect_calls );
+	}
+
+	/**
+	 * 'post' row: singular post, default (unfiltered) redirect url.
+	 */
+	public function test_redirect_public_pages_redirects_singular_post_with_default_url() {
+		global $post;
+		$post = new WP_Post();
+
+		$this->stub_guards_pass();
+		$this->stub_redirect_conditions( array( 'is_singular_post' => true ) );
+
+		WP_Mock::onFilter( 'dwpb_redirect_post' )->with( 'https://example.test/' )->reply( 'https://example.test/' );
+		$this->stub_front_end_redirect_passthrough( 'https://example.test/' );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array( 'https://example.test/' ), $functions->redirect_calls );
+	}
+
+	/**
+	 * The dwpb_redirect_post filter must be able to override the url that reaches redirect().
+	 */
+	public function test_redirect_public_pages_dwpb_redirect_post_filter_overrides_url() {
+		global $post;
+		$post = new WP_Post();
+
+		$this->stub_guards_pass();
+		$this->stub_redirect_conditions( array( 'is_singular_post' => true ) );
+
+		WP_Mock::onFilter( 'dwpb_redirect_post' )->with( 'https://example.test/' )->reply( 'https://example.test/custom-post/' );
+		$this->stub_front_end_redirect_passthrough( 'https://example.test/custom-post/' );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array( 'https://example.test/custom-post/' ), $functions->redirect_calls );
+	}
+
+	/**
+	 * The 'post' row requires BOTH is_singular( 'post' ) AND a real $post global -- proven
+	 * independently of is_singular() by leaving $post null (its set_up() default) while
+	 * is_singular( 'post' ) is stubbed true.
+	 */
+	public function test_redirect_public_pages_no_post_redirect_when_post_global_is_not_a_wp_post_instance() {
+		global $post;
+		$post = null;
+
+		$this->stub_guards_pass();
+		$this->stub_redirect_conditions( array( 'is_singular_post' => true ) );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array(), $functions->redirect_calls );
+	}
+
+	/**
+	 * 'post_tag_archive' row: a tag archive with no other post type using post_tag.
+	 */
+	public function test_redirect_public_pages_redirects_tag_archive_when_no_other_post_types_use_post_tag() {
+		$this->stub_guards_pass();
+		$this->stub_redirect_conditions( array( 'is_tag' => true ) );
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+
+		WP_Mock::onFilter( 'dwpb_redirect_post_tag_archive' )->with( 'https://example.test/' )->reply( 'https://example.test/' );
+		$this->stub_front_end_redirect_passthrough( 'https://example.test/' );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array( 'https://example.test/' ), $functions->redirect_calls );
+	}
+
+	public function test_redirect_public_pages_dwpb_redirect_post_tag_archive_filter_overrides_url() {
+		$this->stub_guards_pass();
+		$this->stub_redirect_conditions( array( 'is_tag' => true ) );
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+
+		WP_Mock::onFilter( 'dwpb_redirect_post_tag_archive' )->with( 'https://example.test/' )->reply( 'https://example.test/custom-tag/' );
+		$this->stub_front_end_redirect_passthrough( 'https://example.test/custom-tag/' );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array( 'https://example.test/custom-tag/' ), $functions->redirect_calls );
+	}
+
+	/**
+	 * When another post type also uses post_tag, the tag archive must NOT redirect.
+	 */
+	public function test_redirect_public_pages_no_tag_redirect_when_other_post_types_use_post_tag() {
+		$this->stub_guards_pass();
+		$this->stub_redirect_conditions( array( 'is_tag' => true ) );
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', array( 'book' ) );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array(), $functions->redirect_calls );
+	}
+
+	/**
+	 * 'category_archive' row: a category archive with no other post type using category.
+	 */
+	public function test_redirect_public_pages_redirects_category_archive_when_no_other_post_types_use_category() {
+		$this->stub_guards_pass();
+		$this->stub_redirect_conditions( array( 'is_category' => true ) );
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', false );
+
+		WP_Mock::onFilter( 'dwpb_redirect_category_archive' )->with( 'https://example.test/' )->reply( 'https://example.test/' );
+		$this->stub_front_end_redirect_passthrough( 'https://example.test/' );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array( 'https://example.test/' ), $functions->redirect_calls );
+	}
+
+	public function test_redirect_public_pages_dwpb_redirect_category_archive_filter_overrides_url() {
+		$this->stub_guards_pass();
+		$this->stub_redirect_conditions( array( 'is_category' => true ) );
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', false );
+
+		WP_Mock::onFilter( 'dwpb_redirect_category_archive' )->with( 'https://example.test/' )->reply( 'https://example.test/custom-category/' );
+		$this->stub_front_end_redirect_passthrough( 'https://example.test/custom-category/' );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array( 'https://example.test/custom-category/' ), $functions->redirect_calls );
+	}
+
+	/**
+	 * When another post type also uses category, the category archive must NOT redirect.
+	 */
+	public function test_redirect_public_pages_no_category_redirect_when_other_post_types_use_category() {
+		$this->stub_guards_pass();
+		$this->stub_redirect_conditions( array( 'is_category' => true ) );
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'category', array( 'page' ) );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array(), $functions->redirect_calls );
+	}
+
+	/**
+	 * 'blog_page' row.
+	 */
+	public function test_redirect_public_pages_redirects_blog_home_with_default_url() {
+		$this->stub_guards_pass();
+		$this->stub_redirect_conditions( array( 'is_home' => true ) );
+
+		WP_Mock::onFilter( 'dwpb_redirect_blog_page' )->with( 'https://example.test/' )->reply( 'https://example.test/' );
+		$this->stub_front_end_redirect_passthrough( 'https://example.test/' );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array( 'https://example.test/' ), $functions->redirect_calls );
+	}
+
+	public function test_redirect_public_pages_dwpb_redirect_blog_page_filter_overrides_url() {
+		$this->stub_guards_pass();
+		$this->stub_redirect_conditions( array( 'is_home' => true ) );
+
+		WP_Mock::onFilter( 'dwpb_redirect_blog_page' )->with( 'https://example.test/' )->reply( 'https://example.test/custom-blog/' );
+		$this->stub_front_end_redirect_passthrough( 'https://example.test/custom-blog/' );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array( 'https://example.test/custom-blog/' ), $functions->redirect_calls );
+	}
+
+	/**
+	 * 'date_archive' row.
+	 */
+	public function test_redirect_public_pages_redirects_date_archive_with_default_url() {
+		$this->stub_guards_pass();
+		$this->stub_redirect_conditions( array( 'is_date' => true ) );
+
+		WP_Mock::onFilter( 'dwpb_redirect_date_archive' )->with( 'https://example.test/' )->reply( 'https://example.test/' );
+		$this->stub_front_end_redirect_passthrough( 'https://example.test/' );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array( 'https://example.test/' ), $functions->redirect_calls );
+	}
+
+	public function test_redirect_public_pages_dwpb_redirect_date_archive_filter_overrides_url() {
+		$this->stub_guards_pass();
+		$this->stub_redirect_conditions( array( 'is_date' => true ) );
+
+		WP_Mock::onFilter( 'dwpb_redirect_date_archive' )->with( 'https://example.test/' )->reply( 'https://example.test/custom-date/' );
+		$this->stub_front_end_redirect_passthrough( 'https://example.test/custom-date/' );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array( 'https://example.test/custom-date/' ), $functions->redirect_calls );
+	}
+
+	/**
+	 * 'author_archive' row: gated by $this->functions->disable_author_archives(), not a plain
+	 * WordPress conditional.
+	 */
+	public function test_redirect_public_pages_redirects_author_archive_when_disable_author_archives_true() {
+		$this->stub_guards_pass();
+		$this->stub_redirect_conditions( array( 'is_author' => true ) );
+
+		WP_Mock::onFilter( 'dwpb_redirect_author_archive' )->with( 'https://example.test/' )->reply( 'https://example.test/' );
+		$this->stub_front_end_redirect_passthrough( 'https://example.test/' );
+
+		$functions                                   = new Disable_Blog_Public_Functions_Double();
+		$functions->disable_author_archives_return = true;
+		$public                                       = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array( 'https://example.test/' ), $functions->redirect_calls );
+	}
+
+	public function test_redirect_public_pages_dwpb_redirect_author_archive_filter_overrides_url() {
+		$this->stub_guards_pass();
+		$this->stub_redirect_conditions( array( 'is_author' => true ) );
+
+		WP_Mock::onFilter( 'dwpb_redirect_author_archive' )->with( 'https://example.test/' )->reply( 'https://example.test/custom-author/' );
+		$this->stub_front_end_redirect_passthrough( 'https://example.test/custom-author/' );
+
+		$functions                                   = new Disable_Blog_Public_Functions_Double();
+		$functions->disable_author_archives_return = true;
+		$public                                       = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array( 'https://example.test/custom-author/' ), $functions->redirect_calls );
+	}
+
+	public function test_redirect_public_pages_no_author_redirect_when_disable_author_archives_false() {
+		$this->stub_guards_pass();
+		$this->stub_redirect_conditions( array( 'is_author' => true ) );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array(), $functions->redirect_calls );
+	}
+
+	/**
+	 * Break semantics: when two rows are simultaneously true, only the FIRST one declared in
+	 * $public_redirects (here, 'blog_page' before 'date_archive') is used -- proven by giving
+	 * both rows distinct filtered urls and asserting only the earlier one's reaches redirect().
+	 */
+	public function test_redirect_public_pages_only_first_matching_row_wins() {
+		$this->stub_guards_pass();
+		$this->stub_redirect_conditions(
+			array(
+				'is_home' => true,
+				'is_date' => true,
+			)
+		);
+
+		WP_Mock::onFilter( 'dwpb_redirect_blog_page' )->with( 'https://example.test/' )->reply( 'https://example.test/blog-page-wins/' );
+		// Deliberately not stubbing dwpb_redirect_date_archive: it must never fire, so if it did
+		// its default (unfiltered) passthrough would leak the raw homepage url through instead.
+		$this->stub_front_end_redirect_passthrough( 'https://example.test/blog-page-wins/' );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array( 'https://example.test/blog-page-wins/' ), $functions->redirect_calls );
+	}
+
+	/**
+	 * dwpb_redirect_front_end toggle: false disables the redirect entirely, even though a row
+	 * matched and a redirect url was computed.
+	 */
+	public function test_redirect_public_pages_dwpb_redirect_front_end_false_skips_redirect_entirely() {
+		$this->stub_guards_pass();
+		$this->stub_redirect_conditions( array( 'is_home' => true ) );
+
+		WP_Mock::onFilter( 'dwpb_redirect_blog_page' )->with( 'https://example.test/' )->reply( 'https://example.test/' );
+		WP_Mock::onFilter( 'dwpb_redirect_front_end' )->with( true )->reply( false );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array(), $functions->redirect_calls );
+	}
+
+	/**
+	 * dwpb_front_end_redirect_url is a global override applied after the per-page filter and
+	 * after the front-end toggle, so it must win over the per-page filtered value.
+	 */
+	public function test_redirect_public_pages_dwpb_front_end_redirect_url_overrides_final_url() {
+		$this->stub_guards_pass();
+		$this->stub_redirect_conditions( array( 'is_home' => true ) );
+
+		WP_Mock::onFilter( 'dwpb_redirect_blog_page' )->with( 'https://example.test/' )->reply( 'https://example.test/' );
+		WP_Mock::onFilter( 'dwpb_redirect_front_end' )->with( true )->reply( true );
+		WP_Mock::onFilter( 'dwpb_front_end_redirect_url' )->with( 'https://example.test/' )->reply( 'https://example.test/global-override/' );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$public->redirect_public_pages();
+
+		$this->assertSame( array( 'https://example.test/global-override/' ), $functions->redirect_calls );
+	}
+
+	/**
+	 * is_category_archive_request() (private)
+	 */
+
+	public function test_is_category_archive_request_true_when_is_category() {
+		WP_Mock::userFunction( 'is_category' )->once()->andReturn( true );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $this->invoke_private( $public, 'is_category_archive_request' ) );
+	}
+
+	public function test_is_category_archive_request_false_on_feed_request() {
+		WP_Mock::userFunction( 'is_category' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'is_feed' )->once()->andReturn( true );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $this->invoke_private( $public, 'is_category_archive_request' ) );
+	}
+
+	public function test_is_category_archive_request_false_when_queried_object_already_resolved() {
+		WP_Mock::userFunction( 'is_category' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'is_feed' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'get_queried_object' )->once()->andReturn( new stdClass() );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $this->invoke_private( $public, 'is_category_archive_request' ) );
+	}
+
+	public function test_is_category_archive_request_true_from_raw_category_name_query_var() {
+		WP_Mock::userFunction( 'is_category' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'is_feed' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'get_queried_object' )->once()->andReturn( null );
+		WP_Mock::userFunction( 'get_query_var' )->with( 'category_name' )->once()->andReturn( 'news' );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $this->invoke_private( $public, 'is_category_archive_request' ) );
+	}
+
+	public function test_is_category_archive_request_true_from_raw_cat_query_var() {
+		WP_Mock::userFunction( 'is_category' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'is_feed' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'get_queried_object' )->once()->andReturn( null );
+		WP_Mock::userFunction( 'get_query_var' )->with( 'category_name' )->once()->andReturn( '' );
+		WP_Mock::userFunction( 'get_query_var' )->with( 'cat' )->once()->andReturn( '4' );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $this->invoke_private( $public, 'is_category_archive_request' ) );
+	}
+
+	public function test_is_category_archive_request_false_when_no_category_query_vars_present() {
+		WP_Mock::userFunction( 'is_category' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'is_feed' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'get_queried_object' )->once()->andReturn( null );
+		WP_Mock::userFunction( 'get_query_var' )->with( 'category_name' )->once()->andReturn( '' );
+		WP_Mock::userFunction( 'get_query_var' )->with( 'cat' )->once()->andReturn( '' );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $this->invoke_private( $public, 'is_category_archive_request' ) );
+	}
+
+	/**
+	 * is_tag_archive_request() (private)
+	 */
+
+	public function test_is_tag_archive_request_true_when_is_tag() {
+		WP_Mock::userFunction( 'is_tag' )->once()->andReturn( true );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $this->invoke_private( $public, 'is_tag_archive_request' ) );
+	}
+
+	public function test_is_tag_archive_request_false_on_feed_request() {
+		WP_Mock::userFunction( 'is_tag' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'is_feed' )->once()->andReturn( true );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $this->invoke_private( $public, 'is_tag_archive_request' ) );
+	}
+
+	public function test_is_tag_archive_request_false_when_queried_object_already_resolved() {
+		WP_Mock::userFunction( 'is_tag' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'is_feed' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'get_queried_object' )->once()->andReturn( new stdClass() );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $this->invoke_private( $public, 'is_tag_archive_request' ) );
+	}
+
+	public function test_is_tag_archive_request_true_from_raw_tag_query_var() {
+		WP_Mock::userFunction( 'is_tag' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'is_feed' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'get_queried_object' )->once()->andReturn( null );
+		WP_Mock::userFunction( 'get_query_var' )->with( 'tag' )->once()->andReturn( 'news' );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $this->invoke_private( $public, 'is_tag_archive_request' ) );
+	}
+
+	public function test_is_tag_archive_request_true_from_raw_tag_id_query_var() {
+		WP_Mock::userFunction( 'is_tag' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'is_feed' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'get_queried_object' )->once()->andReturn( null );
+		WP_Mock::userFunction( 'get_query_var' )->with( 'tag' )->once()->andReturn( '' );
+		WP_Mock::userFunction( 'get_query_var' )->with( 'tag_id' )->once()->andReturn( '7' );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $this->invoke_private( $public, 'is_tag_archive_request' ) );
+	}
+
+	public function test_is_tag_archive_request_false_when_no_tag_query_vars_present() {
+		WP_Mock::userFunction( 'is_tag' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'is_feed' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'get_queried_object' )->once()->andReturn( null );
+		WP_Mock::userFunction( 'get_query_var' )->with( 'tag' )->once()->andReturn( '' );
+		WP_Mock::userFunction( 'get_query_var' )->with( 'tag_id' )->once()->andReturn( '' );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $this->invoke_private( $public, 'is_tag_archive_request' ) );
+	}
+
+	/**
+	 * modify_query()
+	 */
+
+	public function test_modify_query_returns_early_when_is_admin() {
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( true );
+
+		$query  = Mockery::mock( 'Disable_Blog_Public_Query_Double' );
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertNull( $public->modify_query( $query ) );
+	}
+
+	public function test_modify_query_returns_early_when_not_main_query() {
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+
+		$query = Mockery::mock( 'Disable_Blog_Public_Query_Double' );
+		$query->shouldReceive( 'is_main_query' )->once()->andReturn( false );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertNull( $public->modify_query( $query ) );
+	}
+
+	public function test_modify_query_sets_tag_post_types_when_tag_archive_and_other_post_types_use_post_tag() {
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', array( 'book' ) );
+		$this->stub_post_types_with_tax_result( 'category', false );
+
+		$query = Mockery::mock( 'Disable_Blog_Public_Query_Double' );
+		$query->shouldReceive( 'is_main_query' )->once()->andReturn( true );
+		$query->shouldReceive( 'is_tag' )->once()->andReturn( true );
+		$query->shouldReceive( 'set' )->once()->with( 'post_type', array( 'book' ) );
+
+		WP_Mock::onFilter( 'dwpb_tag_post_types' )->with( array( 'book' ), $query )->reply( array( 'book' ) );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$this->assertNull( $public->modify_query( $query ) );
+	}
+
+	public function test_modify_query_tag_branch_dwpb_tag_post_types_filter_overrides_post_types() {
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', array( 'book' ) );
+		$this->stub_post_types_with_tax_result( 'category', false );
+
+		$query = Mockery::mock( 'Disable_Blog_Public_Query_Double' );
+		$query->shouldReceive( 'is_main_query' )->once()->andReturn( true );
+		$query->shouldReceive( 'is_tag' )->once()->andReturn( true );
+		$query->shouldReceive( 'set' )->once()->with( 'post_type', array( 'custom_cpt' ) );
+
+		WP_Mock::onFilter( 'dwpb_tag_post_types' )->with( array( 'book' ), $query )->reply( array( 'custom_cpt' ) );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$this->assertNull( $public->modify_query( $query ) );
+	}
+
+	public function test_modify_query_sets_category_post_types_when_category_archive_and_other_post_types_use_category() {
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+		$this->stub_post_types_with_tax_result( 'category', array( 'page' ) );
+
+		$query = Mockery::mock( 'Disable_Blog_Public_Query_Double' );
+		$query->shouldReceive( 'is_main_query' )->once()->andReturn( true );
+		$query->shouldReceive( 'is_tag' )->once()->andReturn( false );
+		$query->shouldReceive( 'is_category' )->once()->andReturn( true );
+		$query->shouldReceive( 'set' )->once()->with( 'post_type', array( 'page' ) );
+
+		WP_Mock::onFilter( 'dwpb_category_post_types' )->with( array( 'page' ), $query )->reply( array( 'page' ) );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$this->assertNull( $public->modify_query( $query ) );
+	}
+
+	public function test_modify_query_category_branch_dwpb_category_post_types_filter_overrides_post_types() {
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+		$this->stub_post_types_with_tax_result( 'category', array( 'page' ) );
+
+		$query = Mockery::mock( 'Disable_Blog_Public_Query_Double' );
+		$query->shouldReceive( 'is_main_query' )->once()->andReturn( true );
+		$query->shouldReceive( 'is_tag' )->once()->andReturn( false );
+		$query->shouldReceive( 'is_category' )->once()->andReturn( true );
+		$query->shouldReceive( 'set' )->once()->with( 'post_type', array( 'custom_cpt' ) );
+
+		WP_Mock::onFilter( 'dwpb_category_post_types' )->with( array( 'page' ), $query )->reply( array( 'custom_cpt' ) );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$this->assertNull( $public->modify_query( $query ) );
+	}
+
+	public function test_modify_query_sets_author_post_types_when_author_archive_and_functions_reports_post_types() {
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+		$this->stub_post_types_with_tax_result( 'category', false );
+
+		$query = Mockery::mock( 'Disable_Blog_Public_Query_Double' );
+		$query->shouldReceive( 'is_main_query' )->once()->andReturn( true );
+		$query->shouldReceive( 'is_tag' )->once()->andReturn( false );
+		$query->shouldReceive( 'is_category' )->once()->andReturn( false );
+		$query->shouldReceive( 'is_author' )->once()->andReturn( true );
+		$query->shouldReceive( 'set' )->once()->with( 'post_type', array( 'book' ) );
+
+		$functions                                     = new Disable_Blog_Public_Functions_Double();
+		$functions->author_archive_post_types_return = array( 'book' );
+		$public                                         = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$this->assertNull( $public->modify_query( $query ) );
+	}
+
+	public function test_modify_query_does_nothing_when_no_condition_matches() {
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+		$this->stub_post_types_with_tax_result( 'category', false );
+
+		$query = Mockery::mock( 'Disable_Blog_Public_Query_Double' );
+		$query->shouldReceive( 'is_main_query' )->once()->andReturn( true );
+		$query->shouldReceive( 'is_tag' )->once()->andReturn( false );
+		$query->shouldReceive( 'is_category' )->once()->andReturn( false );
+		$query->shouldReceive( 'is_author' )->once()->andReturn( false );
+		$query->shouldNotReceive( 'set' );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$this->assertNull( $public->modify_query( $query ) );
+	}
+
+	public function test_modify_query_author_branch_skipped_when_author_post_types_empty() {
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+		$this->stub_post_types_with_tax_result( 'category', false );
+
+		$query = Mockery::mock( 'Disable_Blog_Public_Query_Double' );
+		$query->shouldReceive( 'is_main_query' )->once()->andReturn( true );
+		$query->shouldReceive( 'is_tag' )->once()->andReturn( false );
+		$query->shouldReceive( 'is_category' )->once()->andReturn( false );
+		$query->shouldReceive( 'is_author' )->once()->andReturn( true );
+		$query->shouldNotReceive( 'set' );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$this->assertNull( $public->modify_query( $query ) );
+	}
+
+	/**
+	 * set_post_types_in_query()
+	 */
+
+	public function test_set_post_types_in_query_without_filter_sets_query_and_returns_true() {
+		$query = Mockery::mock( 'Disable_Blog_Public_Query_Double' );
+		$query->shouldReceive( 'set' )->once()->with( 'post_type', array( 'book' ) );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $public->set_post_types_in_query( $query, array( 'book' ) ) );
+	}
+
+	public function test_set_post_types_in_query_with_filter_applies_and_can_override_post_types() {
+		$query = Mockery::mock( 'Disable_Blog_Public_Query_Double' );
+		$query->shouldReceive( 'set' )->once()->with( 'post_type', array( 'overridden' ) );
+
+		WP_Mock::onFilter( 'my_filter' )->with( array( 'book' ), $query )->reply( array( 'overridden' ) );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertTrue( $public->set_post_types_in_query( $query, array( 'book' ), 'my_filter' ) );
+	}
+
+	public function test_set_post_types_in_query_returns_false_when_resulting_post_types_empty() {
+		$query = Mockery::mock( 'Disable_Blog_Public_Query_Double' );
+		$query->shouldNotReceive( 'set' );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $public->set_post_types_in_query( $query, array() ) );
+	}
+
+	public function test_set_post_types_in_query_returns_false_when_query_object_lacks_set_method() {
+		$query = new stdClass();
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $public->set_post_types_in_query( $query, array( 'book' ) ) );
+	}
+
+	/**
+	 * A filter is free to reply with a non-array value; the is_array() guard must stop that
+	 * from ever reaching $query->set(), which requires an array for its 'post_type' value.
+	 */
+	public function test_set_post_types_in_query_returns_false_when_filter_replies_with_non_array() {
+		$query = Mockery::mock( 'Disable_Blog_Public_Query_Double' );
+		$query->shouldNotReceive( 'set' );
+
+		WP_Mock::onFilter( 'my_filter' )->with( array( 'book' ), $query )->reply( 'oops' );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $public->set_post_types_in_query( $query, array( 'book' ), 'my_filter' ) );
+	}
+}

--- a/tests/php/Support/WpPolyfills.php
+++ b/tests/php/Support/WpPolyfills.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Global WordPress function stubs that WP_Mock::userFunction() cannot express.
+ *
+ * Keep this file minimal: only declare a global function here when it needs real
+ * behavior (e.g. control flow via an exception) rather than a per-test return value.
+ * Everything else should be stubbed per-test with WP_Mock::userFunction().
+ *
+ * @package DisableBlog
+ */
+
+/**
+ * wp_die() normally terminates the request with exit(). Tests can't survive exit(),
+ * so this throws instead, letting exit-terminated code paths be asserted with
+ * expectException()/expectExceptionMessage() in later phases.
+ *
+ * @param string $message Error message.
+ * @param string $title   Error title.
+ * @param array  $args    Arguments.
+ *
+ * @throws Exception Always, carrying $message.
+ */
+function wp_die( $message = '', $title = '', $args = array() ) {
+	throw new Exception( $message );
+}
+
+// Intentionally NOT stubbed here: wp_cache_get() / wp_cache_set().
+// PHP cannot un-declare a function, so a global stub here would fix its return
+// value for the entire suite and make one of the cache-hit/cache-miss branches
+// in includes/functions.php permanently untestable. Stub both per-test via
+// WP_Mock::userFunction() instead, so each test controls its own branch.

--- a/tests/php/Support/WpPolyfills.php
+++ b/tests/php/Support/WpPolyfills.php
@@ -21,7 +21,9 @@
  * @throws Exception Always, carrying $message.
  */
 function wp_die( $message = '', $title = '', $args = array() ) {
-	throw new Exception( $message );
+	// $message never reaches any output sink here -- it only carries the string a test
+	// asserts against via expectExceptionMessage(), inside the same PHP process.
+	throw new Exception( $message ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 }
 
 // Intentionally NOT stubbed here: wp_cache_get() / wp_cache_set().

--- a/tests/php/Support/WpPolyfills.php
+++ b/tests/php/Support/WpPolyfills.php
@@ -29,3 +29,34 @@ function wp_die( $message = '', $title = '', $args = array() ) {
 // value for the entire suite and make one of the cache-hit/cache-miss branches
 // in includes/functions.php permanently untestable. Stub both per-test via
 // WP_Mock::userFunction() instead, so each test controls its own branch.
+
+/**
+ * wp_parse_str() mutates its second argument by reference, and WP_Mock::userFunction()
+ * stubs are declared without by-reference parameters (they collect args via
+ * func_get_args(), which copies), so a stub can never write back into the caller's
+ * variable. Declaring the real behavior here -- identical to WordPress core's own
+ * wp_parse_str() -- is the only way a caller's $query_vars actually gets populated.
+ *
+ * @param string $string The string to parse.
+ * @param array  $array  Variables will be stored in this array.
+ * @return void
+ */
+function wp_parse_str( $string, &$array ) {
+	parse_str( (string) $string, $array );
+}
+
+/**
+ * sanitize_key() is passed to array_map() by name in
+ * Disable_Blog_Functions::get_allowed_query_vars(). PHP 8 resolves a string callback
+ * eagerly, so array_map() raises a TypeError when the function is undeclared -- even
+ * when the array is empty and the callback would never be invoked. A per-test
+ * WP_Mock::userFunction() stub only declares it once that test has run, which would
+ * make every test reaching get_allowed_query_vars() depend on execution order.
+ * Patchwork still intercepts this declaration, so tests can override it as usual.
+ *
+ * @param string $key The key to sanitize.
+ * @return string
+ */
+function sanitize_key( $key ) {
+	return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+}

--- a/tests/php/Support/fixtures/class-admin-functions-double.php
+++ b/tests/php/Support/fixtures/class-admin-functions-double.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Configurable Disable_Blog_Functions double for Disable_Blog_Admin tests.
+ *
+ * Overrides the Disable_Blog_Functions methods Disable_Blog_Admin calls through
+ * $this->functions, so a test can assert exactly what url redirect_admin_pages() decided
+ * on -- without exercising Disable_Blog_Functions's own real WordPress-calling logic, which
+ * DisableBlogFunctionsTest already covers.
+ *
+ * @package DisableBlog
+ */
+
+/**
+ * Test double standing in for Disable_Blog_Functions.
+ */
+class Disable_Blog_Admin_Functions_Double extends Disable_Blog_Functions {
+
+	/**
+	 * Every url passed to redirect(), in call order.
+	 *
+	 * @var string[]
+	 */
+	public $redirect_calls = array();
+
+	/**
+	 * @param string $redirect_url The url that was redirected to.
+	 * @return void
+	 */
+	public function redirect( $redirect_url ) {
+		$this->redirect_calls[] = $redirect_url;
+	}
+}

--- a/tests/php/Support/fixtures/class-admin-wpdb-double.php
+++ b/tests/php/Support/fixtures/class-admin-wpdb-double.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Minimal stand-in for the subset of $wpdb Disable_Blog_Admin::get_comment_counts() reads.
+ *
+ * A plain declared class rather than Mockery::mock(): get_comment_counts() reads ->comments
+ * and ->posts as real properties (interpolated directly into its SQL string) and calls
+ * get_results() as a real method, and phpstan (level 5) needs both to be visible on a known
+ * type instead of an untyped Mockery\MockInterface.
+ *
+ * @package DisableBlog
+ */
+
+/**
+ * Test double standing in for $wpdb.
+ */
+class Disable_Blog_Admin_Wpdb_Double {
+
+	/**
+	 * @var string
+	 */
+	public $comments = 'wp_comments';
+
+	/**
+	 * @var string
+	 */
+	public $posts = 'wp_posts';
+
+	/**
+	 * The rows get_results() answers with.
+	 *
+	 * @var array
+	 */
+	private $rows;
+
+	/**
+	 * @param array $rows The rows get_results() should return.
+	 */
+	public function __construct( array $rows ) {
+		$this->rows = $rows;
+	}
+
+	/**
+	 * @param string      $query  The SQL query (ignored -- this double always answers $rows).
+	 * @param string|null $output The output type (ignored).
+	 * @return array
+	 */
+	public function get_results( $query, $output = null ) {
+		return $this->rows;
+	}
+}

--- a/tests/php/Support/fixtures/class-disable-comments-stub.php
+++ b/tests/php/Support/fixtures/class-disable-comments-stub.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Minimal stand-in for the real Disable Comments plugin's main class.
+ *
+ * Disable_Blog_Integrations::is_disable_comments_active() checks class_exists('Disable_Comments')
+ * as an active-plugin fallback. Loaded only by IntegrationsTest's isolated process test for that
+ * branch -- a class declaration can't live inline in a test method (PHP disallows nesting a class
+ * declaration inside another class's method body) and, once declared, can never be undeclared, so
+ * it must stay out of the main test process entirely.
+ *
+ * @package DisableBlog
+ */
+
+class Disable_Comments {}

--- a/tests/php/Support/fixtures/class-public-functions-double.php
+++ b/tests/php/Support/fixtures/class-public-functions-double.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Configurable Disable_Blog_Functions double for Disable_Blog_Public tests.
+ *
+ * Overrides every Disable_Blog_Functions method Disable_Blog_Public calls through
+ * $this->functions, so a test can control each answer independently and, for redirect(),
+ * assert exactly what url the caller decided on -- without exercising Disable_Blog_Functions's
+ * own real WordPress-calling logic, which DisableBlogFunctionsTest already covers.
+ *
+ * @package DisableBlog
+ */
+
+/**
+ * Test double standing in for Disable_Blog_Functions.
+ */
+class Disable_Blog_Public_Functions_Double extends Disable_Blog_Functions {
+
+	/**
+	 * @var bool
+	 */
+	public $disable_author_archives_return = false;
+
+	/**
+	 * @var array|bool
+	 */
+	public $author_archive_post_types_return = false;
+
+	/**
+	 * @var bool
+	 */
+	public $disable_feeds_return = false;
+
+	/**
+	 * Every url passed to redirect(), in call order.
+	 *
+	 * @var string[]
+	 */
+	public $redirect_calls = array();
+
+	/**
+	 * @return bool
+	 */
+	public function disable_author_archives() {
+		return $this->disable_author_archives_return;
+	}
+
+	/**
+	 * @return array|bool
+	 */
+	public function author_archive_post_types() {
+		return $this->author_archive_post_types_return;
+	}
+
+	/**
+	 * @param object $post            The global post object.
+	 * @param bool   $is_comment_feed True if this is a comment feed.
+	 * @return bool
+	 */
+	public function disable_feeds( $post, $is_comment_feed = false ) {
+		return $this->disable_feeds_return;
+	}
+
+	/**
+	 * @param string $redirect_url The url that was redirected to.
+	 * @return void
+	 */
+	public function redirect( $redirect_url ) {
+		$this->redirect_calls[] = $redirect_url;
+	}
+}

--- a/tests/php/Support/fixtures/class-public-query-double.php
+++ b/tests/php/Support/fixtures/class-public-query-double.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Stand-in for the subset of WordPress core's WP_Query class Disable_Blog_Public reads.
+ *
+ * Deliberately NOT named WP_Query: PHPStan resolves the real WP_Query class from the
+ * szepeviktor/phpstan-wordpress stubs when analysing includes/, and a same-named class declared
+ * here (a real, scanned class, not a stub) would shadow that -- breaking phpstan's analysis of
+ * every OTHER real WP_Query usage in includes/ (e.g. class-disable-blog-admin.php's
+ * `new WP_Query( $args )`), since this file's minimal stand-in has no constructor or ->posts.
+ *
+ * Disable_Blog_Public::modify_query() / set_post_types_in_query() call
+ * method_exists( $query, 'set' ), which is false for a bare Mockery mock -- Mockery only
+ * answers unstubbed method names through __call(), which method_exists() can't see. Declaring
+ * real (empty) methods here gives Mockery::mock( 'Disable_Blog_Public_Query_Double' ) an actual
+ * class to subclass, so the generated double both satisfies method_exists() and stays fully
+ * controllable via shouldReceive().
+ *
+ * @package DisableBlog
+ */
+
+/**
+ * Test double standing in for a WP_Query instance.
+ */
+class Disable_Blog_Public_Query_Double {
+
+	/**
+	 * @return bool
+	 */
+	public function is_main_query() {
+		return true;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function is_tag() {
+		return false;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function is_category() {
+		return false;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function is_author() {
+		return false;
+	}
+
+	/**
+	 * @param string $key   The query var key.
+	 * @param mixed  $value The query var value.
+	 * @return void
+	 */
+	public function set( $key, $value ) {}
+
+	/**
+	 * @return void
+	 */
+	public function set_404() {}
+}

--- a/tests/php/Support/fixtures/class-wp-post-stub.php
+++ b/tests/php/Support/fixtures/class-wp-post-stub.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Minimal stand-in for WordPress core's WP_Post class.
+ *
+ * Disable_Blog_Public::redirect_public_pages() checks `$post instanceof WP_Post`. This
+ * WP_Mock-based unit suite never loads WordPress core, so a plain container with settable
+ * public properties is enough to satisfy that check and carry whatever property value a
+ * given test needs.
+ *
+ * @package DisableBlog
+ */
+
+/**
+ * Stand-in for WP_Post.
+ */
+class WP_Post {
+
+	/**
+	 * @var int
+	 */
+	public $ID = 1;
+
+	/**
+	 * @var string
+	 */
+	public $post_type = 'post';
+
+	/**
+	 * @param array $data Property values to set on the instance, keyed by property name.
+	 */
+	public function __construct( array $data = array() ) {
+		foreach ( $data as $key => $value ) {
+			$this->$key = $value;
+		}
+	}
+}

--- a/tests/php/Support/fixtures/class-wp-sitemaps-stub.php
+++ b/tests/php/Support/fixtures/class-wp-sitemaps-stub.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Minimal stand-in for WordPress core's WP_Sitemaps / WP_Sitemaps_Registry classes.
+ *
+ * Disable_Blog_Public::disable_removed_sitemaps() checks `$server instanceof WP_Sitemaps` and
+ * `$server->registry instanceof WP_Sitemaps_Registry` before reading the registered providers.
+ * Loaded only from PublicMiscTest's isolated-process tests for that method, alongside a
+ * test-declared wp_sitemaps_get_server() -- both a class declaration and a global function
+ * declaration are permanent for the rest of the process, so neither can live in the main
+ * (shared) test process.
+ *
+ * @package DisableBlog
+ */
+
+/**
+ * Stand-in for WP_Sitemaps_Registry.
+ */
+class WP_Sitemaps_Registry {
+
+	/**
+	 * @var array
+	 */
+	private $providers;
+
+	/**
+	 * @param array $providers Registered provider objects, keyed by name.
+	 */
+	public function __construct( array $providers = array() ) {
+		$this->providers = $providers;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function get_providers() {
+		return $this->providers;
+	}
+}
+
+/**
+ * Stand-in for WP_Sitemaps.
+ */
+class WP_Sitemaps {
+
+	/**
+	 * @var WP_Sitemaps_Registry
+	 */
+	public $registry;
+
+	/**
+	 * @param WP_Sitemaps_Registry $registry The sitemaps registry.
+	 */
+	public function __construct( WP_Sitemaps_Registry $registry ) {
+		$this->registry = $registry;
+	}
+}

--- a/tests/php/Support/fixtures/wp-admin/includes/plugin.php
+++ b/tests/php/Support/fixtures/wp-admin/includes/plugin.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Stand-in for WordPress core's wp-admin/includes/plugin.php.
+ *
+ * Disable_Blog_Integrations::is_plugin_active() only include_once()s this path when
+ * is_plugin_active() is not yet defined. Loaded solely by IntegrationsTest's isolated
+ * process test for that branch; ABSPATH is pointed at this fixtures directory there.
+ *
+ * @package DisableBlog
+ */
+
+/**
+ * Minimal is_plugin_active() so the include path under test has something real to call.
+ *
+ * @param string $plugin The plugin path.
+ * @return bool
+ */
+function is_plugin_active( $plugin ) {
+	return 'fixture-plugin/fixture-plugin.php' === $plugin;
+}

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -7,11 +7,24 @@
 
 require __DIR__ . '/../../vendor/autoload.php';
 
+// WP_Mock::bootstrap() defines ABSPATH only `if ( ! defined() )`, specifically so test
+// environments can override it first -- this points it at tests/php/Support/fixtures/ so
+// IntegrationsTest's isolated-process test can exercise Disable_Blog_Integrations::
+// is_plugin_active()'s `include_once ABSPATH . 'wp-admin/includes/plugin.php'` fallback
+// against a real fixture file instead of a nonexistent WordPress core path.
+define( 'ABSPATH', __DIR__ . '/Support/fixtures/' );
+
 WP_Mock::setUsePatchwork( true );
 WP_Mock::bootstrap();
 
 require __DIR__ . '/Support/WpPolyfills.php';
 require __DIR__ . '/includes/TestCase.php';
+require __DIR__ . '/includes/PluginLifecycleTestCase.php';
 
-// Plugin file under test.
+// Plugin files under test.
 require __DIR__ . '/../../includes/functions.php';
+require __DIR__ . '/../../includes/class-disable-blog-loader.php';
+require __DIR__ . '/../../includes/class-disable-blog-i18n.php';
+require __DIR__ . '/../../includes/class-disable-blog-integrations.php';
+require __DIR__ . '/../../includes/class-disable-blog-activator.php';
+require __DIR__ . '/../../includes/class-disable-blog-deactivator.php';

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -15,11 +15,25 @@ require __DIR__ . '/../../vendor/autoload.php';
 define( 'ABSPATH', __DIR__ . '/Support/fixtures/' );
 
 WP_Mock::setUsePatchwork( true );
+
+// Strict mode makes calling a WP function with no WP_Mock::userFunction() stub registered
+// for the CURRENT test throw ExpectationFailedException instead of silently returning null.
+// Without it, a test missing a stub only fails when it's the first test in the run to reach
+// that function (a fatal "call to undefined function", order-dependent); once any earlier
+// test has declared the function, later tests missing the stub pass by accident. Strict mode
+// makes every missing stub fail every time, regardless of run order. activateStrictMode()
+// is a no-op once WP_Mock::$__bootstrapped is true, so it must run before bootstrap().
+WP_Mock::activateStrictMode();
 WP_Mock::bootstrap();
 
 require __DIR__ . '/Support/WpPolyfills.php';
 require __DIR__ . '/includes/TestCase.php';
 require __DIR__ . '/includes/PluginLifecycleTestCase.php';
+
+// Core class stand-ins used across multiple test files; required once here (rather than
+// per test file) so nothing tries to redeclare them and fatals.
+require __DIR__ . '/Support/fixtures/class-wp-post-stub.php';
+require __DIR__ . '/Support/fixtures/class-public-query-double.php';
 
 // Plugin files under test.
 require __DIR__ . '/../../includes/functions.php';
@@ -28,3 +42,7 @@ require __DIR__ . '/../../includes/class-disable-blog-i18n.php';
 require __DIR__ . '/../../includes/class-disable-blog-integrations.php';
 require __DIR__ . '/../../includes/class-disable-blog-activator.php';
 require __DIR__ . '/../../includes/class-disable-blog-deactivator.php';
+
+// Disable_Blog_Functions is deliberately NOT required here -- see ConstructorInjectionTest.php's
+// note; LoaderTest's autoloader test needs it to remain undefined until its own isolated process.
+require __DIR__ . '/../../includes/class-disable-blog-public.php';

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * PHPUnit bootstrap for the plugin's WP_Mock-based unit suite.
+ *
+ * @package DisableBlog
+ */
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+WP_Mock::setUsePatchwork( true );
+WP_Mock::bootstrap();
+
+require __DIR__ . '/Support/WpPolyfills.php';
+require __DIR__ . '/includes/TestCase.php';
+
+// Plugin file under test.
+require __DIR__ . '/../../includes/functions.php';

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -46,3 +46,4 @@ require __DIR__ . '/../../includes/class-disable-blog-deactivator.php';
 // Disable_Blog_Functions is deliberately NOT required here -- see ConstructorInjectionTest.php's
 // note; LoaderTest's autoloader test needs it to remain undefined until its own isolated process.
 require __DIR__ . '/../../includes/class-disable-blog-public.php';
+require __DIR__ . '/../../includes/class-disable-blog-admin.php';

--- a/tests/php/includes/PluginLifecycleTestCase.php
+++ b/tests/php/includes/PluginLifecycleTestCase.php
@@ -1,0 +1,465 @@
+<?php
+/**
+ * Shared base test case for Disable_Blog_Activator and Disable_Blog_Deactivator.
+ *
+ * The two classes are structurally identical (get_request(), validate_request(), check_caps(),
+ * and a public static lifecycle method that reads $_REQUEST and holds static state), differing
+ * only in the verb ('activate' vs 'deactivate') baked into their nonce actions and $_REQUEST
+ * values. Subclasses supply that verb-specific vocabulary via the abstract methods below; every
+ * test method here is verb-agnostic.
+ *
+ * @package DisableBlog
+ */
+
+/**
+ * Base test case for Disable_Blog_Activator / Disable_Blog_Deactivator.
+ */
+abstract class PluginLifecycleTestCase extends TestCase {
+
+	/**
+	 * $_REQUEST as it stood before the test, so it can be restored in tear_down().
+	 *
+	 * @var array
+	 */
+	private $original_request;
+
+	/**
+	 * Fully-qualified name of the class under test.
+	 *
+	 * @return string
+	 */
+	abstract protected function target_class(): string;
+
+	/**
+	 * Name of the public static lifecycle method under test ('activate' or 'deactivate').
+	 *
+	 * @return string
+	 */
+	abstract protected function lifecycle_method(): string;
+
+	/**
+	 * Nonce action prefix used for the single-plugin path (e.g. 'activate-plugin_').
+	 *
+	 * @return string
+	 */
+	abstract protected function single_nonce_action_prefix(): string;
+
+	/**
+	 * $_REQUEST['action'] value expected on the single-plugin path (e.g. 'activate').
+	 *
+	 * @return string
+	 */
+	abstract protected function single_action_value(): string;
+
+	/**
+	 * $_REQUEST['action'] value expected on the bulk path (e.g. 'activate-selected').
+	 *
+	 * @return string
+	 */
+	abstract protected function bulk_action_value(): string;
+
+	protected function set_up() {
+		parent::set_up();
+
+		$this->original_request = $_REQUEST;
+
+		$this->reset_target_static_state();
+
+		// Every get_request() path runs $_REQUEST values through these before use; treat
+		// them as passthroughs so tests can assert on the raw values they set.
+		WP_Mock::userFunction( 'sanitize_text_field', array( 'return_arg' => 0 ) );
+		WP_Mock::userFunction( 'wp_unslash', array( 'return_arg' => 0 ) );
+	}
+
+	protected function tear_down() {
+		$_REQUEST = $this->original_request;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Resets the target class's static::$request and static::$plugin to their initial
+	 * values. Both are private static properties that persist across tests in the same
+	 * process, so without this, an earlier test's leftover state would leak into the next.
+	 *
+	 * @return void
+	 */
+	private function reset_target_static_state() {
+		$class = new ReflectionClass( $this->target_class() );
+
+		$request_property = $class->getProperty( 'request' );
+		$request_property->setAccessible( true );
+		$request_property->setValue( null, array() );
+
+		$plugin_property = $class->getProperty( 'plugin' );
+		$plugin_property->setAccessible( true );
+		$plugin_property->setValue( null, 'disable-blog' );
+	}
+
+	/**
+	 * Directly sets the target class's static::$request, bypassing get_request(), so
+	 * validate_request() can be tested in isolation.
+	 *
+	 * @param array $value The value to assign.
+	 * @return void
+	 */
+	private function set_target_static_request( array $value ) {
+		$class    = new ReflectionClass( $this->target_class() );
+		$property = $class->getProperty( 'request' );
+		$property->setAccessible( true );
+		$property->setValue( null, $value );
+	}
+
+	/**
+	 * Invokes a private static method on the target class via Reflection.
+	 *
+	 * @param string $method Method name.
+	 * @param array  $args   Positional arguments.
+	 * @return mixed
+	 */
+	private function invoke_private_static( $method, array $args = array() ) {
+		$class      = new ReflectionClass( $this->target_class() );
+		$reflection = $class->getMethod( $method );
+		$reflection->setAccessible( true );
+
+		return $reflection->invokeArgs( null, $args );
+	}
+
+	/**
+	 * Invokes the target class's public static lifecycle method (activate()/deactivate()).
+	 *
+	 * @return mixed
+	 */
+	private function invoke_lifecycle_method() {
+		$target = $this->target_class();
+		$method = $this->lifecycle_method();
+
+		return $target::$method();
+	}
+
+	/**
+	 * get_request()
+	 */
+
+	/**
+	 * The `! empty( $_REQUEST )` clause in get_request()'s outer guard can't be isolated by
+	 * any input: whenever $_REQUEST is empty, the isset() checks that follow it in the same
+	 * && chain already evaluate false on their own, so this test cannot distinguish that
+	 * clause being present from it being absent. It still confirms the real, non-redundant
+	 * behavior that a request with no keys at all returns false without a PHP notice on the
+	 * missing array indexes.
+	 */
+	public function test_get_request_returns_false_when_request_has_no_keys_at_all() {
+		$_REQUEST = array();
+
+		$this->assertFalse( $this->invoke_private_static( 'get_request' ) );
+	}
+
+	public function test_get_request_returns_false_when_required_keys_missing() {
+		// Has 'plugin' and '_wpnonce', but no 'action' -- the outer guard must fail closed.
+		$_REQUEST = array(
+			'_wpnonce' => 'nonce-value',
+			'plugin'   => 'disable-blog',
+		);
+
+		$this->assertFalse( $this->invoke_private_static( 'get_request' ) );
+	}
+
+	public function test_get_request_returns_populated_array_when_single_plugin_nonce_valid() {
+		$_REQUEST = array(
+			'_wpnonce' => 'nonce-value',
+			'action'   => $this->single_action_value(),
+			'plugin'   => 'disable-blog',
+		);
+
+		WP_Mock::userFunction( 'wp_verify_nonce' )
+			->once()
+			->with( 'nonce-value', $this->single_nonce_action_prefix() . 'disable-blog' )
+			->andReturn( 1 );
+
+		$this->assertSame(
+			array(
+				'plugin' => 'disable-blog',
+				'action' => $this->single_action_value(),
+			),
+			$this->invoke_private_static( 'get_request' )
+		);
+	}
+
+	public function test_get_request_returns_false_when_single_plugin_nonce_invalid() {
+		$_REQUEST = array(
+			'_wpnonce' => 'bad-nonce',
+			'action'   => $this->single_action_value(),
+			'plugin'   => 'disable-blog',
+		);
+
+		WP_Mock::userFunction( 'wp_verify_nonce' )
+			->once()
+			->with( 'bad-nonce', $this->single_nonce_action_prefix() . 'disable-blog' )
+			->andReturn( false );
+
+		$this->assertFalse( $this->invoke_private_static( 'get_request' ) );
+	}
+
+	public function test_get_request_returns_populated_array_when_bulk_nonce_valid() {
+		$_REQUEST = array(
+			'_wpnonce' => 'nonce-value',
+			'action'   => $this->bulk_action_value(),
+			'checked'  => array( 'disable-blog', 'other-plugin' ),
+		);
+
+		WP_Mock::userFunction( 'wp_verify_nonce' )
+			->once()
+			->with( 'nonce-value', 'bulk-plugins' )
+			->andReturn( 1 );
+
+		$this->assertSame(
+			array(
+				'action'  => $this->bulk_action_value(),
+				'plugins' => array( 'disable-blog', 'other-plugin' ),
+			),
+			$this->invoke_private_static( 'get_request' )
+		);
+	}
+
+	public function test_get_request_returns_false_when_bulk_nonce_invalid() {
+		$_REQUEST = array(
+			'_wpnonce' => 'bad-nonce',
+			'action'   => $this->bulk_action_value(),
+			'checked'  => array( 'disable-blog' ),
+		);
+
+		WP_Mock::userFunction( 'wp_verify_nonce' )
+			->once()
+			->with( 'bad-nonce', 'bulk-plugins' )
+			->andReturn( false );
+
+		$this->assertFalse( $this->invoke_private_static( 'get_request' ) );
+	}
+
+	/**
+	 * validate_request( $plugin )
+	 */
+
+	public function test_validate_request_true_for_matching_single_plugin() {
+		$this->set_target_static_request(
+			array(
+				'plugin' => 'disable-blog',
+				'action' => $this->single_action_value(),
+			)
+		);
+
+		$this->assertTrue( $this->invoke_private_static( 'validate_request', array( 'disable-blog' ) ) );
+	}
+
+	public function test_validate_request_false_for_mismatched_plugin() {
+		$this->set_target_static_request(
+			array(
+				'plugin' => 'some-other-plugin',
+				'action' => $this->single_action_value(),
+			)
+		);
+
+		$this->assertFalse( $this->invoke_private_static( 'validate_request', array( 'disable-blog' ) ) );
+	}
+
+	public function test_validate_request_false_for_wrong_action() {
+		$this->set_target_static_request(
+			array(
+				'plugin' => 'disable-blog',
+				'action' => 'some-unrelated-action',
+			)
+		);
+
+		$this->assertFalse( $this->invoke_private_static( 'validate_request', array( 'disable-blog' ) ) );
+	}
+
+	public function test_validate_request_true_for_matching_bulk_selection() {
+		$this->set_target_static_request(
+			array(
+				'plugins' => array( 'other-plugin', 'disable-blog' ),
+				'action'  => $this->bulk_action_value(),
+			)
+		);
+
+		$this->assertTrue( $this->invoke_private_static( 'validate_request', array( 'disable-blog' ) ) );
+	}
+
+	public function test_validate_request_false_when_plugin_not_in_bulk_selection() {
+		$this->set_target_static_request(
+			array(
+				'plugins' => array( 'other-plugin' ),
+				'action'  => $this->bulk_action_value(),
+			)
+		);
+
+		$this->assertFalse( $this->invoke_private_static( 'validate_request', array( 'disable-blog' ) ) );
+	}
+
+	public function test_validate_request_false_when_neither_plugin_nor_plugins_set() {
+		$this->set_target_static_request( array() );
+
+		$this->assertFalse( $this->invoke_private_static( 'validate_request', array( 'disable-blog' ) ) );
+	}
+
+	/**
+	 * check_caps()
+	 */
+
+	public function test_check_caps_true_when_user_can_activate_plugins() {
+		WP_Mock::userFunction( 'current_user_can' )
+			->once()
+			->with( 'activate_plugins' )
+			->andReturn( true );
+
+		$this->assertTrue( $this->invoke_private_static( 'check_caps' ) );
+	}
+
+	public function test_check_caps_false_when_user_cannot_activate_plugins() {
+		WP_Mock::userFunction( 'current_user_can' )
+			->once()
+			->with( 'activate_plugins' )
+			->andReturn( false );
+
+		$this->assertFalse( $this->invoke_private_static( 'check_caps' ) );
+	}
+
+	/**
+	 * activate() / deactivate()
+	 */
+
+	/**
+	 * Terminating paths guarded by check_admin_referer() end in exit;, which a test process
+	 * can't survive. Stubbing check_admin_referer() to throw exercises the guard clause and
+	 * proves the exception propagates out of the lifecycle method -- but the exception is
+	 * thrown by check_admin_referer() itself, so control never reaches the exit; statement
+	 * that follows it. Verifying that literal exit; is reached is out of reach without a
+	 * source-side refactor (e.g. routing through a wrapper exit() could be intercepted), which
+	 * is out of scope for a zero-source-change phase.
+	 */
+	public function test_public_static_method_calls_check_admin_referer_with_correct_action_and_propagates_exception_when_single_plugin_validation_fails() {
+		$_REQUEST = array(
+			'_wpnonce' => 'nonce-value',
+			'action'   => $this->single_action_value(),
+			'plugin'   => 'some-other-plugin',
+		);
+
+		WP_Mock::userFunction( 'wp_verify_nonce' )
+			->once()
+			->with( 'nonce-value', $this->single_nonce_action_prefix() . 'some-other-plugin' )
+			->andReturn( 1 );
+
+		// get_request() succeeds (nonce valid) and populates static::$request['plugin'] with
+		// 'some-other-plugin', so validate_request() fails on the plugin-name comparison --
+		// not on a missing array key -- keeping the interpolation below well-defined.
+		WP_Mock::userFunction( 'check_admin_referer' )
+			->once()
+			->with( $this->single_nonce_action_prefix() . 'some-other-plugin' )
+			->andThrow( new Exception( 'halted' ) );
+
+		WP_Mock::userFunction( 'wp_cache_delete' )->never();
+		WP_Mock::userFunction( 'delete_transient' )->never();
+		WP_Mock::userFunction( 'flush_rewrite_rules' )->never();
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'halted' );
+
+		$this->invoke_lifecycle_method();
+	}
+
+	/**
+	 * See the docblock on the single-plugin variant above: this proves check_admin_referer()
+	 * is called with the bulk nonce action and that its exception propagates, not that the
+	 * exit; statement itself is reached.
+	 */
+	public function test_public_static_method_calls_check_admin_referer_with_bulk_action_and_propagates_exception_when_bulk_nonce_invalid() {
+		$_REQUEST = array(
+			'_wpnonce' => 'bad-nonce',
+			'action'   => $this->bulk_action_value(),
+			'checked'  => array( 'some-other-plugin' ),
+		);
+
+		WP_Mock::userFunction( 'wp_verify_nonce' )
+			->once()
+			->with( 'bad-nonce', 'bulk-plugins' )
+			->andReturn( false );
+
+		WP_Mock::userFunction( 'check_admin_referer' )
+			->once()
+			->with( 'bulk-plugins' )
+			->andThrow( new Exception( 'halted' ) );
+
+		WP_Mock::userFunction( 'wp_cache_delete' )->never();
+		WP_Mock::userFunction( 'delete_transient' )->never();
+		WP_Mock::userFunction( 'flush_rewrite_rules' )->never();
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'halted' );
+
+		$this->invoke_lifecycle_method();
+	}
+
+	/**
+	 * When $_REQUEST has neither 'plugin' nor 'checked', the guard's if/elseif has no
+	 * matching branch and no else -- check_admin_referer() is never called and execution
+	 * falls straight through to the cleanup calls. This is the source's actual behavior,
+	 * quirky as it is.
+	 */
+	public function test_public_static_method_proceeds_without_referer_check_when_neither_plugin_nor_checked_present() {
+		$_REQUEST = array();
+
+		WP_Mock::userFunction( 'check_admin_referer' )->never();
+
+		WP_Mock::userFunction( 'wp_cache_delete' )->once()->with( 'comments-0', 'counts' );
+		WP_Mock::userFunction( 'delete_transient' )->once()->with( 'wc_count_comments' );
+
+		$flush_called = false;
+		WP_Mock::userFunction( 'flush_rewrite_rules' )
+			->once()
+			->andReturnUsing(
+				function () use ( &$flush_called ) {
+					$flush_called = true;
+				}
+			);
+
+		$this->invoke_lifecycle_method();
+
+		$this->assertTrue( $flush_called );
+	}
+
+	public function test_public_static_method_skips_referer_check_and_runs_cleanup_when_fully_validated() {
+		$_REQUEST = array(
+			'_wpnonce' => 'nonce-value',
+			'action'   => $this->single_action_value(),
+			'plugin'   => 'disable-blog',
+		);
+
+		WP_Mock::userFunction( 'wp_verify_nonce' )
+			->once()
+			->with( 'nonce-value', $this->single_nonce_action_prefix() . 'disable-blog' )
+			->andReturn( 1 );
+
+		WP_Mock::userFunction( 'current_user_can' )
+			->once()
+			->with( 'activate_plugins' )
+			->andReturn( true );
+
+		WP_Mock::userFunction( 'check_admin_referer' )->never();
+
+		WP_Mock::userFunction( 'wp_cache_delete' )->once()->with( 'comments-0', 'counts' );
+		WP_Mock::userFunction( 'delete_transient' )->once()->with( 'wc_count_comments' );
+
+		$flush_called = false;
+		WP_Mock::userFunction( 'flush_rewrite_rules' )
+			->once()
+			->andReturnUsing(
+				function () use ( &$flush_called ) {
+					$flush_called = true;
+				}
+			);
+
+		$this->invoke_lifecycle_method();
+
+		$this->assertTrue( $flush_called );
+	}
+}

--- a/tests/php/includes/TestCase.php
+++ b/tests/php/includes/TestCase.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Shared base test case wiring WP_Mock into PHPUnit's lifecycle.
+ *
+ * @package DisableBlog
+ */
+
+/**
+ * Base test case for the plugin's WP_Mock-based unit suite.
+ */
+class TestCase extends \Yoast\PHPUnitPolyfills\TestCases\TestCase {
+
+	/**
+	 * Boots WP_Mock and registers the common translation passthroughs before each test.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		WP_Mock::setUp();
+
+		// Translation functions used throughout the plugin: pass the first argument through.
+		WP_Mock::userFunction(
+			'__',
+			array(
+				'return_arg' => 0,
+			)
+		);
+		WP_Mock::userFunction(
+			'_e',
+			array(
+				'return_arg' => 0,
+			)
+		);
+		WP_Mock::userFunction(
+			'esc_html__',
+			array(
+				'return_arg' => 0,
+			)
+		);
+		WP_Mock::userFunction(
+			'esc_html_e',
+			array(
+				'return_arg' => 0,
+			)
+		);
+		WP_Mock::userFunction(
+			'esc_attr__',
+			array(
+				'return_arg' => 0,
+			)
+		);
+	}
+
+	/**
+	 * Tears down WP_Mock after each test.
+	 *
+	 * @return void
+	 */
+	protected function tear_down() {
+		WP_Mock::tearDown();
+
+		parent::tear_down();
+	}
+}


### PR DESCRIPTION
Builds a PHPUnit suite on WP_Mock, replacing the dormant `tests/phpunit` branch (closed as #70). **399 tests / 528 assertions, 96.97% line coverage (895/923).**

Based on `e2e/playwright` rather than `stable`, since it changes the same files this suite targets.

## Coverage

| Class | Lines | Methods |
|---|---|---|
| `Disable_Blog_Admin` | 100% (440/440) | 100% (48/48) |
| `Disable_Blog_Public` | 100% (187/187) | 100% (19/19) |
| `Disable_Blog_Loader` | 100% (32/32) | 100% (8/8) |
| `Disable_Blog_Integrations` | 100% (16/16) | 100% (5/5) |
| `Disable_Blog_I18n` | 100% (5/5) | 100% (1/1) |
| `Disable_Blog_Functions` | 97.30% (36/37) | 87.50% (7/8) |
| `Disable_Blog_Activator` | 94.44% (34/36) | 75% (3/4) |
| `Disable_Blog_Deactivator` | 94.44% (34/36) | 75% (3/4) |
| `Disable_Blog` | 76.60% (72/94) | 81.82% (9/11) |

The ~28 uncovered lines are structurally unreachable, not skipped:

- Five `exit;` statements (Activator ×2, Deactivator ×2, `Disable_Blog_Functions::redirect()`). `exit` is a language construct, so Patchwork cannot intercept it. Everything around them is covered by stubbing the preceding WP function to throw.
- `Disable_Blog::load_dependencies()` and its constructor. It performs a bare `include` of classes the test bootstrap already requires, so invoking it fatals on redeclaration in any process. The class is exercised via `newInstanceWithoutConstructor()`.

## Toolchain

PHPUnit 9.6, `10up/wp_mock` ^1.1, `yoast/phpunit-polyfills` ^4.0, `mockery/mockery` ^1.6. PHPUnit 9.6 is fixed by WP_Mock, which has no PHPUnit 10+ support. Patchwork arrives transitively.

Coverage uses Xdebug rather than pcov, because pcov cannot collect coverage inside `@runInSeparateProcess` subprocesses, which several tests require.

CI gains a `phpunit` job (PHP 7.4 and 8.4, no coverage driver) and a `coverage` job (8.4, Xdebug).

## Source changes

Two, both minimal and backward compatible:

1. `Disable_Blog_Admin` and `Disable_Blog_Public` take an optional third constructor argument so a `Disable_Blog_Functions` double can be injected. Both existing call sites pass two arguments and are unaffected.
2. `dwpb_post_types_with_tax()` now caches, matching `dwpb_post_types_with_feature()`. The key hashes taxonomy, `$args` and `$output` separately. `get_post_types()` and the `dwpb_taxonomy_support` filter still run on a cache hit, since that filter documents `$post_types` among its arguments.

No other file under `includes/` is modified.

## Test-quality measures

**WP_Mock strict mode is enabled.** WP_Mock declares stubs by `eval` at call time and they persist for the process, so a test that never stubs a function its code path calls still passes whenever an earlier test declared it — the suite passed or failed by run order. Two such bugs shipped before this was caught (`sanitize_key`, then `is_admin`, the latter failing only on random seed 6). Strict mode makes every missing stub fail immediately. Enabling it exposed 61 tests across seven files relying on an implicitly declared function or a silently passed-through filter.

Order-independence is verified against default, reverse and many random seeds.

**`tests/php` is held to the same standards as plugin source** — PHPCS (WordPress-VIP-Go) and PHPStan level 5. Exemptions are scoped with `path:`/`exclude-pattern` to individual files so none can mask an error in `includes/`, and each carries its justification. This required PHPStan ^2.2 for `phpstan-phpunit`, and removing a stale `implode()` ignore that newer `wordpress-stubs` no longer triggers.

Every test was verified load-bearing: the covered source was mutated, the test confirmed failing, then restored.

## Known limitations

- `dwpb_post_types_with_tax()`'s negative result is not cached. `wp_cache_get()` returns `false` on a miss, so a cached `false` recomputes on every call — likely the common case. This mirrors `dwpb_post_types_with_feature()`, which has the same behavior. Fixing it properly needs a sentinel value in both.
- `_n()` cannot be stubbed. WP_Mock hard-codes it with real singular/plural logic that bypasses the expectation system, so a `userFunction()` stub registers an expectation that never resolves. Tests let the real logic run.
- Mockery's `->with()` compares arrays with loose `==`, so `array('x') == true`. Assertions where the exact type matters use `Mockery::on()` with `assertSame()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)