### PR TITLE
Testability seams, working negative cache, and honest PHPCS suppressions

### DIFF
--- a/includes/class-disable-blog-activator.php
+++ b/includes/class-disable-blog-activator.php
@@ -54,11 +54,11 @@ class Disable_Blog_Activator {
 		) {
 			if ( isset( $_REQUEST['plugin'] ) ) {
 				if ( ! check_admin_referer( 'activate-plugin_' . self::$request['plugin'] ) ) {
-					exit;
+					static::terminate();
 				}
 			} elseif ( isset( $_REQUEST['checked'] ) ) {
 				if ( ! check_admin_referer( 'bulk-plugins' ) ) {
-					exit;
+					static::terminate();
 				}
 			}
 		}
@@ -70,6 +70,20 @@ class Disable_Blog_Activator {
 		wp_cache_delete( 'comments-0', 'counts' );
 		delete_transient( 'wc_count_comments' );
 		flush_rewrite_rules();
+	}
+
+	/**
+	 * Wraps `exit` so a test subclass can override it to observe termination
+	 * without actually ending the process.
+	 *
+	 * Uses late static binding (`static::`) rather than `self::` so subclasses
+	 * can override this method; called via `static::terminate()`.
+	 *
+	 * @since 0.5.6
+	 * @return void
+	 */
+	protected static function terminate() {
+		exit;
 	}
 
 	/**

--- a/includes/class-disable-blog-admin.php
+++ b/includes/class-disable-blog-admin.php
@@ -115,9 +115,7 @@ class Disable_Blog_Admin {
 
 			foreach ( $arguments_to_remove as $arg ) {
 				if ( isset( $wp_post_types['post']->$arg ) ) {
-					// @codingStandardsIgnoreStart - phpcs doesn't like using variables like this.
 					$wp_post_types['post']->$arg = false;
-					// @codingStandardsIgnoreEnd
 				}
 			}
 
@@ -178,9 +176,7 @@ class Disable_Blog_Admin {
 
 					foreach ( $arguments_to_remove as $arg ) {
 						if ( isset( $wp_taxonomies[ $tax ]->$arg ) ) {
-							// @codingStandardsIgnoreStart - phpcs doesn't like using variables like this.
 							$wp_taxonomies[ $tax ]->$arg = false;
-							// @codingStandardsIgnoreEnd
 						}
 					}
 				}
@@ -312,9 +308,7 @@ class Disable_Blog_Admin {
 	 */
 	public function redirect_admin_post() {
 
-		// @codingStandardsIgnoreStart - phpcs wants to sanitize this, but it's not necessary.
-		return ( isset( $_GET['post'] ) && 'post' == get_post_type( $_GET['post'] ) );
-		// @codingStandardsIgnoreEnd
+		return ( isset( $_GET['post'] ) && 'post' == get_post_type( $_GET['post'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- read-only redirect-target check, not a state-changing form submission, so no nonce applies; $_GET['post'] only reaches get_post_type(), which resolves it via get_post() rather than a query or output, so it needs no extra sanitizing.
 	}
 
 	/**
@@ -325,9 +319,8 @@ class Disable_Blog_Admin {
 	 */
 	public function redirect_admin_edit() {
 
-		// @codingStandardsIgnoreStart - phpcs wants to sanitize this, but it's not necessary.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only redirect-target check, not a state-changing form submission, so no nonce applies.
 		if ( ! isset( $_GET['post_type'] ) || isset( $_GET['post_type'] ) && $_GET['post_type'] == 'post' ) {
-		// @codingStandardsIgnoreEnd
 
 			return admin_url( 'edit.php?post_type=page' );
 
@@ -344,9 +337,8 @@ class Disable_Blog_Admin {
 	 */
 	public function redirect_admin_post_new() {
 
-		// @codingStandardsIgnoreStart - phpcs wants to sanitize this, but it's not necessary.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only redirect-target check, not a state-changing form submission, so no nonce applies.
 		if ( ( ! isset( $_GET['post_type'] ) || isset( $_GET['post_type'] ) && $_GET['post_type'] == 'post' ) ) {
-		// @codingStandardsIgnoreEnd
 
 			return admin_url( 'post-new.php?post_type=page' );
 
@@ -365,9 +357,7 @@ class Disable_Blog_Admin {
 	 */
 	public function redirect_admin_term() {
 
-		// @codingStandardsIgnoreStart - phpcs wants to sanitize this, but it's not necessary.
-		return ( isset( $_GET['taxonomy'] ) && ! dwpb_post_types_with_tax( $_GET['taxonomy'] ) );
-		// @codingStandardsIgnoreEnd
+		return ( isset( $_GET['taxonomy'] ) && ! dwpb_post_types_with_tax( $_GET['taxonomy'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- read-only redirect-target check, not a state-changing form submission, so no nonce applies; $_GET['taxonomy'] only reaches dwpb_post_types_with_tax(), which compares it against registered taxonomy names and hashes it into a wp_cache key, never a query or output.
 	}
 
 	/**
@@ -378,9 +368,7 @@ class Disable_Blog_Admin {
 	 */
 	public function redirect_admin_edit_tags() {
 
-		// @codingStandardsIgnoreStart - phpcs wants to sanitize this, but it's not necessary.
-		return ( isset( $_GET['taxonomy'] ) && ! dwpb_post_types_with_tax( $_GET['taxonomy'] ) );
-		// @codingStandardsIgnoreEnd
+		return ( isset( $_GET['taxonomy'] ) && ! dwpb_post_types_with_tax( $_GET['taxonomy'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- read-only redirect-target check, not a state-changing form submission, so no nonce applies; $_GET['taxonomy'] only reaches dwpb_post_types_with_tax(), which compares it against registered taxonomy names and hashes it into a wp_cache key, never a query or output.
 	}
 
 	/**
@@ -442,9 +430,7 @@ class Disable_Blog_Admin {
 		 * The isset( $_GET['page'] ) check is to confirm the page
 		 * isn't a 3rd party plugin's option page built into the tools page.
 		 */
-		// @codingStandardsIgnoreStart - phpcs wants to nounce this, but that's not needed.
-		return ! isset( $_GET['page'] );
-		// @codingStandardsIgnoreEnd
+		return ! isset( $_GET['page'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only check for a 3rd-party plugin's tools sub-page, not a state-changing form submission, so no nonce applies.
 	}
 
 	/**
@@ -930,7 +916,7 @@ class Disable_Blog_Admin {
 		$in_post_types = implode( "','", $sanitized_post_types );
 
 		// Grab the comments that are associated with supported post types only.
-		// @codingStandardsIgnoreStart -- The get_results function doesn't need a wpdb->prepare here because $in_post_types is sanitized above.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- no wpdb schema method covers this comments/posts join, so a direct query is unavoidable; the absence of caching is not, and this result is recomputed on every call; $in_post_types is esc_sql()'d above and comes from dwpb_post_types_with_feature() (get_post_types() output), never request input, so the interpolation is not an injection vector.
 		$totals = (array) $wpdb->get_results(
 			"SELECT comment_approved, COUNT( * ) AS total
 			FROM {$wpdb->comments}
@@ -942,7 +928,7 @@ class Disable_Blog_Admin {
 			GROUP BY comment_approved",
 			ARRAY_A
 		);
-		// @codingStandardsIgnoreEnd
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		foreach ( $totals as $row ) {
 			switch ( $row['comment_approved'] ) {
@@ -1074,11 +1060,11 @@ class Disable_Blog_Admin {
 		$sslverify = apply_filters( 'https_local_ssl_verify', false );
 
 		// Include Basic auth in loopback requests.
-		// @codingStandardsIgnoreStart
+		// phpcs:disable WordPressVIPMinimum.Variables.ServerVariables.BasicAuthentication, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- mirrors core's WP_Site_Health::get_test_rest_availability(), relaying the site's own already-validated Basic Auth credentials to this same-site loopback REST request so password-protected sites still pass the check; there is no external input to sanitize.
 		if ( isset( $_SERVER['PHP_AUTH_USER'] ) && isset( $_SERVER['PHP_AUTH_PW'] ) ) {
 			$headers['Authorization'] = 'Basic ' . base64_encode( wp_unslash( $_SERVER['PHP_AUTH_USER'] ) . ':' . wp_unslash( $_SERVER['PHP_AUTH_PW'] ) );
 		}
-		// @codingStandardsIgnoreEnd
+		// phpcs:enable WordPressVIPMinimum.Variables.ServerVariables.BasicAuthentication, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		// -- here's the money, change this from 'post' to  'page'.
 		$url = rest_url( 'wp/v2/types/page' );
@@ -1091,7 +1077,7 @@ class Disable_Blog_Admin {
 			$url
 		);
 
-		$r = wp_remote_get( $url, compact( 'cookies', 'headers', 'timeout', 'sslverify' ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
+		$r = wp_remote_get( $url, compact( 'cookies', 'headers', 'timeout', 'sslverify' ) );
 
 		if ( is_wp_error( $r ) ) {
 			$result['status'] = 'critical';
@@ -1343,20 +1329,18 @@ class Disable_Blog_Admin {
 
 				// Note that we have to explicitly add the query variable for post type in order
 				// to avoid it being stripped by the admin redirect on the edit.php page.
-				// @codingStandardsIgnoreStart - phpcs doesn't like the mismatched placeholders, but it works.
 				$output = sprintf(
 					'<a href="%s" class="edit"><span aria-hidden="true">%s</span><span class="screen-reader-text">%s</span></a>',
 					"edit.php?post_type={$post_type}&author={$user_id}",
 					$page_count,
 					sprintf(
 						// translators: %1$s: Number of pieces of content by this author. %2$s and %3$s are the singular and plural names, respectively, for the content type. For example: "1 page by this author" and "2 pages by this author".
-						_n( '%1$s %2$s by this author', '%1$s %3$s by this author', $page_count, 'disable-blog' ),
+						_n( '%1$s %2$s by this author', '%1$s %3$s by this author', $page_count, 'disable-blog' ), // phpcs:ignore WordPress.WP.I18n.MismatchedPlaceholders -- the singular and plural strings intentionally reference different placeholders (%2$s the singular label, %3$s the plural label), since only one of the two names applies per branch; this is correct _n() usage, not a mismatch.
 						number_format_i18n( $page_count ),
 						$post_type_obj->labels->singular_name,
 						$post_type_obj->labels->name
 					)
 				);
-				// @codingStandardsIgnoreEnd
 			}
 		}
 
@@ -1474,7 +1458,7 @@ class Disable_Blog_Admin {
 	public function posts_page_notice() {
 
 		// translators: this notice informs the user why the blog page editor is disabled and that it is redirected to the homepage.
-		echo '<div class="notice notice-warning inline"><p>' . __( 'You are currently editing the page that shows your latest posts, which is redirected to the homepage because the blog is disabled.', 'disable-blog' ) . '</p></div>'; // phpcs:ignore
+		echo '<div class="notice notice-warning inline"><p>' . esc_html__( 'You are currently editing the page that shows your latest posts, which is redirected to the homepage because the blog is disabled.', 'disable-blog' ) . '</p></div>';
 	}
 
 	/**

--- a/includes/class-disable-blog-admin.php
+++ b/includes/class-disable-blog-admin.php
@@ -1035,21 +1035,21 @@ class Disable_Blog_Admin {
 	public function get_test_rest_availability() {
 
 		$result = array(
-			'label'       => __( 'The REST API is available' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+			'label'       => __( 'The REST API is available' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reuses core's own Site Health string verbatim so it inherits core's translation; adding a domain here would orphan it.
 			'status'      => 'good',
 			'badge'       => array(
-				'label' => __( 'Performance' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+				'label' => __( 'Performance' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reuses core's own Site Health string verbatim so it inherits core's translation; adding a domain here would orphan it.
 				'color' => 'blue',
 			),
 			'description' => sprintf(
 				'<p>%s</p>',
-				__( 'The REST API is one way WordPress, and other applications, communicate with the server. One example is the block editor screen, which relies on this to display, and save, your posts and pages.' ) // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+				__( 'The REST API is one way WordPress, and other applications, communicate with the server. One example is the block editor screen, which relies on this to display, and save, your posts and pages.' ) // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reuses core's own Site Health string verbatim so it inherits core's translation; adding a domain here would orphan it.
 			),
 			'actions'     => '',
 			'test'        => 'rest_availability',
 		);
 
-		$cookies = wp_unslash( $_COOKIE ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		$cookies = wp_unslash( $_COOKIE ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE -- forwards the current request's cookies to a same-site loopback request; this runs only inside the admin Site Health check, which is never full-page cached.
 		$timeout = 10;
 		$headers = array(
 			'Cache-Control' => 'no-cache',
@@ -1082,16 +1082,16 @@ class Disable_Blog_Admin {
 		if ( is_wp_error( $r ) ) {
 			$result['status'] = 'critical';
 
-			$result['label'] = __( 'The REST API encountered an error' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+			$result['label'] = __( 'The REST API encountered an error' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reuses core's own Site Health string verbatim so it inherits core's translation; adding a domain here would orphan it.
 
 			$result['description'] .= sprintf(
 				'<p>%s</p>',
 				sprintf(
 					'%s<br>%s',
-					__( 'The REST API request failed due to an error.' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+					__( 'The REST API request failed due to an error.' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reuses core's own Site Health string verbatim so it inherits core's translation; adding a domain here would orphan it.
 					sprintf(
 						/* translators: 1: The WordPress error message. 2: The WordPress error code. */
-						__( 'Error: %1$s (%2$s)' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+						__( 'Error: %1$s (%2$s)' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reuses core's own Site Health string verbatim so it inherits core's translation; adding a domain here would orphan it.
 						$r->get_error_message(),
 						$r->get_error_code()
 					)
@@ -1100,13 +1100,13 @@ class Disable_Blog_Admin {
 		} elseif ( 200 !== wp_remote_retrieve_response_code( $r ) ) {
 			$result['status'] = 'recommended';
 
-			$result['label'] = __( 'The REST API encountered an unexpected result' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+			$result['label'] = __( 'The REST API encountered an unexpected result' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reuses core's own Site Health string verbatim so it inherits core's translation; adding a domain here would orphan it.
 
 			$result['description'] .= sprintf(
 				'<p>%s</p>',
 				sprintf(
 					/* translators: 1: The HTTP error code. 2: The HTTP error message. */
-					__( 'The REST API call gave the following unexpected result: (%1$d) %2$s.' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+					__( 'The REST API call gave the following unexpected result: (%1$d) %2$s.' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reuses core's own Site Health string verbatim so it inherits core's translation; adding a domain here would orphan it.
 					wp_remote_retrieve_response_code( $r ),
 					esc_html( wp_remote_retrieve_body( $r ) )
 				)
@@ -1117,13 +1117,13 @@ class Disable_Blog_Admin {
 			if ( false !== $json && ! isset( $json['capabilities'] ) ) {
 				$result['status'] = 'recommended';
 
-				$result['label'] = __( 'The REST API did not behave correctly' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+				$result['label'] = __( 'The REST API did not behave correctly' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reuses core's own Site Health string verbatim so it inherits core's translation; adding a domain here would orphan it.
 
 				$result['description'] .= sprintf(
 					'<p>%s</p>',
 					sprintf(
 						/* translators: %s: The name of the query parameter being tested. */
-						__( 'The REST API did not process the %s query parameter correctly.' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+						__( 'The REST API did not process the %s query parameter correctly.' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain -- reuses core's own Site Health string verbatim so it inherits core's translation; adding a domain here would orphan it.
 						'<code>context</code>'
 					)
 				);
@@ -1210,7 +1210,7 @@ class Disable_Blog_Admin {
 			'post_type'              => $post_type,
 			'no_found_rows'          => true,
 			'update_post_meta_cache' => false,
-			'tax_query'              => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+			'tax_query'              => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- counting posts in a term requires a tax_query; the result is memoized per request in a non-persistent group.
 				array(
 					'taxonomy' => $taxonomy,
 					'field'    => 'id',

--- a/includes/class-disable-blog-admin.php
+++ b/includes/class-disable-blog-admin.php
@@ -1172,13 +1172,51 @@ class Disable_Blog_Admin {
 	/**
 	 * Return the post count for a term based by post type.
 	 *
+	 * Memoized per (term_id, taxonomy, post_type) for the life of the request: this hooks
+	 * onto core's `{$taxonomy}_row_actions`, which fires once per term row rendered on
+	 * edit-tags.php, so without memoizing, a full page of terms means a full uncached
+	 * WP_Query per row.
+	 *
+	 * The wp_cache_*() calls are guarded by function_exists(): they are core WordPress API
+	 * and always present once WordPress has bootstrapped, but this method is also exercised
+	 * directly by unit tests that construct this class outside of a WordPress runtime, where
+	 * those functions do not exist. The guard is a no-op in production and simply disables
+	 * memoization in that unit-test context.
+	 *
 	 * @since 0.5.0
+	 * @since 0.5.6 memoized per request.
 	 * @param int    $term_id   the current term id.
 	 * @param string $taxonomy  the taxonomy slug.
 	 * @param string $post_type the post type slug.
 	 * @return int
 	 */
 	public function get_term_post_count_by_type( $term_id, $taxonomy, $post_type ) {
+
+		$can_cache   = function_exists( 'wp_cache_get' ) && function_exists( 'wp_cache_set' ) && function_exists( 'wp_cache_add_non_persistent_groups' );
+		$cache_group = 'dwpb-term-post-count-by-type';
+
+		// Each component is hashed separately (rather than concatenated raw) so that no
+		// combination of taxonomy/post type values can straddle the '-' delimiter and
+		// collide with a different combination.
+		$cache_key = md5( (string) $term_id ) . '-' . md5( $taxonomy ) . '-' . md5( $post_type );
+
+		if ( $can_cache ) {
+			// Term post counts change whenever a post is edited, so this cache must never
+			// persist across requests (a persistent backend like Redis/Memcached would show
+			// stale counts indefinitely). It exists only to dedupe repeat lookups for the
+			// same term within a single page render. wp_cache_add_non_persistent_groups() is
+			// idempotent, so registering it on every call (rather than tracking "already
+			// registered" state) is safe and keeps the guard co-located with its first use.
+			wp_cache_add_non_persistent_groups( $cache_group );
+
+			// The $found out-parameter distinguishes a real cached 0 (a term with no
+			// matching posts) from a cache miss, since a plain falsy check can't -- 0 is
+			// falsy too.
+			$count = wp_cache_get( $cache_key, $cache_group, false, $found );
+			if ( $found ) {
+				return $count;
+			}
+		}
 
 		$args  = array(
 			'fields'                 => 'ids',
@@ -1195,12 +1233,13 @@ class Disable_Blog_Admin {
 			),
 		);
 		$query = new WP_Query( $args );
+		$count = count( $query->posts );
 
-		if ( count( $query->posts ) > 0 ) {
-			return count( $query->posts );
-		} else {
-			return 0;
+		if ( $can_cache ) {
+			wp_cache_set( $cache_key, $count, $cache_group );
 		}
+
+		return $count;
 	}
 
 	/**

--- a/includes/class-disable-blog-deactivator.php
+++ b/includes/class-disable-blog-deactivator.php
@@ -54,11 +54,11 @@ class Disable_Blog_Deactivator {
 		) {
 			if ( isset( $_REQUEST['plugin'] ) ) {
 				if ( ! check_admin_referer( 'deactivate-plugin_' . self::$request['plugin'] ) ) {
-					exit;
+					static::terminate();
 				}
 			} elseif ( isset( $_REQUEST['checked'] ) ) {
 				if ( ! check_admin_referer( 'bulk-plugins' ) ) {
-					exit;
+					static::terminate();
 				}
 			}
 		}
@@ -70,6 +70,20 @@ class Disable_Blog_Deactivator {
 		wp_cache_delete( 'comments-0', 'counts' );
 		delete_transient( 'wc_count_comments' );
 		flush_rewrite_rules();
+	}
+
+	/**
+	 * Wraps `exit` so a test subclass can override it to observe termination
+	 * without actually ending the process.
+	 *
+	 * Uses late static binding (`static::`) rather than `self::` so subclasses
+	 * can override this method; called via `static::terminate()`.
+	 *
+	 * @since 0.5.6
+	 * @return void
+	 */
+	protected static function terminate() {
+		exit;
 	}
 
 	/**

--- a/includes/class-disable-blog-functions.php
+++ b/includes/class-disable-blog-functions.php
@@ -60,7 +60,18 @@ class Disable_Blog_Functions {
 			$redirect_url = $this->parse_query_string( $redirect_url );
 		}
 
-		wp_safe_redirect( esc_url_raw( $redirect_url ), $this->get_redirect_status_code( $current_url, $redirect_url ) );
+		wp_safe_redirect( esc_url_raw( $redirect_url ), $this->get_redirect_status_code( $current_url, $redirect_url ) ); // phpcs:ignore WordPressVIPMinimum.Security.ExitAfterRedirect.NoExit -- terminate() below calls exit.
+		$this->terminate();
+	}
+
+	/**
+	 * Wraps `exit` so a test subclass can override it to observe termination
+	 * without actually ending the process.
+	 *
+	 * @since 0.5.6
+	 * @return void
+	 */
+	protected function terminate() {
 		exit;
 	}
 

--- a/includes/class-disable-blog-functions.php
+++ b/includes/class-disable-blog-functions.php
@@ -90,7 +90,7 @@ class Disable_Blog_Functions {
 
 		// Setup an array of the current query string variables.
 		$query_vars = array();
-		wp_parse_str( $_SERVER['QUERY_STRING'], $query_vars ); // phpcs:ignore
+		wp_parse_str( $_SERVER['QUERY_STRING'], $query_vars ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- wp_parse_str() itself parses the raw query string into an array; the parsed $query_vars are filtered against an allow-list below before use, not the raw string.
 
 		// Only allow specific query vars.
 		$allowed_query_vars = $this->get_allowed_query_vars();

--- a/includes/class-disable-blog-public.php
+++ b/includes/class-disable-blog-public.php
@@ -559,7 +559,7 @@ class Disable_Blog_Public {
 		$methods_to_remove = apply_filters( 'dwpb_disabled_xmlrpc_methods', $methods_to_remove );
 
 		// filter any invalid entries out before returning the array.
-		return is_array( $methods_to_remove ) ? array_filter( $methods_to_remove, 'is_string' ) : false; // phpcs:ignore
+		return is_array( $methods_to_remove ) ? array_filter( $methods_to_remove, 'is_string' ) : false;
 	}
 
 	/**

--- a/includes/class-disable-blog-public.php
+++ b/includes/class-disable-blog-public.php
@@ -607,6 +607,22 @@ class Disable_Blog_Public {
 			return;
 		}
 
+		$this->do_remove_pingback_header();
+	}
+
+	/**
+	 * Perform the actual X-Pingback header removal.
+	 *
+	 * Split out from remove_pingback_header_fallback() so the early-return
+	 * guard above has an observable effect: a test subclass can override this
+	 * method to record whether the removal path was taken, without needing to
+	 * stub the PHP internals `headers_sent()`/`header_remove()`.
+	 *
+	 * @since 0.5.6
+	 * @return void
+	 */
+	protected function do_remove_pingback_header() {
+
 		if ( ! headers_sent() ) {
 			header_remove( 'X-Pingback' );
 		}

--- a/includes/class-disable-blog.php
+++ b/includes/class-disable-blog.php
@@ -64,11 +64,30 @@ class Disable_Blog {
 	 * @access public
 	 * @param string $plugin_name The name of this plugin.
 	 * @param string $version     The version of this plugin.
+	 * @param bool   $boot        Optional. Whether to run boot() immediately. Defaults to true;
+	 *                            pass false to construct without side effects, e.g. in tests.
 	 */
-	public function __construct( $plugin_name, $version ) {
+	public function __construct( $plugin_name, $version, $boot = true ) {
 
 		$this->plugin_name = $plugin_name;
 		$this->version     = $version;
+
+		if ( $boot ) {
+			$this->boot();
+		}
+	}
+
+	/**
+	 * Run the plugin's setup: dependencies, locale, integrations, and hooks.
+	 *
+	 * Split out from __construct() so a test can construct the class with
+	 * $boot = false and call the individual setup methods directly.
+	 *
+	 * @since 0.5.6
+	 * @access public
+	 * @return void
+	 */
+	public function boot() {
 
 		do_action( 'dwpb_init' );
 
@@ -84,9 +103,9 @@ class Disable_Blog {
 	 * Upgrade check.
 	 *
 	 * @since 0.4.0
-	 * @access private
+	 * @access protected
 	 */
-	private static function upgrade_check() {
+	protected static function upgrade_check() {
 
 		// let's only run these checks on the admin page load.
 		if ( ! is_admin() ) {
@@ -125,9 +144,11 @@ class Disable_Blog {
 	 *
 	 * @since 0.4.0
 	 * @since 0.5.3 Added Integrations class.
-	 * @access private
+	 * @since 0.5.6 only construct the loader if one isn't already set, so a test
+	 *              can inject a spy before calling this method.
+	 * @access protected
 	 */
-	private function load_dependencies() {
+	protected function load_dependencies() {
 
 		// Includes directory.
 		$includes_dir = plugin_dir_path( __DIR__ ) . 'includes';
@@ -146,7 +167,9 @@ class Disable_Blog {
 		/**
 		 * Make it so.
 		 */
-		$this->loader = new Disable_Blog_Loader();
+		if ( null === $this->loader ) {
+			$this->loader = new Disable_Blog_Loader();
+		}
 
 		$classes = array(
 			'Disable_Blog_I18n',
@@ -167,9 +190,9 @@ class Disable_Blog {
 	 * with WordPress.
 	 *
 	 * @since 0.4.0
-	 * @access private
+	 * @access protected
 	 */
-	private function set_locale() {
+	protected function set_locale() {
 
 		$plugin_i18n = new Disable_Blog_I18n();
 
@@ -182,9 +205,9 @@ class Disable_Blog {
 	 *
 	 * @since 0.4.0
 	 * @since 0.5.3 Separated comment functions to run only if comments are supported.
-	 * @access private
+	 * @access protected
 	 */
-	private function define_admin_hooks() {
+	protected function define_admin_hooks() {
 
 		$plugin_admin = new Disable_Blog_Admin( $this->get_plugin_name(), $this->get_version() );
 
@@ -297,9 +320,9 @@ class Disable_Blog {
 	 * @since 0.4.0
 	 * @since 0.5.6 added disable_removed_sitemaps() on template_redirect.
 	 * @since 0.5.6 added remove_pingback_header_fallback() on the 'wp' action, for older WP.
-	 * @access private
+	 * @access protected
 	 */
-	private function define_public_hooks() {
+	protected function define_public_hooks() {
 
 		$plugin_public = new Disable_Blog_Public( $this->get_plugin_name(), $this->get_version() );
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -48,10 +48,17 @@ function dwpb_post_types_with_feature( $feature, $args = array() ) {
 			}
 		}
 
-		// Keep the array if there are any, otherwise make it return false.
-		$post_types_with_feature = empty( $post_types_with_feature ) ? false : $post_types_with_feature;
-
+		// Cache the array as-is, including when empty. An empty array is a valid,
+		// distinguishable "nothing found" result, unlike false, which wp_cache_get()
+		// also returns on a cache miss; storing false here would make every negative
+		// result indistinguishable from an uncached one and defeat the cache.
 		wp_cache_set( $cache_name, $post_types_with_feature, 'post-types-by-feature' );
+	}
+
+	// Normalize the empty-array negative-cache sentinel back to the documented
+	// array|bool contract before it reaches the public filter below.
+	if ( empty( $post_types_with_feature ) ) {
+		$post_types_with_feature = false;
 	}
 
 	/**
@@ -135,9 +142,8 @@ function dwpb_post_types_with_tax( $taxonomy, $args = array(), $output = 'names'
 			}
 		}
 
-		// Keep the array if there are any, otherwise make it return false.
-		$post_types_with_tax = empty( $post_types_with_tax ) ? false : $post_types_with_tax;
-
+		// Cache the array as-is, including when empty (see dwpb_post_types_with_feature()
+		// for why false cannot be the negative-cache value).
 		wp_cache_set( $cache_name, $post_types_with_tax, 'post-types-by-tax' );
 	}
 


### PR DESCRIPTION
Stacked on #86. Production changes only — the tests that exercise them are in the
PR stacked on top of this one.

An adversarial audit of #86's suite mutation-tested `includes/` with 521 hand-built
mutants and found **50 confirmed survivors**: mutations that change behaviour while all
399 tests stay green. Each was reproduced independently by a second agent. This PR makes
21 of them killable and fixes two real defects found along the way.

## Testability seams (`fc0daa1`)

Behaviour-preserving in production; a token-stream diff confirmed no non-comment change
beyond what is described here.

- **`terminate()`** wraps `exit` in `Disable_Blog_Functions::redirect()` and in the
  Activator/Deactivator nonce-failure paths, invoked via `static::` so a test subclass can
  observe it. `exit` still fires unconditionally in production. Without this, deleting
  `exit` after `wp_safe_redirect()` — or **inverting `check_admin_referer()`** — left the
  suite green.
- **`Disable_Blog::__construct( $plugin_name, $version, $boot = true )`** delegates to a
  new public `boot()`; the six setup methods widen `private` → `protected`, and
  `load_dependencies()` reuses an already-set loader. The constructor and
  `load_dependencies()` were previously 0% covered, because tests build the class with
  `newInstanceWithoutConstructor()`. Default `$boot = true` keeps every existing caller
  identical.
- **`do_remove_pingback_header()`** holds the `headers_sent()`/`header_remove()` body so
  the filter guard's early return has an observable effect.

## The negative cache never engaged (`857ba9b`)

`dwpb_post_types_with_feature()` and `dwpb_post_types_with_tax()` cached a negative result
as `false`. `wp_cache_get()` also returns `false` on a miss, so a cached "nothing found"
was indistinguishable from "not cached" and the body recomputed on every call — for
`dwpb_post_types_with_tax( 'post_tag' )` on a site with no CPT using post tags, the common
case, the cache never engaged at all.

Both now cache the empty array and normalise back to `false` before returning, so every
observable value is unchanged: `dwpb_post_types_supporting_{$feature}` still receives
`false`, and `dwpb_taxonomy_support` still receives the raw `get_post_types()` output.

**Measured cost of the bug: ~473µs per request minimum, ~1ms on an admin page.** Real, but
noise against a normal WordPress request — the honest case for fixing it is intent, plus
the avoidable round-trips on sites with a persistent object cache.

Same commit memoizes `get_term_post_count_by_type()`, which ran a fresh `WP_Query` for
every term row on `edit-tags.php` — up to one per row per page load. It uses
`wp_cache_get()`'s `$found` out-parameter so a legitimate count of `0` is not mistaken for
a miss, and registers the group non-persistent, since term counts change whenever a post
is edited.

## PHPCS suppressions now say what they hide (`75930a7`, `202cd87`)

Eleven `@codingStandardsIgnoreStart` blocks and three bare `phpcs:ignore` lines silenced
every sniff on their span without naming any. **Blanket suppressions: 11 → 0. Bare: 3 → 0.**
All 23 remaining name their sniff and state a reason.

One hid a genuine **error**: `WordPress.Security.EscapeOutput.OutputNotEscaped` on an admin
notice. Escaping with `esc_html__()` resolves it with no suppression at all.

Four were dead — removing them changes nothing. Two hid more than their comment admitted:
the `$wpdb` block also silenced an unaddressed `NoCaching` warning, and one block had no
comment at all while hiding six findings.

## Verification

`OK (399 tests, 528 assertions)` unchanged throughout — these are production changes, and
the tests that cover them land in the stacked PR. PHPStan level 5 `[OK] No errors`, PHPCS
clean, **order-independence green across 14 random seeds**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)