### PR TITLE
Kill 45 mutation survivors and make the argument matchers discriminate

### DIFF
--- a/includes/class-disable-blog-admin.php
+++ b/includes/class-disable-blog-admin.php
@@ -1161,13 +1161,13 @@ class Disable_Blog_Admin {
 	 * Memoized per (term_id, taxonomy, post_type) for the life of the request: this hooks
 	 * onto core's `{$taxonomy}_row_actions`, which fires once per term row rendered on
 	 * edit-tags.php, so without memoizing, a full page of terms means a full uncached
-	 * WP_Query per row.
+	 * WP_Query per row. The cache group is registered non-persistent, since term post
+	 * counts change whenever a post is edited and must never survive past the request that
+	 * computed them.
 	 *
-	 * The wp_cache_*() calls are guarded by function_exists(): they are core WordPress API
-	 * and always present once WordPress has bootstrapped, but this method is also exercised
-	 * directly by unit tests that construct this class outside of a WordPress runtime, where
-	 * those functions do not exist. The guard is a no-op in production and simply disables
-	 * memoization in that unit-test context.
+	 * The query only needs a total, not the matching posts themselves, so it asks WP_Query
+	 * for a single row and reads found_posts rather than paging through (and counting)
+	 * every matching id.
 	 *
 	 * @since 0.5.0
 	 * @since 0.5.6 memoized per request.
@@ -1178,7 +1178,6 @@ class Disable_Blog_Admin {
 	 */
 	public function get_term_post_count_by_type( $term_id, $taxonomy, $post_type ) {
 
-		$can_cache   = function_exists( 'wp_cache_get' ) && function_exists( 'wp_cache_set' ) && function_exists( 'wp_cache_add_non_persistent_groups' );
 		$cache_group = 'dwpb-term-post-count-by-type';
 
 		// Each component is hashed separately (rather than concatenated raw) so that no
@@ -1186,29 +1185,23 @@ class Disable_Blog_Admin {
 		// collide with a different combination.
 		$cache_key = md5( (string) $term_id ) . '-' . md5( $taxonomy ) . '-' . md5( $post_type );
 
-		if ( $can_cache ) {
-			// Term post counts change whenever a post is edited, so this cache must never
-			// persist across requests (a persistent backend like Redis/Memcached would show
-			// stale counts indefinitely). It exists only to dedupe repeat lookups for the
-			// same term within a single page render. wp_cache_add_non_persistent_groups() is
-			// idempotent, so registering it on every call (rather than tracking "already
-			// registered" state) is safe and keeps the guard co-located with its first use.
-			wp_cache_add_non_persistent_groups( $cache_group );
+		// wp_cache_add_non_persistent_groups() is idempotent, so registering it on every
+		// call (rather than tracking "already registered" state) is safe and keeps it
+		// co-located with its first use.
+		wp_cache_add_non_persistent_groups( $cache_group );
 
-			// The $found out-parameter distinguishes a real cached 0 (a term with no
-			// matching posts) from a cache miss, since a plain falsy check can't -- 0 is
-			// falsy too.
-			$count = wp_cache_get( $cache_key, $cache_group, false, $found );
-			if ( $found ) {
-				return $count;
-			}
+		// The $found out-parameter distinguishes a real cached 0 (a term with no matching
+		// posts) from a cache miss, since a plain falsy check can't -- 0 is falsy too.
+		$count = wp_cache_get( $cache_key, $cache_group, false, $found );
+		if ( $found ) {
+			return $count;
 		}
 
 		$args  = array(
 			'fields'                 => 'ids',
-			'posts_per_page'         => 100,
+			'posts_per_page'         => 1,
 			'post_type'              => $post_type,
-			'no_found_rows'          => true,
+			'no_found_rows'          => false,
 			'update_post_meta_cache' => false,
 			'tax_query'              => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- counting posts in a term requires a tax_query; the result is memoized per request in a non-persistent group.
 				array(
@@ -1219,11 +1212,9 @@ class Disable_Blog_Admin {
 			),
 		);
 		$query = new WP_Query( $args );
-		$count = count( $query->posts );
+		$count = (int) $query->found_posts;
 
-		if ( $can_cache ) {
-			wp_cache_set( $cache_key, $count, $cache_group );
-		}
+		wp_cache_set( $cache_key, $count, $cache_group );
 
 		return $count;
 	}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -30,7 +30,6 @@
 	<config name="minimum_supported_wp_version" value="5.9"/>
 	<rule ref="WordPress-VIP-Go">
 		<!-- Exclude overly strict prefix rules that don't recognize -->
-		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.ShortPrefixPassed"/>
 		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound"/>
 		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound"/>
 		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound"/>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -80,6 +80,17 @@ parameters:
             message: '#^Inner named functions are not supported by PHPStan\.#'
             path: tests/php/PublicMiscTest.php
 
+        # Same reasoning as the two entries above, for wp_cache_get()/wp_cache_set(). These
+        # must be real global functions declared with wp_cache_get()'s by-reference $found
+        # parameter: WP_Mock::userFunction()'s generated stubs collect arguments through
+        # func_get_args(), which copies, so a stub can never write back to $found -- the
+        # same limitation WpPolyfills.php documents for wp_parse_str(). They stay nested
+        # inside the @runInSeparateProcess tests that need them, since PHP cannot un-declare
+        # a function and a file-scope declaration would mask missing stubs everywhere else.
+        -
+            message: '#^Inner named functions are not supported by PHPStan\.#'
+            path: tests/php/AdminCommentsTest.php
+
         # Mockery\LegacyMockInterface::shouldReceive() is documented to return
         # Expectation|ExpectationInterface|HigherOrderMessage, but PHPStan can only resolve the
         # union down to a specific method's real Expectation-typed return with the separate

--- a/tests/php/ActivatorTest.php
+++ b/tests/php/ActivatorTest.php
@@ -6,6 +6,30 @@
  */
 
 /**
+ * Spies on terminate() so the referer-check branches in activate() can be exercised without
+ * the real exit; ending the test process. activate() invokes `static::terminate()`, so late
+ * static binding dispatches to this override instead of the parent's.
+ */
+class ActivatorTerminateSpy extends Disable_Blog_Activator {
+
+	/**
+	 * Whether terminate() was invoked during the current test.
+	 *
+	 * @var bool
+	 */
+	public static $terminate_called = false;
+
+	/**
+	 * Records the call instead of exiting.
+	 *
+	 * @return void
+	 */
+	protected static function terminate() {
+		self::$terminate_called = true;
+	}
+}
+
+/**
  * @covers Disable_Blog_Activator
  */
 class ActivatorTest extends PluginLifecycleTestCase {
@@ -135,5 +159,138 @@ class ActivatorTest extends PluginLifecycleTestCase {
 		$this->expectExceptionMessage( 'halted' );
 
 		Disable_Blog_Activator::activate();
+	}
+
+	/**
+	 * activate()'s single-plugin branch guards terminate() with
+	 * `if ( ! check_admin_referer( ... ) )`. When the referer check fails (returns false),
+	 * the `!` makes the condition true and terminate() must run.
+	 */
+	public function test_activate_terminates_when_single_plugin_referer_check_fails() {
+		ActivatorTerminateSpy::$terminate_called = false;
+
+		$this->set_static_request( array( 'plugin' => 'disable-blog' ) );
+
+		$_REQUEST = array(
+			'_wpnonce' => 'bad-nonce',
+			'action'   => 'activate',
+			'plugin'   => 'disable-blog',
+		);
+
+		WP_Mock::userFunction( 'wp_verify_nonce' )
+			->once()
+			->with( 'bad-nonce', 'activate-plugin_disable-blog' )
+			->andReturn( false );
+
+		WP_Mock::userFunction( 'check_admin_referer' )
+			->once()
+			->with( 'activate-plugin_disable-blog' )
+			->andReturn( false );
+
+		WP_Mock::userFunction( 'wp_cache_delete' )->once()->with( 'comments-0', 'counts' );
+		WP_Mock::userFunction( 'delete_transient' )->once()->with( 'wc_count_comments' );
+		WP_Mock::userFunction( 'flush_rewrite_rules' )->once();
+
+		ActivatorTerminateSpy::activate();
+
+		$this->assertTrue( ActivatorTerminateSpy::$terminate_called );
+	}
+
+	/**
+	 * Same branch as above with the referer check passing (returns true): `! true` is false,
+	 * so terminate() must NOT run. Paired with the failing-check test above, this pins down
+	 * both directions of the `!`, so inverting it fails one test or the other.
+	 */
+	public function test_activate_does_not_terminate_when_single_plugin_referer_check_passes() {
+		ActivatorTerminateSpy::$terminate_called = false;
+
+		$this->set_static_request( array( 'plugin' => 'disable-blog' ) );
+
+		$_REQUEST = array(
+			'_wpnonce' => 'bad-nonce',
+			'action'   => 'activate',
+			'plugin'   => 'disable-blog',
+		);
+
+		WP_Mock::userFunction( 'wp_verify_nonce' )
+			->once()
+			->with( 'bad-nonce', 'activate-plugin_disable-blog' )
+			->andReturn( false );
+
+		WP_Mock::userFunction( 'check_admin_referer' )
+			->once()
+			->with( 'activate-plugin_disable-blog' )
+			->andReturn( true );
+
+		WP_Mock::userFunction( 'wp_cache_delete' )->once()->with( 'comments-0', 'counts' );
+		WP_Mock::userFunction( 'delete_transient' )->once()->with( 'wc_count_comments' );
+		WP_Mock::userFunction( 'flush_rewrite_rules' )->once();
+
+		ActivatorTerminateSpy::activate();
+
+		$this->assertFalse( ActivatorTerminateSpy::$terminate_called );
+	}
+
+	/**
+	 * Same guard on the bulk-plugins branch: a failing referer check must terminate.
+	 */
+	public function test_activate_terminates_when_bulk_referer_check_fails() {
+		ActivatorTerminateSpy::$terminate_called = false;
+
+		$_REQUEST = array(
+			'_wpnonce' => 'bad-nonce',
+			'action'   => 'activate-selected',
+			'checked'  => array( 'some-other-plugin' ),
+		);
+
+		WP_Mock::userFunction( 'wp_verify_nonce' )
+			->once()
+			->with( 'bad-nonce', 'bulk-plugins' )
+			->andReturn( false );
+
+		WP_Mock::userFunction( 'check_admin_referer' )
+			->once()
+			->with( 'bulk-plugins' )
+			->andReturn( false );
+
+		WP_Mock::userFunction( 'wp_cache_delete' )->once()->with( 'comments-0', 'counts' );
+		WP_Mock::userFunction( 'delete_transient' )->once()->with( 'wc_count_comments' );
+		WP_Mock::userFunction( 'flush_rewrite_rules' )->once();
+
+		ActivatorTerminateSpy::activate();
+
+		$this->assertTrue( ActivatorTerminateSpy::$terminate_called );
+	}
+
+	/**
+	 * Bulk-plugins branch, referer check passing: terminate() must NOT run. Paired with the
+	 * failing-check test above, this pins down both directions of the `!` on this branch.
+	 */
+	public function test_activate_does_not_terminate_when_bulk_referer_check_passes() {
+		ActivatorTerminateSpy::$terminate_called = false;
+
+		$_REQUEST = array(
+			'_wpnonce' => 'bad-nonce',
+			'action'   => 'activate-selected',
+			'checked'  => array( 'some-other-plugin' ),
+		);
+
+		WP_Mock::userFunction( 'wp_verify_nonce' )
+			->once()
+			->with( 'bad-nonce', 'bulk-plugins' )
+			->andReturn( false );
+
+		WP_Mock::userFunction( 'check_admin_referer' )
+			->once()
+			->with( 'bulk-plugins' )
+			->andReturn( true );
+
+		WP_Mock::userFunction( 'wp_cache_delete' )->once()->with( 'comments-0', 'counts' );
+		WP_Mock::userFunction( 'delete_transient' )->once()->with( 'wc_count_comments' );
+		WP_Mock::userFunction( 'flush_rewrite_rules' )->once();
+
+		ActivatorTerminateSpy::activate();
+
+		$this->assertFalse( ActivatorTerminateSpy::$terminate_called );
 	}
 }

--- a/tests/php/ActivatorTest.php
+++ b/tests/php/ActivatorTest.php
@@ -29,4 +29,111 @@ class ActivatorTest extends PluginLifecycleTestCase {
 	protected function bulk_action_value(): string {
 		return 'activate-selected';
 	}
+
+	/**
+	 * Directly sets Disable_Blog_Activator::$request via Reflection, bypassing get_request(),
+	 * to simulate static state left over from an earlier, successful call.
+	 *
+	 * @param array $value The value to assign.
+	 * @return void
+	 */
+	private function set_static_request( array $value ) {
+		$class    = new ReflectionClass( Disable_Blog_Activator::class );
+		$property = $class->getProperty( 'request' );
+		$property->setAccessible( true );
+		$property->setValue( null, $value );
+	}
+
+	/**
+	 * activate()'s outer guard is `false === self::get_request() || ...`. get_request() only
+	 * ever returns `false` or an array, never boolean `true`, so `true === self::get_request()`
+	 * can never be satisfied by any input -- it would make the first OR clause permanently
+	 * dead, silently changing the guard from "get_request() failed" (true whenever it returns
+	 * false) to always-false, falling through to whatever validate_request()/check_caps()
+	 * decide instead.
+	 *
+	 * This primes static::$request with data that would satisfy validate_request() and stubs
+	 * check_caps() to succeed, then drives $_REQUEST down a path where get_request() itself
+	 * fails (bad nonce) without touching static::$request. Under the real guard, get_request()
+	 * failing alone is enough to enter the check_admin_referer() branch: the guard is an OR,
+	 * so stale primed state that would satisfy validate_request() and check_caps() must not
+	 * suppress the nonce check.
+	 */
+	public function test_activate_enters_referer_check_when_get_request_fails_even_if_stale_state_would_validate() {
+		$this->set_static_request(
+			array(
+				'plugin' => 'disable-blog',
+				'action' => 'activate',
+			)
+		);
+
+		$_REQUEST = array(
+			'_wpnonce' => 'bad-nonce',
+			'action'   => 'activate',
+			'plugin'   => 'disable-blog',
+		);
+
+		WP_Mock::userFunction( 'wp_verify_nonce' )
+			->once()
+			->with( 'bad-nonce', 'activate-plugin_disable-blog' )
+			->andReturn( false );
+
+		// Present so check_caps() resolves on the path where the guard wrongly defers to it.
+		WP_Mock::userFunction( 'current_user_can' )
+			->with( 'activate_plugins' )
+			->andReturn( true );
+
+		WP_Mock::userFunction( 'check_admin_referer' )
+			->once()
+			->with( 'activate-plugin_disable-blog' )
+			->andThrow( new Exception( 'halted' ) );
+
+		WP_Mock::userFunction( 'wp_cache_delete' )->never();
+		WP_Mock::userFunction( 'delete_transient' )->never();
+		WP_Mock::userFunction( 'flush_rewrite_rules' )->never();
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'halted' );
+
+		Disable_Blog_Activator::activate();
+	}
+
+	/**
+	 * validate_request()'s bulk branch calls
+	 * `in_array( $plugin, self::$request['plugins'], true )`. If the strict flag is relaxed to
+	 * false, a non-empty string like 'disable-blog' loosely equals boolean true, so a
+	 * $_REQUEST['checked'] entry of `true` would (wrongly) validate as if 'disable-blog' were
+	 * among the checked plugins.
+	 */
+	public function test_activate_runs_referer_check_when_bulk_selection_only_loosely_matches_plugin() {
+		$_REQUEST = array(
+			'_wpnonce' => 'nonce-value',
+			'action'   => 'activate-selected',
+			'checked'  => array( true ),
+		);
+
+		WP_Mock::userFunction( 'wp_verify_nonce' )
+			->once()
+			->with( 'nonce-value', 'bulk-plugins' )
+			->andReturn( 1 );
+
+		// Present so check_caps() resolves if the bulk selection wrongly validates.
+		WP_Mock::userFunction( 'current_user_can' )
+			->with( 'activate_plugins' )
+			->andReturn( true );
+
+		WP_Mock::userFunction( 'check_admin_referer' )
+			->once()
+			->with( 'bulk-plugins' )
+			->andThrow( new Exception( 'halted' ) );
+
+		WP_Mock::userFunction( 'wp_cache_delete' )->never();
+		WP_Mock::userFunction( 'delete_transient' )->never();
+		WP_Mock::userFunction( 'flush_rewrite_rules' )->never();
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'halted' );
+
+		Disable_Blog_Activator::activate();
+	}
 }

--- a/tests/php/AdminCommentsTest.php
+++ b/tests/php/AdminCommentsTest.php
@@ -677,8 +677,48 @@ class AdminCommentsTest extends TestCase {
 	 */
 
 	/**
+	 * Declares real wp_cache_get()/wp_cache_set() functions backed by
+	 * $GLOBALS['dwpb_test_cache_store'], keyed by "{$group}|{$key}".
+	 *
+	 * WP_Mock::userFunction()'s dynamically generated stubs collect arguments with
+	 * func_get_args(), which always copies, so nothing written to a 4th argument is ever
+	 * visible to the caller -- wp_cache_get()'s $found parameter is by reference and can
+	 * only be exercised by a function declared with the real signature (the identical
+	 * limitation documented for wp_parse_str() in tests/php/Support/WpPolyfills.php).
+	 *
+	 * Only safe to call from an @runInSeparateProcess test: PHP cannot un-declare a
+	 * function, so this would otherwise leak into every later test sharing the process.
+	 *
+	 * @return void
+	 */
+	private function stub_object_cache() {
+
+		if ( function_exists( 'wp_cache_get' ) ) {
+			return;
+		}
+
+		$GLOBALS['dwpb_test_cache_store'] = array();
+
+		function wp_cache_get( $key, $group = '', $force = false, &$found = null ) {
+			$composite = $group . '|' . $key;
+			if ( array_key_exists( $composite, $GLOBALS['dwpb_test_cache_store'] ) ) {
+				$found = true;
+				return $GLOBALS['dwpb_test_cache_store'][ $composite ];
+			}
+			$found = false;
+			return false;
+		}
+
+		function wp_cache_set( $key, $value, $group = '' ) {
+			$GLOBALS['dwpb_test_cache_store'][ $group . '|' . $key ] = $value;
+			return true;
+		}
+	}
+
+	/**
 	 * Makes the next `new WP_Query( $args )` call return an instance whose ->posts is
-	 * $posts, and records the constructor args into $captured_args by reference.
+	 * $posts and ->found_posts is $found_posts, and records the constructor args into
+	 * $captured_args by reference.
 	 *
 	 * Uses Mockery::mock( 'overload:WP_Query' ) rather than a same-named fixture class: a
 	 * real `class WP_Query` declared in tests/php/ would be picked up by phpstan.neon.dist's
@@ -689,23 +729,31 @@ class AdminCommentsTest extends TestCase {
 	 * it -- but that also means the instance handed back for the ->posts assignment below is
 	 * only known to phpstan as Mockery\MockInterface, which declares no ->posts property.
 	 * There is no supported way to type that without the disallowed phpstan-mockery
-	 * extension; see this file's scoped phpstan.neon.dist ignores for the resulting errors.
+	 * extension; see this file's scoped phpstan.neon.dist ignore for the resulting error.
+	 * ->found_posts is instead written through a separately @var-typed stdClass alias of
+	 * the same instance (stdClass permits dynamic properties, so PHPStan raises nothing to
+	 * ignore) rather than adding a second, unignored property-access error of its own.
 	 *
 	 * @param array      $posts         The posts array the query should report.
+	 * @param int        $found_posts   The found_posts total the query should report.
 	 * @param array|null $captured_args Set by reference to the args WP_Query was constructed with.
 	 * @return void
 	 */
-	private function stub_wp_query_returns_posts( array $posts, &$captured_args = null ) {
+	private function stub_wp_query_returns_posts( array $posts, $found_posts, &$captured_args = null ) {
 		$container = Mockery::getContainer();
 		$container->mock( 'overload:WP_Query' )
 			->shouldReceive( '__construct' )
 			->once()
 			->andReturnUsing(
-				function ( $args ) use ( $container, $posts, &$captured_args ) {
-					$captured_args    = $args;
-					$mocks            = $container->getMocks();
-					$instance         = end( $mocks );
-					$instance->posts  = $posts;
+				function ( $args ) use ( $container, $posts, $found_posts, &$captured_args ) {
+					$captured_args   = $args;
+					$mocks           = $container->getMocks();
+					$instance        = end( $mocks );
+					$instance->posts = $posts;
+
+					/** @var stdClass $stdclass_alias */
+					$stdclass_alias              = $instance;
+					$stdclass_alias->found_posts = $found_posts;
 				}
 			);
 	}
@@ -718,7 +766,12 @@ class AdminCommentsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_get_term_post_count_by_type_returns_post_count_when_posts_found() {
-		$this->stub_wp_query_returns_posts( array( 101, 102, 103 ) );
+		$this->stub_object_cache();
+		WP_Mock::userFunction( 'wp_cache_add_non_persistent_groups' );
+
+		// found_posts (3) deliberately differs from count( $posts ) (1): the return value
+		// must come from found_posts, not from counting the ids WP_Query happened to return.
+		$this->stub_wp_query_returns_posts( array( 101 ), 3 );
 
 		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
 
@@ -730,7 +783,10 @@ class AdminCommentsTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_get_term_post_count_by_type_returns_zero_when_no_posts_found() {
-		$this->stub_wp_query_returns_posts( array() );
+		$this->stub_object_cache();
+		WP_Mock::userFunction( 'wp_cache_add_non_persistent_groups' );
+
+		$this->stub_wp_query_returns_posts( array(), 0 );
 
 		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
 
@@ -738,23 +794,207 @@ class AdminCommentsTest extends TestCase {
 	}
 
 	/**
-	 * Proves the query args passed to `new WP_Query()` are wired correctly: the taxonomy,
-	 * term id and post type all land in the expected places.
+	 * A term with more matches than one page of results reports its true total. The count
+	 * comes from found_posts, not from the number of rows the query returns.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_term_post_count_by_type_returns_count_above_the_old_cap() {
+		$this->stub_object_cache();
+		WP_Mock::userFunction( 'wp_cache_add_non_persistent_groups' );
+
+		$this->stub_wp_query_returns_posts( array( 101 ), 250 );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( 250, $admin->get_term_post_count_by_type( 5, 'category', 'page' ) );
+	}
+
+	/**
+	 * Proves the query args passed to `new WP_Query()` are wired exactly as expected --
+	 * every key and value, not just the taxonomy/term id/post type -- so any future change
+	 * to the query (e.g. posts_per_page creeping back up, or no_found_rows flipping back to
+	 * true) is caught.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	public function test_get_term_post_count_by_type_builds_expected_query_args() {
+		$this->stub_object_cache();
+		WP_Mock::userFunction( 'wp_cache_add_non_persistent_groups' );
+
 		$captured_args = null;
-		$this->stub_wp_query_returns_posts( array(), $captured_args );
+		$this->stub_wp_query_returns_posts( array(), 0, $captured_args );
 
 		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
 		$admin->get_term_post_count_by_type( 7, 'post_tag', 'page' );
 
-		$this->assertSame( 'page', $captured_args['post_type'] );
-		$this->assertSame( 'ids', $captured_args['fields'] );
-		$this->assertSame( 'post_tag', $captured_args['tax_query'][0]['taxonomy'] );
-		$this->assertSame( 'id', $captured_args['tax_query'][0]['field'] );
-		$this->assertSame( 7, $captured_args['tax_query'][0]['terms'] );
+		$expected = array(
+			'fields'                 => 'ids',
+			'posts_per_page'         => 1,
+			'post_type'              => 'page',
+			'no_found_rows'          => false,
+			'update_post_meta_cache' => false,
+			'tax_query'              => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- pins the exact args get_term_post_count_by_type() passes to WP_Query; the slow-query caveat is the production code's concern (already flagged and justified there), not this comparison array's.
+				array(
+					'taxonomy' => 'post_tag',
+					'field'    => 'id',
+					'terms'    => 7,
+				),
+			),
+		);
+		$this->assertSame( $expected, $captured_args );
+	}
+
+	/**
+	 * A second call for the same (term_id, taxonomy, post_type) must be answered from the
+	 * cache without building a second WP_Query.
+	 *
+	 * Counts constructions itself rather than via shouldReceive( '__construct' )->once():
+	 * Mockery's overload-mock call count is unreliable once a test's overloaded class is
+	 * instantiated more than once (confirmed with a minimal repro against a throwaway
+	 * overloaded class, entirely outside this plugin's code -- `new Probe( 1 ); new
+	 * Probe( 2 );` against a `shouldReceive( '__construct' )->once()` expectation, then
+	 * Mockery::close() -- which reports "called 1 times" and passes even though the
+	 * constructor genuinely ran twice). A plain incremented counter is not subject to that.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_term_post_count_by_type_second_call_uses_cache_without_second_query() {
+		$this->stub_object_cache();
+		WP_Mock::userFunction( 'wp_cache_add_non_persistent_groups' );
+
+		$construct_count = 0;
+		$container       = Mockery::getContainer();
+		$container->mock( 'overload:WP_Query' )
+			->shouldReceive( '__construct' )
+			->andReturnUsing(
+				function ( $args ) use ( $container, &$construct_count ) {
+					++$construct_count;
+					$mocks    = $container->getMocks();
+					$instance = end( $mocks );
+
+					/** @var stdClass $stdclass_alias */
+					$stdclass_alias              = $instance;
+					$stdclass_alias->found_posts = 2;
+				}
+			);
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( 2, $admin->get_term_post_count_by_type( 5, 'category', 'page' ) );
+		$this->assertSame( 2, $admin->get_term_post_count_by_type( 5, 'category', 'page' ) );
+		$this->assertSame( 1, $construct_count );
+	}
+
+	/**
+	 * A cached count of 0 must short-circuit the same as any other cached count.
+	 * wp_cache_get() returns false on a miss, and 0 is falsy too, so a naive
+	 * `if ( $cached = wp_cache_get(...) )` implementation would treat a real cached 0
+	 * identically to a miss and recompute forever -- constructing a second WP_Query.
+	 *
+	 * Counts constructions itself rather than via shouldReceive( '__construct' )->once():
+	 * see test_get_term_post_count_by_type_second_call_uses_cache_without_second_query()'s
+	 * docblock for why that expectation can't be trusted to catch a second construction.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_term_post_count_by_type_cached_zero_short_circuits() {
+		$this->stub_object_cache();
+		WP_Mock::userFunction( 'wp_cache_add_non_persistent_groups' );
+
+		$construct_count = 0;
+		$container       = Mockery::getContainer();
+		$container->mock( 'overload:WP_Query' )
+			->shouldReceive( '__construct' )
+			->andReturnUsing(
+				function ( $args ) use ( $container, &$construct_count ) {
+					++$construct_count;
+					$mocks    = $container->getMocks();
+					$instance = end( $mocks );
+
+					/** @var stdClass $stdclass_alias */
+					$stdclass_alias              = $instance;
+					$stdclass_alias->found_posts = 0;
+				}
+			);
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( 0, $admin->get_term_post_count_by_type( 5, 'category', 'page' ) );
+		$this->assertSame( 0, $admin->get_term_post_count_by_type( 5, 'category', 'page' ) );
+		$this->assertSame( 1, $construct_count );
+	}
+
+	/**
+	 * (5, 'genre', 'fiction-book') and (5, 'genre-fiction', 'book') would both concatenate
+	 * to "5-genre-fiction-book" under a naive cache key, so each must return its own
+	 * distinct count rather than one colliding into the other's cache entry. Also proves
+	 * each triple is itself cached: a third and fourth call for the same two triples must
+	 * not trigger any further WP_Query construction.
+	 *
+	 * Counts constructions itself rather than via shouldReceive( '__construct' )->times():
+	 * see test_get_term_post_count_by_type_second_call_uses_cache_without_second_query()'s
+	 * docblock for why that expectation can't be trusted here.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_term_post_count_by_type_distinguishes_similar_triples() {
+		$this->stub_object_cache();
+		WP_Mock::userFunction( 'wp_cache_add_non_persistent_groups' );
+
+		$construct_count = 0;
+		$container       = Mockery::getContainer();
+		$container->mock( 'overload:WP_Query' )
+			->shouldReceive( '__construct' )
+			->andReturnUsing(
+				function ( $args ) use ( $container, &$construct_count ) {
+					++$construct_count;
+					$mocks    = $container->getMocks();
+					$instance = end( $mocks );
+
+					/** @var stdClass $stdclass_alias */
+					$stdclass_alias = $instance;
+					if ( 'fiction-book' === $args['post_type'] ) {
+						$stdclass_alias->found_posts = 11;
+					} else {
+						$stdclass_alias->found_posts = 22;
+					}
+				}
+			);
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( 11, $admin->get_term_post_count_by_type( 5, 'genre', 'fiction-book' ) );
+		$this->assertSame( 22, $admin->get_term_post_count_by_type( 5, 'genre-fiction', 'book' ) );
+
+		// Repeat calls for both triples must be answered from the cache, not a 3rd/4th query.
+		$this->assertSame( 11, $admin->get_term_post_count_by_type( 5, 'genre', 'fiction-book' ) );
+		$this->assertSame( 22, $admin->get_term_post_count_by_type( 5, 'genre-fiction', 'book' ) );
+		$this->assertSame( 2, $construct_count );
+	}
+
+	/**
+	 * Term post counts change whenever a post is edited, so the cache group must never be
+	 * allowed to persist across requests.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_term_post_count_by_type_registers_non_persistent_group() {
+		$this->stub_object_cache();
+		WP_Mock::userFunction( 'wp_cache_add_non_persistent_groups' )
+			->once()
+			->with( 'dwpb-term-post-count-by-type' );
+
+		$this->stub_wp_query_returns_posts( array( 101 ), 1 );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		$this->assertSame( 1, $admin->get_term_post_count_by_type( 5, 'category', 'page' ) );
 	}
 }

--- a/tests/php/AdminCommentsTest.php
+++ b/tests/php/AdminCommentsTest.php
@@ -98,7 +98,19 @@ class AdminCommentsTest extends TestCase {
 	 * dwpb_post_types_with_feature() is concerned -- it skips get_post_types()/
 	 * post_type_supports() entirely and passes the cached value straight to the
 	 * dwpb_post_types_supporting_{$feature} filter, whose reply IS the function's return
-	 * value regardless of what was "cached".
+	 * value regardless of what was "cached". Because the "cached" value here is always an
+	 * empty array, dwpb_post_types_with_feature()'s own negative-result normalization
+	 * always runs, so the filter always receives the normalized sentinel `false` (not
+	 * `array()`) as its first argument -- regardless of $return_value.
+	 *
+	 * dwpb_post_types_supporting_{$feature} is a two-argument filter ($post_types,
+	 * $args), so this cannot use TestCase::stub_filter_strict() (single-expected-arg):
+	 * onFilter()->with() builds its match key per positional argument, and the second
+	 * position ($args, always array() here) needs a key of its own for the responder to
+	 * ever be reached. The first position is still the collision-prone one -- false and
+	 * '' (and array()) all collide under safe_offset() -- so the responder callback below
+	 * pulls the REAL invoked value via func_get_args() and asserts it strictly, same as
+	 * stub_filter_strict() does.
 	 *
 	 * @param string     $feature      The feature slug (e.g. 'comments').
 	 * @param array|bool $return_value The value dwpb_post_types_with_feature() should return.
@@ -110,8 +122,19 @@ class AdminCommentsTest extends TestCase {
 			->with( "post-types-supporting-{$feature}", 'post-types-by-feature' )
 			->andReturn( array() );
 		WP_Mock::onFilter( "dwpb_post_types_supporting_{$feature}" )
-			->with( array(), array() )
-			->reply( $return_value );
+			->with( false, array() )
+			->reply(
+				new WP_Mock\InvokedFilterValue(
+					function ( $post_types_with_feature ) use ( $feature, $return_value ) {
+						$this->assertFalse(
+							$post_types_with_feature,
+							"dwpb_post_types_supporting_{$feature} must receive the normalized false sentinel it documents."
+						);
+
+						return $return_value;
+					}
+				)
+			);
 	}
 
 	/**

--- a/tests/php/AdminCommentsTest.php
+++ b/tests/php/AdminCommentsTest.php
@@ -15,6 +15,31 @@ require_once __DIR__ . '/../../includes/class-disable-blog-functions.php';
 require_once __DIR__ . '/Support/fixtures/class-admin-wpdb-double.php';
 
 /**
+ * Records the SQL string get_comment_counts() passes to get_results(), so tests can assert
+ * on it directly. Defined here (rather than in Support/fixtures/) since only this file needs
+ * the capture behavior.
+ */
+class Disable_Blog_Admin_Wpdb_Query_Capturing_Double extends Disable_Blog_Admin_Wpdb_Double {
+
+	/**
+	 * The query string passed to the most recent get_results() call.
+	 *
+	 * @var string|null
+	 */
+	public $captured_query;
+
+	/**
+	 * @param string      $query  The SQL query.
+	 * @param string|null $output The output type.
+	 * @return array
+	 */
+	public function get_results( $query, $output = null ) {
+		$this->captured_query = $query;
+		return parent::get_results( $query, $output );
+	}
+}
+
+/**
  * @covers Disable_Blog_Admin::get_comment_counts
  * @covers Disable_Blog_Admin::filter_wp_count_comments
  * @covers Disable_Blog_Admin::filter_admin_table_comment_count
@@ -330,6 +355,29 @@ class AdminCommentsTest extends TestCase {
 			'all'                 => 13,
 		);
 		$this->assertSame( $expected, $admin->get_comment_counts() );
+	}
+
+	/**
+	 * The post types are joined with `implode( "','", ... )` so each becomes its own quoted
+	 * SQL string literal inside the `IN (...)` list. Asserts the exact resulting clause,
+	 * since a plain `implode( ',', ... )` would still produce a query that "looks" similar
+	 * but silently collapses every post type into a single unquoted/mis-quoted literal.
+	 */
+	public function test_get_comment_counts_quotes_each_post_type_separately_in_the_in_clause() {
+		$this->stub_feature_cache_hit( 'comments', array( 'book', 'recipe', 'event' ) );
+
+		global $wpdb;
+		$wpdb = new Disable_Blog_Admin_Wpdb_Query_Capturing_Double( array() );
+		WP_Mock::userFunction( 'esc_sql' )->andReturnUsing(
+			function ( $value ) {
+				return $value;
+			}
+		);
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->get_comment_counts();
+
+		$this->assertStringContainsString( "post_type in ('book','recipe','event')", $wpdb->captured_query );
 	}
 
 	/**
@@ -706,6 +754,7 @@ class AdminCommentsTest extends TestCase {
 		$this->assertSame( 'page', $captured_args['post_type'] );
 		$this->assertSame( 'ids', $captured_args['fields'] );
 		$this->assertSame( 'post_tag', $captured_args['tax_query'][0]['taxonomy'] );
+		$this->assertSame( 'id', $captured_args['tax_query'][0]['field'] );
 		$this->assertSame( 7, $captured_args['tax_query'][0]['terms'] );
 	}
 }

--- a/tests/php/AdminHooksTest.php
+++ b/tests/php/AdminHooksTest.php
@@ -81,10 +81,27 @@ class AdminHooksTest extends TestCase {
 	 * @return void
 	 */
 	private function stub_tax_lookup_plumbing() {
-		WP_Mock::userFunction( 'get_post_types' )->with( array(), 'names' )->andReturn( array() );
+		WP_Mock::userFunction( 'get_post_types' )
+			->with(
+				Mockery::on(
+					function ( $args ) {
+						return array() === $args;
+					}
+				),
+				'names'
+			)
+			->andReturn( array() );
 		WP_Mock::userFunction( 'wp_cache_get' )->andReturn( false );
 		WP_Mock::userFunction( 'wp_cache_set' )->andReturn( null );
-		WP_Mock::userFunction( 'maybe_serialize' )->with( array() )->andReturn( 'a:0:{}' );
+		WP_Mock::userFunction( 'maybe_serialize' )
+			->with(
+				Mockery::on(
+					function ( $args ) {
+						return array() === $args;
+					}
+				)
+			)
+			->andReturn( 'a:0:{}' );
 	}
 
 	/**
@@ -100,7 +117,16 @@ class AdminHooksTest extends TestCase {
 		WP_Mock::userFunction( 'esc_attr' )->with( $taxonomy )->andReturn( $taxonomy );
 		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
 			->with( null, $taxonomy, array(), array(), 'names' )
-			->reply( $return_value );
+			->reply(
+				new WP_Mock\InvokedFilterValue(
+					function ( $null, $tax, $post_types, $args, $output ) use ( $return_value ) {
+						$this->assertSame( array(), $post_types, 'dwpb_taxonomy_support must receive the exact $post_types array it documents.' );
+						$this->assertSame( array(), $args, 'dwpb_taxonomy_support must receive the exact $args array it documents.' );
+
+						return $return_value;
+					}
+				)
+			);
 	}
 
 	/**
@@ -123,7 +149,19 @@ class AdminHooksTest extends TestCase {
 			->andReturn( array() );
 		WP_Mock::onFilter( "dwpb_post_types_supporting_{$feature}" )
 			->with( array(), array() )
-			->reply( $return_value );
+			->reply(
+				new WP_Mock\InvokedFilterValue(
+					function ( $post_types_with_feature, $args ) use ( $return_value ) {
+						// The cached empty array is normalized to false before it reaches
+						// this filter -- safe_offset() string-casts both to '', so WP_Mock's
+						// ->with( array(), array() ) above (needed to route here at all)
+						// cannot by itself tell the two apart. assertSame() can.
+						$this->assertFalse( $post_types_with_feature );
+						$this->assertSame( array(), $args );
+						return $return_value;
+					}
+				)
+			);
 	}
 
 	/**
@@ -133,7 +171,81 @@ class AdminHooksTest extends TestCase {
 	 * @return void
 	 */
 	private function stub_remove_writing_options( $return_value ) {
-		WP_Mock::onFilter( 'dwpb_remove_options_writing' )->with( false )->reply( $return_value );
+		WP_Mock::onFilter( 'dwpb_remove_options_writing' )->with( false )->reply(
+			new WP_Mock\InvokedFilterValue(
+				function ( $default ) use ( $return_value ) {
+					// safe_offset( false ) === safe_offset( '' ), so the ->with( false )
+					// above routes here for either value; assertSame() confirms the real
+					// argument really is the boolean default, not a loosely-equal string.
+					$this->assertFalse( $default );
+					return $return_value;
+				}
+			)
+		);
+	}
+
+	/**
+	 * Forces remove_menu_pages()'s dwpb_menu_pages_to_remove filter, asserting the real
+	 * argument is the full array WP_Mock routed on and not merely a value that flattens to
+	 * the same safe_offset() string (a one-element array of a string collides with that bare
+	 * string under safe_offset()).
+	 *
+	 * @param array $expected_pages The exact pages array $remove_pages must equal.
+	 * @param array $return_value   The value the filter should reply with.
+	 * @return void
+	 */
+	private function stub_menu_pages_to_remove( array $expected_pages, array $return_value ) {
+		WP_Mock::onFilter( 'dwpb_menu_pages_to_remove' )->with( $expected_pages )->reply(
+			new WP_Mock\InvokedFilterValue(
+				function ( $pages ) use ( $expected_pages, $return_value ) {
+					$this->assertSame( $expected_pages, $pages );
+					return $return_value;
+				}
+			)
+		);
+	}
+
+	/**
+	 * Stubs a single-argument filter, asserting via InvokedFilterValue that the real
+	 * argument WP_Mock routed on strictly (===) matches $expected_arg, rather than merely
+	 * matching loosely (==) as safe_offset()'s string-cast routing key would otherwise
+	 * allow -- e.g. bool true and int 1 both safe_offset() to the same key.
+	 *
+	 * @param string $hook         The filter hook name.
+	 * @param mixed  $expected_arg The exact value apply_filters() must be called with.
+	 * @param mixed  $return_value The value the filter should reply with.
+	 * @return void
+	 */
+	private function stub_strict_filter( $hook, $expected_arg, $return_value ) {
+		WP_Mock::onFilter( $hook )->with( $expected_arg )->reply(
+			new WP_Mock\InvokedFilterValue(
+				function ( $actual_arg ) use ( $expected_arg, $return_value ) {
+					$this->assertSame( $expected_arg, $actual_arg );
+					return $return_value;
+				}
+			)
+		);
+	}
+
+	/**
+	 * Stubs remove_widgets()'s dwpb_unregister_widgets filter for a single widget class,
+	 * asserting the real first argument is strictly the boolean default (bool true and int 1
+	 * both safe_offset() to the same routing key).
+	 *
+	 * @param string $widget       The widget class name.
+	 * @param bool   $return_value The value the filter should reply with.
+	 * @return void
+	 */
+	private function stub_unregister_widget_filter( $widget, $return_value ) {
+		WP_Mock::onFilter( 'dwpb_unregister_widgets' )->with( true, $widget )->reply(
+			new WP_Mock\InvokedFilterValue(
+				function ( $default, $actual_widget ) use ( $widget, $return_value ) {
+					$this->assertTrue( $default );
+					$this->assertSame( $widget, $actual_widget );
+					return $return_value;
+				}
+			)
+		);
 	}
 
 	/**
@@ -148,7 +260,7 @@ class AdminHooksTest extends TestCase {
 		$this->stub_feature_cache_hit( 'comments', array( 'page' ) );
 		$this->stub_remove_writing_options( false );
 
-		WP_Mock::onFilter( 'dwpb_menu_pages_to_remove' )->with( array( 'edit.php' ) )->reply( array( 'edit.php' ) );
+		$this->stub_menu_pages_to_remove( array( 'edit.php' ), array( 'edit.php' ) );
 		WP_Mock::userFunction( 'remove_menu_page' )->once()->with( 'edit.php' );
 
 		$expected_subpages = array(
@@ -198,7 +310,7 @@ class AdminHooksTest extends TestCase {
 		$this->stub_feature_cache_hit( 'comments', array( 'page' ) );
 		$this->stub_remove_writing_options( true );
 
-		WP_Mock::onFilter( 'dwpb_menu_pages_to_remove' )->with( array( 'edit.php' ) )->reply( array( 'edit.php' ) );
+		$this->stub_menu_pages_to_remove( array( 'edit.php' ), array( 'edit.php' ) );
 		WP_Mock::userFunction( 'remove_menu_page' )->once()->with( 'edit.php' );
 
 		$expected_subpages = array(
@@ -222,9 +334,7 @@ class AdminHooksTest extends TestCase {
 		$this->stub_feature_cache_hit( 'comments', array( 'page' ) );
 		$this->stub_remove_writing_options( false );
 
-		WP_Mock::onFilter( 'dwpb_menu_pages_to_remove' )
-			->with( array( 'edit.php' ) )
-			->reply( array( 'edit.php', 'extra-page.php' ) );
+		$this->stub_menu_pages_to_remove( array( 'edit.php' ), array( 'edit.php', 'extra-page.php' ) );
 		WP_Mock::userFunction( 'remove_menu_page' )->once()->with( 'edit.php' );
 		WP_Mock::userFunction( 'remove_menu_page' )->once()->with( 'extra-page.php' );
 
@@ -249,7 +359,7 @@ class AdminHooksTest extends TestCase {
 		$this->stub_feature_cache_hit( 'comments', array( 'page' ) );
 		$this->stub_remove_writing_options( false );
 
-		WP_Mock::onFilter( 'dwpb_menu_pages_to_remove' )->with( array( 'edit.php' ) )->reply( array( 'edit.php' ) );
+		$this->stub_menu_pages_to_remove( array( 'edit.php' ), array( 'edit.php' ) );
 		WP_Mock::userFunction( 'remove_menu_page' )->once()->with( 'edit.php' );
 
 		$default_subpages = array(
@@ -271,8 +381,8 @@ class AdminHooksTest extends TestCase {
 	 */
 
 	public function test_remove_dashboard_widgets_removes_both_widgets_by_default() {
-		WP_Mock::onFilter( 'dwpb_disable_dashboard_quick_press' )->with( true )->reply( true );
-		WP_Mock::onFilter( 'dwpb_disable_dashboard_activity' )->with( true )->reply( true );
+		$this->stub_strict_filter( 'dwpb_disable_dashboard_quick_press', true, true );
+		$this->stub_strict_filter( 'dwpb_disable_dashboard_activity', true, true );
 		WP_Mock::userFunction( 'remove_meta_box' )->once()->with( 'dashboard_quick_press', 'dashboard', 'side' );
 		WP_Mock::userFunction( 'remove_meta_box' )->once()->with( 'dashboard_activity', 'dashboard', 'normal' );
 
@@ -283,8 +393,8 @@ class AdminHooksTest extends TestCase {
 	}
 
 	public function test_remove_dashboard_widgets_keeps_quick_press_when_its_filter_returns_false() {
-		WP_Mock::onFilter( 'dwpb_disable_dashboard_quick_press' )->with( true )->reply( false );
-		WP_Mock::onFilter( 'dwpb_disable_dashboard_activity' )->with( true )->reply( true );
+		$this->stub_strict_filter( 'dwpb_disable_dashboard_quick_press', true, false );
+		$this->stub_strict_filter( 'dwpb_disable_dashboard_activity', true, true );
 		WP_Mock::userFunction( 'remove_meta_box' )->never()->with( 'dashboard_quick_press', 'dashboard', 'side' );
 		WP_Mock::userFunction( 'remove_meta_box' )->once()->with( 'dashboard_activity', 'dashboard', 'normal' );
 
@@ -295,8 +405,8 @@ class AdminHooksTest extends TestCase {
 	}
 
 	public function test_remove_dashboard_widgets_keeps_activity_when_its_filter_returns_false() {
-		WP_Mock::onFilter( 'dwpb_disable_dashboard_quick_press' )->with( true )->reply( true );
-		WP_Mock::onFilter( 'dwpb_disable_dashboard_activity' )->with( true )->reply( false );
+		$this->stub_strict_filter( 'dwpb_disable_dashboard_quick_press', true, true );
+		$this->stub_strict_filter( 'dwpb_disable_dashboard_activity', true, false );
 		WP_Mock::userFunction( 'remove_meta_box' )->once()->with( 'dashboard_quick_press', 'dashboard', 'side' );
 		WP_Mock::userFunction( 'remove_meta_box' )->never()->with( 'dashboard_activity', 'dashboard', 'normal' );
 
@@ -331,7 +441,7 @@ class AdminHooksTest extends TestCase {
 
 	public function test_remove_widgets_unregisters_every_supported_widget_by_default() {
 		foreach ( $this->widget_class_names() as $widget ) {
-			WP_Mock::onFilter( 'dwpb_unregister_widgets' )->with( true, $widget )->reply( true );
+			$this->stub_unregister_widget_filter( $widget, true );
 			WP_Mock::userFunction( 'unregister_widget' )->once()->with( $widget );
 		}
 
@@ -348,7 +458,7 @@ class AdminHooksTest extends TestCase {
 	public function test_remove_widgets_dwpb_unregister_widgets_filter_can_keep_one_widget() {
 		foreach ( $this->widget_class_names() as $widget ) {
 			$unregister = 'WP_Widget_Categories' !== $widget;
-			WP_Mock::onFilter( 'dwpb_unregister_widgets' )->with( true, $widget )->reply( $unregister );
+			$this->stub_unregister_widget_filter( $widget, $unregister );
 			if ( $unregister ) {
 				WP_Mock::userFunction( 'unregister_widget' )->once()->with( $widget );
 			} else {

--- a/tests/php/AdminMiscTest.php
+++ b/tests/php/AdminMiscTest.php
@@ -93,10 +93,27 @@ class AdminMiscTest extends TestCase {
 	 * @return void
 	 */
 	private function stub_tax_lookup_plumbing() {
-		WP_Mock::userFunction( 'get_post_types' )->with( array(), 'names' )->andReturn( array() );
+		WP_Mock::userFunction( 'get_post_types' )
+			->with(
+				Mockery::on(
+					function ( $args ) {
+						return array() === $args;
+					}
+				),
+				'names'
+			)
+			->andReturn( array() );
 		WP_Mock::userFunction( 'wp_cache_get' )->andReturn( false );
 		WP_Mock::userFunction( 'wp_cache_set' )->andReturn( null );
-		WP_Mock::userFunction( 'maybe_serialize' )->with( array() )->andReturn( 'a:0:{}' );
+		WP_Mock::userFunction( 'maybe_serialize' )
+			->with(
+				Mockery::on(
+					function ( $args ) {
+						return array() === $args;
+					}
+				)
+			)
+			->andReturn( 'a:0:{}' );
 	}
 
 	/**
@@ -112,7 +129,38 @@ class AdminMiscTest extends TestCase {
 		WP_Mock::userFunction( 'esc_attr' )->with( $taxonomy )->andReturn( $taxonomy );
 		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
 			->with( null, $taxonomy, array(), array(), 'names' )
-			->reply( $return_value );
+			->reply(
+				new WP_Mock\InvokedFilterValue(
+					function ( $null, $tax, $post_types, $args, $output ) use ( $return_value ) {
+						$this->assertSame( array(), $post_types, 'dwpb_taxonomy_support must receive the exact $post_types array it documents.' );
+						$this->assertSame( array(), $args, 'dwpb_taxonomy_support must receive the exact $args array it documents.' );
+
+						return $return_value;
+					}
+				)
+			);
+	}
+
+	/**
+	 * Stubs a single-argument filter, asserting via InvokedFilterValue that the real
+	 * argument WP_Mock routed on strictly (===) matches $expected_arg, rather than merely
+	 * matching loosely (==) as safe_offset()'s string-cast routing key would otherwise
+	 * allow -- e.g. bool false, an empty array and '' all safe_offset() to the same key.
+	 *
+	 * @param string $hook         The filter hook name.
+	 * @param mixed  $expected_arg The exact value apply_filters() must be called with.
+	 * @param mixed  $return_value The value the filter should reply with.
+	 * @return void
+	 */
+	private function stub_strict_filter( $hook, $expected_arg, $return_value ) {
+		WP_Mock::onFilter( $hook )->with( $expected_arg )->reply(
+			new WP_Mock\InvokedFilterValue(
+				function ( $actual_arg ) use ( $expected_arg, $return_value ) {
+					$this->assertSame( $expected_arg, $actual_arg );
+					return $return_value;
+				}
+			)
+		);
 	}
 
 	/**
@@ -533,7 +581,7 @@ class AdminMiscTest extends TestCase {
 	public function test_available_permalink_structure_tags_removes_category_when_unsupported() {
 		$this->stub_tax_lookup_plumbing();
 		$this->stub_post_types_with_tax_result( 'category', false );
-		WP_Mock::onFilter( 'dwpb_disable_author_archives' )->with( false )->reply( false );
+		$this->stub_strict_filter( 'dwpb_disable_author_archives', false, false );
 
 		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
 		$result = $admin->available_permalink_structure_tags(
@@ -550,7 +598,7 @@ class AdminMiscTest extends TestCase {
 	public function test_available_permalink_structure_tags_keeps_category_when_supported() {
 		$this->stub_tax_lookup_plumbing();
 		$this->stub_post_types_with_tax_result( 'category', array( 'book' ) );
-		WP_Mock::onFilter( 'dwpb_disable_author_archives' )->with( false )->reply( false );
+		$this->stub_strict_filter( 'dwpb_disable_author_archives', false, false );
 
 		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
 		$result = $admin->available_permalink_structure_tags( array( 'category' => '%category%' ) );
@@ -559,7 +607,7 @@ class AdminMiscTest extends TestCase {
 	}
 
 	public function test_available_permalink_structure_tags_removes_author_when_author_archives_disabled() {
-		WP_Mock::onFilter( 'dwpb_disable_author_archives' )->with( false )->reply( true );
+		$this->stub_strict_filter( 'dwpb_disable_author_archives', false, true );
 
 		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
 		$result = $admin->available_permalink_structure_tags( array( 'author' => '%author%' ) );
@@ -568,7 +616,7 @@ class AdminMiscTest extends TestCase {
 	}
 
 	public function test_available_permalink_structure_tags_keeps_author_when_author_archives_enabled() {
-		WP_Mock::onFilter( 'dwpb_disable_author_archives' )->with( false )->reply( false );
+		$this->stub_strict_filter( 'dwpb_disable_author_archives', false, false );
 
 		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
 		$result = $admin->available_permalink_structure_tags( array( 'author' => '%author%' ) );
@@ -680,9 +728,19 @@ class AdminMiscTest extends TestCase {
 	 * @return void
 	 */
 	private function stub_get_test_rest_availability_common() {
-		WP_Mock::userFunction( 'wp_unslash' )->with( array() )->andReturn( array() );
+		// array() == false, so a plain ->with( array() ) would also accept a regression
+		// that passed false to wp_unslash() -- Mockery::on() forces ===.
+		WP_Mock::userFunction( 'wp_unslash' )
+			->with(
+				Mockery::on(
+					function ( $value ) {
+						return array() === $value;
+					}
+				)
+			)
+			->andReturn( array() );
 		WP_Mock::userFunction( 'wp_create_nonce' )->once()->with( 'wp_rest' )->andReturn( 'a-nonce' );
-		WP_Mock::onFilter( 'https_local_ssl_verify' )->with( false )->reply( false );
+		$this->stub_strict_filter( 'https_local_ssl_verify', false, false );
 		WP_Mock::userFunction( 'rest_url' )->once()->with( 'wp/v2/types/page' )->andReturn( 'https://example.test/wp-json/wp/v2/types/page' );
 		WP_Mock::userFunction( 'add_query_arg' )
 			->once()
@@ -770,11 +828,21 @@ class AdminMiscTest extends TestCase {
 		$_SERVER['PHP_AUTH_PW']   = 'secret';
 		// phpcs:enable WordPressVIPMinimum.Variables.ServerVariables.BasicAuthentication
 
-		WP_Mock::userFunction( 'wp_unslash' )->with( array() )->andReturn( array() );
+		// array() == false, so a plain ->with( array() ) would also accept a regression
+		// that passed false to wp_unslash() -- Mockery::on() forces ===.
+		WP_Mock::userFunction( 'wp_unslash' )
+			->with(
+				Mockery::on(
+					function ( $value ) {
+						return array() === $value;
+					}
+				)
+			)
+			->andReturn( array() );
 		WP_Mock::userFunction( 'wp_unslash' )->with( 'admin' )->andReturn( 'admin' );
 		WP_Mock::userFunction( 'wp_unslash' )->with( 'secret' )->andReturn( 'secret' );
 		WP_Mock::userFunction( 'wp_create_nonce' )->once()->with( 'wp_rest' )->andReturn( 'a-nonce' );
-		WP_Mock::onFilter( 'https_local_ssl_verify' )->with( false )->reply( false );
+		$this->stub_strict_filter( 'https_local_ssl_verify', false, false );
 		WP_Mock::userFunction( 'rest_url' )->once()->with( 'wp/v2/types/page' )->andReturn( 'https://example.test/wp-json/wp/v2/types/page' );
 		WP_Mock::userFunction( 'add_query_arg' )
 			->once()

--- a/tests/php/AdminMiscTest.php
+++ b/tests/php/AdminMiscTest.php
@@ -233,6 +233,30 @@ class AdminMiscTest extends TestCase {
 		$this->assertTrue( $category->public );
 	}
 
+	/**
+	 * The taxonomy list is `array( 'category', 'post_tag' )` -- a taxonomy keyed under any
+	 * other slug (e.g. a typo'd 'post_tags') is silently skipped by the `isset()` guard, so
+	 * this must exercise 'post_tag' specifically rather than only 'category' as the other
+	 * tests in this group do.
+	 */
+	public function test_modify_taxonomies_arguments_processes_post_tag_slug_exactly() {
+		global $wp_taxonomies;
+
+		$post_tag              = new stdClass();
+		$post_tag->object_type = array( 'post' );
+		$post_tag->public      = true;
+		$wp_taxonomies          = array( 'post_tag' => $post_tag );
+
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+		$admin->modify_taxonomies_arguments();
+
+		$this->assertNotContains( 'post', $post_tag->object_type );
+		$this->assertFalse( $post_tag->public );
+	}
+
 	public function test_modify_taxonomies_arguments_skips_when_taxonomy_not_set() {
 		global $wp_taxonomies;
 
@@ -301,6 +325,27 @@ class AdminMiscTest extends TestCase {
 	public function test_admin_notices_returns_early_when_screen_base_not_set() {
 		WP_Mock::userFunction( 'get_current_screen' )->once()->andReturn( new stdClass() );
 
+		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
+
+		ob_start();
+		$admin->admin_notices();
+		$this->assertSame( '', ob_get_clean() );
+	}
+
+	/**
+	 * `in_array( ..., true )` must use strict comparison: a screen base of `true` is loosely
+	 * equal to every string in $screens (a non-empty string always == true) but strictly
+	 * equal to none of them. With strict comparison the early return fires and nothing past
+	 * get_current_screen() runs; with loose comparison it would fall through into
+	 * has_front_page(), whose get_option() calls are deliberately left unstubbed here so a
+	 * WP_Mock strict-mode failure demonstrates the guard was bypassed.
+	 */
+	public function test_admin_notices_returns_early_for_screen_base_only_loosely_equal_to_listed_value() {
+		$current_screen       = new stdClass();
+		$current_screen->base = true;
+		WP_Mock::userFunction( 'get_current_screen' )->once()->andReturn( $current_screen );
+
+		// has_front_page() must never be reached: nothing further is stubbed.
 		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
 
 		ob_start();
@@ -586,11 +631,9 @@ class AdminMiscTest extends TestCase {
 
 	/**
 	 * Documents behavior, not a distinct branch: the guard's `! is_string( $metadata['name'] )`
-	 * half is unreachable-as-observable. Proven by mutation -- deleting that half of the
-	 * guard and rerunning this test still passes, because the subsequent
-	 * `'core/query' === $metadata['name']` strict comparison already evaluates to false for
-	 * any non-string $metadata['name'] under PHP's strict-equality type rules, independent
-	 * of the guard. This test asserts the function's actual (correct) output for a
+	 * half has no observable effect. The subsequent `'core/query' === $metadata['name']`
+	 * strict comparison already evaluates to false for any non-string $metadata['name']
+	 * under PHP's strict-equality type rules, so the guard cannot change the outcome. This test asserts the function's actual (correct) output for a
 	 * non-string name; it does not, and cannot, isolate the is_string() check itself.
 	 */
 	public function test_filter_block_type_metadata_bails_when_name_not_a_string() {

--- a/tests/php/AdminRedirectsTest.php
+++ b/tests/php/AdminRedirectsTest.php
@@ -89,7 +89,33 @@ class AdminRedirectsTest extends TestCase {
 	 */
 	private function stub_final_filters_passthrough( $redirect_url ) {
 		WP_Mock::onFilter( 'dwpb_admin_redirect_url' )->with( $redirect_url )->reply( $redirect_url );
-		WP_Mock::onFilter( 'dwpb_redirect_admin' )->with( true, $redirect_url )->reply( true );
+		$this->stub_redirect_admin_filter( $redirect_url, true );
+	}
+
+	/**
+	 * Stubs the dwpb_redirect_admin filter, asserting via InvokedFilterValue that the real
+	 * leading argument is strictly (===) the boolean true, rather than merely matching
+	 * loosely (==) as safe_offset()'s string-cast routing key would otherwise allow -- e.g.
+	 * bool true and int 1 both safe_offset() to the same key. The second ($redirect_url)
+	 * argument is left out of the strict check on purpose: it is a distinct, non-empty url
+	 * string every time this is called, so it can't collide with another value under
+	 * safe_offset(), and it still has to appear in ->with() to route the two-argument
+	 * filter invocation to this responder at all.
+	 *
+	 * @param string $redirect_url The url expected to reach the filter as the 2nd argument.
+	 * @param bool   $reply        The value the filter should reply with.
+	 * @return void
+	 */
+	private function stub_redirect_admin_filter( $redirect_url, $reply ) {
+		WP_Mock::onFilter( 'dwpb_redirect_admin' )->with( true, $redirect_url )->reply(
+			new WP_Mock\InvokedFilterValue(
+				function ( $enabled ) use ( $reply ) {
+					$this->assertTrue( $enabled );
+
+					return $reply;
+				}
+			)
+		);
 	}
 
 	/**
@@ -101,10 +127,27 @@ class AdminRedirectsTest extends TestCase {
 	 * @return void
 	 */
 	private function stub_tax_lookup_plumbing() {
-		WP_Mock::userFunction( 'get_post_types' )->with( array(), 'names' )->andReturn( array() );
+		WP_Mock::userFunction( 'get_post_types' )
+			->with(
+				Mockery::on(
+					function ( $args ) {
+						return array() === $args;
+					}
+				),
+				'names'
+			)
+			->andReturn( array() );
 		WP_Mock::userFunction( 'wp_cache_get' )->andReturn( false );
 		WP_Mock::userFunction( 'wp_cache_set' )->andReturn( null );
-		WP_Mock::userFunction( 'maybe_serialize' )->with( array() )->andReturn( 'a:0:{}' );
+		WP_Mock::userFunction( 'maybe_serialize' )
+			->with(
+				Mockery::on(
+					function ( $args ) {
+						return array() === $args;
+					}
+				)
+			)
+			->andReturn( 'a:0:{}' );
 	}
 
 	/**
@@ -120,7 +163,16 @@ class AdminRedirectsTest extends TestCase {
 		WP_Mock::userFunction( 'esc_attr' )->with( $taxonomy )->andReturn( $taxonomy );
 		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
 			->with( null, $taxonomy, array(), array(), 'names' )
-			->reply( $return_value );
+			->reply(
+				new WP_Mock\InvokedFilterValue(
+					function ( $null, $tax, $post_types, $args, $output ) use ( $return_value ) {
+						$this->assertSame( array(), $post_types, 'dwpb_taxonomy_support must receive the exact $post_types array it documents.' );
+						$this->assertSame( array(), $args, 'dwpb_taxonomy_support must receive the exact $args array it documents.' );
+
+						return $return_value;
+					}
+				)
+			);
 	}
 
 	/**
@@ -143,7 +195,40 @@ class AdminRedirectsTest extends TestCase {
 			->andReturn( array() );
 		WP_Mock::onFilter( "dwpb_post_types_supporting_{$feature}" )
 			->with( array(), array() )
-			->reply( $return_value );
+			->reply(
+				new WP_Mock\InvokedFilterValue(
+					function ( $post_types_with_feature, $args ) use ( $return_value ) {
+						// The cached empty array is normalized to false before it reaches
+						// this filter -- safe_offset() string-casts both to '', so WP_Mock's
+						// ->with( array(), array() ) above (needed to route here at all)
+						// cannot by itself tell the two apart. assertSame() can.
+						$this->assertFalse( $post_types_with_feature );
+						$this->assertSame( array(), $args );
+						return $return_value;
+					}
+				)
+			);
+	}
+
+	/**
+	 * Forces redirect_admin_options_writing()'s dwpb_remove_options_writing filter to
+	 * $return_value.
+	 *
+	 * @param bool $return_value The value the filter should reply with.
+	 * @return void
+	 */
+	private function stub_remove_writing_options( $return_value ) {
+		WP_Mock::onFilter( 'dwpb_remove_options_writing' )->with( false )->reply(
+			new WP_Mock\InvokedFilterValue(
+				function ( $default ) use ( $return_value ) {
+					// safe_offset( false ) === safe_offset( '' ), so the ->with( false )
+					// above routes here for either value; assertSame() confirms the real
+					// argument really is the boolean default, not a loosely-equal string.
+					$this->assertFalse( $default );
+					return $return_value;
+				}
+			)
+		);
 	}
 
 	/**
@@ -201,7 +286,7 @@ class AdminRedirectsTest extends TestCase {
 
 		$dashboard_url = 'https://example.test/wp-admin/index.php';
 		WP_Mock::userFunction( 'admin_url' )->with( 'index.php' )->andReturn( $dashboard_url );
-		WP_Mock::onFilter( 'dwpb_admin_redirect_url' )->with( false )->reply( false );
+		$this->stub_filter_strict( 'dwpb_admin_redirect_url', false, false );
 
 		$functions = new Disable_Blog_Admin_Functions_Double();
 		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
@@ -222,7 +307,7 @@ class AdminRedirectsTest extends TestCase {
 		$dashboard_url = 'https://example.test/wp-admin/index.php';
 		$this->stub_dashboard_guards_pass( $dashboard_url );
 		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
-		WP_Mock::onFilter( 'dwpb_admin_redirect_url' )->with( false )->reply( false );
+		$this->stub_filter_strict( 'dwpb_admin_redirect_url', false, false );
 
 		$functions = new Disable_Blog_Admin_Functions_Double();
 		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
@@ -331,7 +416,7 @@ class AdminRedirectsTest extends TestCase {
 
 		$global_override_url = 'https://example.test/wp-admin/global-override/';
 		WP_Mock::onFilter( 'dwpb_admin_redirect_url' )->with( $dashboard_url )->reply( $global_override_url );
-		WP_Mock::onFilter( 'dwpb_redirect_admin' )->with( true, $global_override_url )->reply( true );
+		$this->stub_redirect_admin_filter( $global_override_url, true );
 
 		$functions = new Disable_Blog_Admin_Functions_Double();
 		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
@@ -360,7 +445,7 @@ class AdminRedirectsTest extends TestCase {
 			->andReturn( $dashboard_url );
 
 		WP_Mock::onFilter( 'dwpb_admin_redirect_url' )->with( $dashboard_url )->reply( $dashboard_url );
-		WP_Mock::onFilter( 'dwpb_redirect_admin' )->with( true, $dashboard_url )->reply( false );
+		$this->stub_redirect_admin_filter( $dashboard_url, false );
 
 		$functions = new Disable_Blog_Admin_Functions_Double();
 		$admin     = new Disable_Blog_Admin( 'disable-blog', '0.5.6', $functions );
@@ -710,7 +795,7 @@ class AdminRedirectsTest extends TestCase {
 		$options_general_url = 'https://example.test/wp-admin/options-general.php';
 		$this->stub_dashboard_guards_pass( $dashboard_url );
 		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
-		WP_Mock::onFilter( 'dwpb_remove_options_writing' )->with( false )->reply( true );
+		$this->stub_remove_writing_options( true );
 		WP_Mock::userFunction( 'admin_url' )->with( 'options-general.php' )->andReturn( $options_general_url );
 		WP_Mock::userFunction( 'esc_url_raw' )->with( $options_general_url )->andReturn( $options_general_url );
 
@@ -733,7 +818,7 @@ class AdminRedirectsTest extends TestCase {
 		$options_general_url  = 'https://example.test/wp-admin/options-general.php';
 		$this->stub_dashboard_guards_pass( $dashboard_url );
 		WP_Mock::userFunction( 'is_admin' )->andReturn( true );
-		WP_Mock::onFilter( 'dwpb_remove_options_writing' )->with( false )->reply( true );
+		$this->stub_remove_writing_options( true );
 		WP_Mock::userFunction( 'admin_url' )->with( 'options-general.php' )->andReturn( $options_general_url );
 		WP_Mock::userFunction( 'esc_url_raw' )->with( $options_general_url )->andReturn( $options_general_url );
 
@@ -1081,7 +1166,7 @@ class AdminRedirectsTest extends TestCase {
 
 	public function test_redirect_admin_options_writing_redirects_when_writing_options_removed() {
 		$url = 'https://example.test/wp-admin/options-general.php';
-		WP_Mock::onFilter( 'dwpb_remove_options_writing' )->with( false )->reply( true );
+		$this->stub_remove_writing_options( true );
 		WP_Mock::userFunction( 'admin_url' )->once()->with( 'options-general.php' )->andReturn( $url );
 
 		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
@@ -1090,7 +1175,7 @@ class AdminRedirectsTest extends TestCase {
 	}
 
 	public function test_redirect_admin_options_writing_false_when_writing_options_kept() {
-		WP_Mock::onFilter( 'dwpb_remove_options_writing' )->with( false )->reply( false );
+		$this->stub_remove_writing_options( false );
 
 		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
 

--- a/tests/php/AdminUsersTest.php
+++ b/tests/php/AdminUsersTest.php
@@ -56,6 +56,51 @@ class AdminUsersTest extends TestCase {
 	}
 
 	/**
+	 * Stubs a single-argument filter, asserting via InvokedFilterValue that the real
+	 * argument WP_Mock routed on strictly (===) matches $expected_arg, rather than merely
+	 * matching loosely (==) as safe_offset()'s string-cast routing key would otherwise
+	 * allow -- e.g. bool false, an empty array and '' all safe_offset() to the same key, as
+	 * do a one-element array of a string and that bare string.
+	 *
+	 * @param string $hook         The filter hook name.
+	 * @param mixed  $expected_arg The exact value apply_filters() must be called with.
+	 * @param mixed  $return_value The value the filter should reply with.
+	 * @return void
+	 */
+	private function stub_strict_filter( $hook, $expected_arg, $return_value ) {
+		WP_Mock::onFilter( $hook )->with( $expected_arg )->reply(
+			new WP_Mock\InvokedFilterValue(
+				function ( $actual_arg ) use ( $expected_arg, $return_value ) {
+					$this->assertSame( $expected_arg, $actual_arg );
+					return $return_value;
+				}
+			)
+		);
+	}
+
+	/**
+	 * A Mockery matcher asserting the argument is exactly array( $value ), pinning $value
+	 * by identity (===) rather than Mockery's default loose (==) comparison. This is
+	 * distinct from onFilter()'s safe_offset() collision that stub_strict_filter() guards
+	 * against: apply_filters_deprecated() is a plain userFunction(), so its ->with()
+	 * expectation IS Mockery-backed and matches with ==, under which array( true ) ==
+	 * array( 1 ) and array( false ) == array( '' ) both hold -- a plain
+	 * ->with( array( true ) ) therefore still matches a caller that passed array( 1 ) (or
+	 * any other loosely-equal value) instead of the literal boolean it documents.
+	 *
+	 * @param bool $value The exact boolean the single-element array must contain.
+	 * @return Mockery\Matcher\Closure
+	 */
+	private function strict_bool_array( $value ) {
+		return Mockery::on(
+			function ( $actual ) use ( $value ) {
+				$this->assertSame( array( $value ), $actual );
+				return true;
+			}
+		);
+	}
+
+	/**
 	 * Forces user_column_post_types() to resolve to array( 'page' ): an empty
 	 * dwpb_author_archive_post_types reply (real Disable_Blog_Functions::author_archive_post_types()
 	 * default), merged with 'page', passed through dwpb_admin_user_post_types unchanged.
@@ -63,8 +108,8 @@ class AdminUsersTest extends TestCase {
 	 * @return void
 	 */
 	private function stub_default_user_column_post_types() {
-		WP_Mock::onFilter( 'dwpb_author_archive_post_types' )->with( array() )->reply( array() );
-		WP_Mock::onFilter( 'dwpb_admin_user_post_types' )->with( array( 'page' ) )->reply( array( 'page' ) );
+		$this->stub_strict_filter( 'dwpb_author_archive_post_types', array(), array() );
+		$this->stub_strict_filter( 'dwpb_admin_user_post_types', array( 'page' ), array( 'page' ) );
 	}
 
 	/**
@@ -72,10 +117,10 @@ class AdminUsersTest extends TestCase {
 	 */
 
 	public function test_manage_users_columns_removes_posts_column_and_adds_page_column_by_default() {
-		WP_Mock::onFilter( 'dwpb_disable_user_post_column' )->with( true )->reply( true );
+		$this->stub_strict_filter( 'dwpb_disable_user_post_column', true, true );
 		WP_Mock::userFunction( 'apply_filters_deprecated' )
 			->once()
-			->with( 'dpwb_disable_user_post_column', array( true ), '0.5.6', 'dwpb_disable_user_post_column' )
+			->with( 'dpwb_disable_user_post_column', $this->strict_bool_array( true ), '0.5.6', 'dwpb_disable_user_post_column' )
 			->andReturn( true );
 
 		global $current_screen;
@@ -85,10 +130,10 @@ class AdminUsersTest extends TestCase {
 
 		$this->stub_default_user_column_post_types();
 
-		WP_Mock::onFilter( 'dwpb_create_user_page_column' )->with( true )->reply( true );
+		$this->stub_strict_filter( 'dwpb_create_user_page_column', true, true );
 		WP_Mock::userFunction( 'apply_filters_deprecated' )
 			->once()
-			->with( 'dpwb_create_user_page_column', array( true ), '0.5.6', 'dwpb_create_user_page_column' )
+			->with( 'dpwb_create_user_page_column', $this->strict_bool_array( true ), '0.5.6', 'dwpb_create_user_page_column' )
 			->andReturn( true );
 
 		$page_type          = new stdClass();
@@ -113,10 +158,10 @@ class AdminUsersTest extends TestCase {
 	 * overriding the primary filter's reply back to false keeps the posts column.
 	 */
 	public function test_manage_users_columns_deprecated_disable_alias_can_keep_posts_column() {
-		WP_Mock::onFilter( 'dwpb_disable_user_post_column' )->with( true )->reply( true );
+		$this->stub_strict_filter( 'dwpb_disable_user_post_column', true, true );
 		WP_Mock::userFunction( 'apply_filters_deprecated' )
 			->once()
-			->with( 'dpwb_disable_user_post_column', array( true ), '0.5.6', 'dwpb_disable_user_post_column' )
+			->with( 'dpwb_disable_user_post_column', $this->strict_bool_array( true ), '0.5.6', 'dwpb_disable_user_post_column' )
 			->andReturn( false );
 
 		global $current_screen;
@@ -126,10 +171,10 @@ class AdminUsersTest extends TestCase {
 
 		$this->stub_default_user_column_post_types();
 
-		WP_Mock::onFilter( 'dwpb_create_user_page_column' )->with( true )->reply( false );
+		$this->stub_strict_filter( 'dwpb_create_user_page_column', true, false );
 		WP_Mock::userFunction( 'apply_filters_deprecated' )
 			->once()
-			->with( 'dpwb_create_user_page_column', array( false ), '0.5.6', 'dwpb_create_user_page_column' )
+			->with( 'dpwb_create_user_page_column', $this->strict_bool_array( false ), '0.5.6', 'dwpb_create_user_page_column' )
 			->andReturn( false );
 
 		$admin  = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
@@ -144,10 +189,10 @@ class AdminUsersTest extends TestCase {
 	 * effect: the primary filter says yes, but the deprecated alias overrides to no.
 	 */
 	public function test_manage_users_columns_deprecated_create_alias_can_disable_page_column() {
-		WP_Mock::onFilter( 'dwpb_disable_user_post_column' )->with( true )->reply( true );
+		$this->stub_strict_filter( 'dwpb_disable_user_post_column', true, true );
 		WP_Mock::userFunction( 'apply_filters_deprecated' )
 			->once()
-			->with( 'dpwb_disable_user_post_column', array( true ), '0.5.6', 'dwpb_disable_user_post_column' )
+			->with( 'dpwb_disable_user_post_column', $this->strict_bool_array( true ), '0.5.6', 'dwpb_disable_user_post_column' )
 			->andReturn( true );
 
 		global $current_screen;
@@ -157,10 +202,10 @@ class AdminUsersTest extends TestCase {
 
 		$this->stub_default_user_column_post_types();
 
-		WP_Mock::onFilter( 'dwpb_create_user_page_column' )->with( true )->reply( true );
+		$this->stub_strict_filter( 'dwpb_create_user_page_column', true, true );
 		WP_Mock::userFunction( 'apply_filters_deprecated' )
 			->once()
-			->with( 'dpwb_create_user_page_column', array( true ), '0.5.6', 'dwpb_create_user_page_column' )
+			->with( 'dpwb_create_user_page_column', $this->strict_bool_array( true ), '0.5.6', 'dwpb_create_user_page_column' )
 			->andReturn( false );
 
 		// get_post_type_object() must never be reached: nothing further is stubbed.
@@ -171,10 +216,10 @@ class AdminUsersTest extends TestCase {
 	}
 
 	public function test_manage_users_columns_skips_column_on_site_users_network_screen() {
-		WP_Mock::onFilter( 'dwpb_disable_user_post_column' )->with( true )->reply( true );
+		$this->stub_strict_filter( 'dwpb_disable_user_post_column', true, true );
 		WP_Mock::userFunction( 'apply_filters_deprecated' )
 			->once()
-			->with( 'dpwb_disable_user_post_column', array( true ), '0.5.6', 'dwpb_disable_user_post_column' )
+			->with( 'dpwb_disable_user_post_column', $this->strict_bool_array( true ), '0.5.6', 'dwpb_disable_user_post_column' )
 			->andReturn( true );
 
 		global $current_screen;
@@ -184,10 +229,10 @@ class AdminUsersTest extends TestCase {
 
 		$this->stub_default_user_column_post_types();
 
-		WP_Mock::onFilter( 'dwpb_create_user_page_column' )->with( true )->reply( true );
+		$this->stub_strict_filter( 'dwpb_create_user_page_column', true, true );
 		WP_Mock::userFunction( 'apply_filters_deprecated' )
 			->once()
-			->with( 'dpwb_create_user_page_column', array( true ), '0.5.6', 'dwpb_create_user_page_column' )
+			->with( 'dpwb_create_user_page_column', $this->strict_bool_array( true ), '0.5.6', 'dwpb_create_user_page_column' )
 			->andReturn( true );
 
 		// get_post_type_object() must never be reached: nothing further is stubbed.
@@ -198,10 +243,10 @@ class AdminUsersTest extends TestCase {
 	}
 
 	public function test_manage_users_columns_skips_column_when_post_type_labels_missing() {
-		WP_Mock::onFilter( 'dwpb_disable_user_post_column' )->with( true )->reply( true );
+		$this->stub_strict_filter( 'dwpb_disable_user_post_column', true, true );
 		WP_Mock::userFunction( 'apply_filters_deprecated' )
 			->once()
-			->with( 'dpwb_disable_user_post_column', array( true ), '0.5.6', 'dwpb_disable_user_post_column' )
+			->with( 'dpwb_disable_user_post_column', $this->strict_bool_array( true ), '0.5.6', 'dwpb_disable_user_post_column' )
 			->andReturn( true );
 
 		global $current_screen;
@@ -211,10 +256,10 @@ class AdminUsersTest extends TestCase {
 
 		$this->stub_default_user_column_post_types();
 
-		WP_Mock::onFilter( 'dwpb_create_user_page_column' )->with( true )->reply( true );
+		$this->stub_strict_filter( 'dwpb_create_user_page_column', true, true );
 		WP_Mock::userFunction( 'apply_filters_deprecated' )
 			->once()
-			->with( 'dpwb_create_user_page_column', array( true ), '0.5.6', 'dwpb_create_user_page_column' )
+			->with( 'dpwb_create_user_page_column', $this->strict_bool_array( true ), '0.5.6', 'dwpb_create_user_page_column' )
 			->andReturn( true );
 
 		// No 'labels' property at all -- isset( $post_type_obj->labels->name ) is false.
@@ -227,10 +272,10 @@ class AdminUsersTest extends TestCase {
 	}
 
 	public function test_manage_users_columns_adds_columns_for_additional_author_archive_post_types() {
-		WP_Mock::onFilter( 'dwpb_disable_user_post_column' )->with( true )->reply( true );
+		$this->stub_strict_filter( 'dwpb_disable_user_post_column', true, true );
 		WP_Mock::userFunction( 'apply_filters_deprecated' )
 			->once()
-			->with( 'dpwb_disable_user_post_column', array( true ), '0.5.6', 'dwpb_disable_user_post_column' )
+			->with( 'dpwb_disable_user_post_column', $this->strict_bool_array( true ), '0.5.6', 'dwpb_disable_user_post_column' )
 			->andReturn( true );
 
 		global $current_screen;
@@ -238,16 +283,16 @@ class AdminUsersTest extends TestCase {
 		$current_screen->id = 'users';
 		WP_Mock::userFunction( 'get_current_screen' )->once()->andReturn( $current_screen );
 
-		WP_Mock::onFilter( 'dwpb_author_archive_post_types' )->with( array() )->reply( array( 'book' ) );
+		$this->stub_strict_filter( 'dwpb_author_archive_post_types', array(), array( 'book' ) );
 		WP_Mock::onFilter( 'dwpb_admin_user_post_types' )
 			->with( array( 'page', 'book' ) )
 			->reply( array( 'page', 'book' ) );
 
 		foreach ( array( 'page', 'book' ) as $post_type ) {
-			WP_Mock::onFilter( "dwpb_create_user_{$post_type}_column" )->with( true )->reply( true );
+			$this->stub_strict_filter( "dwpb_create_user_{$post_type}_column", true, true );
 			WP_Mock::userFunction( 'apply_filters_deprecated' )
 				->once()
-				->with( "dpwb_create_user_{$post_type}_column", array( true ), '0.5.6', "dwpb_create_user_{$post_type}_column" )
+				->with( "dpwb_create_user_{$post_type}_column", $this->strict_bool_array( true ), '0.5.6', "dwpb_create_user_{$post_type}_column" )
 				->andReturn( true );
 
 			$type_obj                 = new stdClass();
@@ -343,7 +388,7 @@ class AdminUsersTest extends TestCase {
 	}
 
 	public function test_manage_users_custom_column_skips_when_post_type_labels_missing() {
-		WP_Mock::onFilter( 'dwpb_author_archive_post_types' )->with( array() )->reply( array( 'book' ) );
+		$this->stub_strict_filter( 'dwpb_author_archive_post_types', array(), array( 'book' ) );
 		WP_Mock::onFilter( 'dwpb_admin_user_post_types' )
 			->with( array( 'page', 'book' ) )
 			->reply( array( 'page', 'book' ) );
@@ -372,7 +417,7 @@ class AdminUsersTest extends TestCase {
 	}
 
 	public function test_user_column_post_types_merges_author_archive_post_types_with_page() {
-		WP_Mock::onFilter( 'dwpb_author_archive_post_types' )->with( array() )->reply( array( 'book' ) );
+		$this->stub_strict_filter( 'dwpb_author_archive_post_types', array(), array( 'book' ) );
 		WP_Mock::onFilter( 'dwpb_admin_user_post_types' )
 			->with( array( 'page', 'book' ) )
 			->reply( array( 'page', 'book' ) );
@@ -383,8 +428,8 @@ class AdminUsersTest extends TestCase {
 	}
 
 	public function test_user_column_post_types_filter_can_override_the_whole_list() {
-		WP_Mock::onFilter( 'dwpb_author_archive_post_types' )->with( array() )->reply( array() );
-		WP_Mock::onFilter( 'dwpb_admin_user_post_types' )->with( array( 'page' ) )->reply( array( 'custom-cpt' ) );
+		$this->stub_strict_filter( 'dwpb_author_archive_post_types', array(), array() );
+		$this->stub_strict_filter( 'dwpb_admin_user_post_types', array( 'page' ), array( 'custom-cpt' ) );
 
 		$admin = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
 
@@ -396,7 +441,7 @@ class AdminUsersTest extends TestCase {
 	 */
 
 	public function test_user_row_actions_removes_view_link_when_author_archives_disabled() {
-		WP_Mock::onFilter( 'dwpb_disable_author_archives' )->with( false )->reply( true );
+		$this->stub_strict_filter( 'dwpb_disable_author_archives', false, true );
 
 		$admin   = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
 		$actions = array( 'view' => '<a>View</a>' );
@@ -405,7 +450,7 @@ class AdminUsersTest extends TestCase {
 	}
 
 	public function test_user_row_actions_keeps_view_link_when_author_archives_enabled() {
-		WP_Mock::onFilter( 'dwpb_disable_author_archives' )->with( false )->reply( false );
+		$this->stub_strict_filter( 'dwpb_disable_author_archives', false, false );
 
 		$admin   = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
 		$actions = array( 'view' => '<a>View</a>' );
@@ -414,7 +459,7 @@ class AdminUsersTest extends TestCase {
 	}
 
 	public function test_user_row_actions_no_op_when_view_link_already_absent() {
-		WP_Mock::onFilter( 'dwpb_disable_author_archives' )->with( false )->reply( true );
+		$this->stub_strict_filter( 'dwpb_disable_author_archives', false, true );
 
 		$admin   = new Disable_Blog_Admin( 'disable-blog', '0.5.6' );
 		$actions = array( 'edit' => '<a>Edit</a>' );

--- a/tests/php/ConstructorInjectionTest.php
+++ b/tests/php/ConstructorInjectionTest.php
@@ -84,7 +84,7 @@ class ConstructorInjectionTest extends TestCase {
 		$public   = new Disable_Blog_Public( 'disable-blog', '0.5.6', $double );
 		$provider = new stdClass();
 
-		WP_Mock::onFilter( 'dwpb_disable_user_sitemap' )->with( false )->reply( false );
+		$this->stub_filter_strict( 'dwpb_disable_user_sitemap', false, false );
 
 		$this->assertSame( $provider, $public->wp_author_sitemaps( $provider, 'users' ) );
 	}

--- a/tests/php/DeactivatorTest.php
+++ b/tests/php/DeactivatorTest.php
@@ -6,6 +6,30 @@
  */
 
 /**
+ * Spies on terminate() so the referer-check branch in deactivate() can be exercised without
+ * the real exit; ending the test process. deactivate() invokes `static::terminate()`, so late
+ * static binding dispatches to this override instead of the parent's.
+ */
+class DeactivatorTerminateSpy extends Disable_Blog_Deactivator {
+
+	/**
+	 * Whether terminate() was invoked during the current test.
+	 *
+	 * @var bool
+	 */
+	public static $terminate_called = false;
+
+	/**
+	 * Records the call instead of exiting.
+	 *
+	 * @return void
+	 */
+	protected static function terminate() {
+		self::$terminate_called = true;
+	}
+}
+
+/**
  * @covers Disable_Blog_Deactivator
  */
 class DeactivatorTest extends PluginLifecycleTestCase {
@@ -135,5 +159,75 @@ class DeactivatorTest extends PluginLifecycleTestCase {
 		$this->expectExceptionMessage( 'halted' );
 
 		Disable_Blog_Deactivator::deactivate();
+	}
+
+	/**
+	 * deactivate()'s single-plugin branch guards terminate() with
+	 * `if ( ! check_admin_referer( ... ) )`. When the referer check fails (returns false),
+	 * the `!` makes the condition true and terminate() must run.
+	 */
+	public function test_deactivate_terminates_when_single_plugin_referer_check_fails() {
+		DeactivatorTerminateSpy::$terminate_called = false;
+
+		$this->set_static_request( array( 'plugin' => 'disable-blog' ) );
+
+		$_REQUEST = array(
+			'_wpnonce' => 'bad-nonce',
+			'action'   => 'deactivate',
+			'plugin'   => 'disable-blog',
+		);
+
+		WP_Mock::userFunction( 'wp_verify_nonce' )
+			->once()
+			->with( 'bad-nonce', 'deactivate-plugin_disable-blog' )
+			->andReturn( false );
+
+		WP_Mock::userFunction( 'check_admin_referer' )
+			->once()
+			->with( 'deactivate-plugin_disable-blog' )
+			->andReturn( false );
+
+		WP_Mock::userFunction( 'wp_cache_delete' )->once()->with( 'comments-0', 'counts' );
+		WP_Mock::userFunction( 'delete_transient' )->once()->with( 'wc_count_comments' );
+		WP_Mock::userFunction( 'flush_rewrite_rules' )->once();
+
+		DeactivatorTerminateSpy::deactivate();
+
+		$this->assertTrue( DeactivatorTerminateSpy::$terminate_called );
+	}
+
+	/**
+	 * Same branch as above with the referer check passing (returns true): `! true` is false,
+	 * so terminate() must NOT run. Paired with the failing-check test above, this pins down
+	 * both directions of the `!`, so inverting it fails one test or the other.
+	 */
+	public function test_deactivate_does_not_terminate_when_single_plugin_referer_check_passes() {
+		DeactivatorTerminateSpy::$terminate_called = false;
+
+		$this->set_static_request( array( 'plugin' => 'disable-blog' ) );
+
+		$_REQUEST = array(
+			'_wpnonce' => 'bad-nonce',
+			'action'   => 'deactivate',
+			'plugin'   => 'disable-blog',
+		);
+
+		WP_Mock::userFunction( 'wp_verify_nonce' )
+			->once()
+			->with( 'bad-nonce', 'deactivate-plugin_disable-blog' )
+			->andReturn( false );
+
+		WP_Mock::userFunction( 'check_admin_referer' )
+			->once()
+			->with( 'deactivate-plugin_disable-blog' )
+			->andReturn( true );
+
+		WP_Mock::userFunction( 'wp_cache_delete' )->once()->with( 'comments-0', 'counts' );
+		WP_Mock::userFunction( 'delete_transient' )->once()->with( 'wc_count_comments' );
+		WP_Mock::userFunction( 'flush_rewrite_rules' )->once();
+
+		DeactivatorTerminateSpy::deactivate();
+
+		$this->assertFalse( DeactivatorTerminateSpy::$terminate_called );
 	}
 }

--- a/tests/php/DeactivatorTest.php
+++ b/tests/php/DeactivatorTest.php
@@ -29,4 +29,111 @@ class DeactivatorTest extends PluginLifecycleTestCase {
 	protected function bulk_action_value(): string {
 		return 'deactivate-selected';
 	}
+
+	/**
+	 * Directly sets Disable_Blog_Deactivator::$request via Reflection, bypassing
+	 * get_request(), to simulate static state left over from an earlier, successful call.
+	 *
+	 * @param array $value The value to assign.
+	 * @return void
+	 */
+	private function set_static_request( array $value ) {
+		$class    = new ReflectionClass( Disable_Blog_Deactivator::class );
+		$property = $class->getProperty( 'request' );
+		$property->setAccessible( true );
+		$property->setValue( null, $value );
+	}
+
+	/**
+	 * deactivate()'s outer guard is `false === self::get_request() || ...`. get_request() only
+	 * ever returns `false` or an array, never boolean `true`, so `true === self::get_request()`
+	 * can never be satisfied by any input -- it would make the first OR clause permanently
+	 * dead, silently changing the guard from "get_request() failed" (true whenever it returns
+	 * false) to always-false, falling through to whatever validate_request()/check_caps()
+	 * decide instead.
+	 *
+	 * This primes static::$request with data that would satisfy validate_request() and stubs
+	 * check_caps() to succeed, then drives $_REQUEST down a path where get_request() itself
+	 * fails (bad nonce) without touching static::$request. Under the real guard, get_request()
+	 * failing alone is enough to enter the check_admin_referer() branch: the guard is an OR,
+	 * so stale primed state that would satisfy validate_request() and check_caps() must not
+	 * suppress the nonce check.
+	 */
+	public function test_deactivate_enters_referer_check_when_get_request_fails_even_if_stale_state_would_validate() {
+		$this->set_static_request(
+			array(
+				'plugin' => 'disable-blog',
+				'action' => 'deactivate',
+			)
+		);
+
+		$_REQUEST = array(
+			'_wpnonce' => 'bad-nonce',
+			'action'   => 'deactivate',
+			'plugin'   => 'disable-blog',
+		);
+
+		WP_Mock::userFunction( 'wp_verify_nonce' )
+			->once()
+			->with( 'bad-nonce', 'deactivate-plugin_disable-blog' )
+			->andReturn( false );
+
+		// Present so check_caps() resolves on the path where the guard wrongly defers to it.
+		WP_Mock::userFunction( 'current_user_can' )
+			->with( 'activate_plugins' )
+			->andReturn( true );
+
+		WP_Mock::userFunction( 'check_admin_referer' )
+			->once()
+			->with( 'deactivate-plugin_disable-blog' )
+			->andThrow( new Exception( 'halted' ) );
+
+		WP_Mock::userFunction( 'wp_cache_delete' )->never();
+		WP_Mock::userFunction( 'delete_transient' )->never();
+		WP_Mock::userFunction( 'flush_rewrite_rules' )->never();
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'halted' );
+
+		Disable_Blog_Deactivator::deactivate();
+	}
+
+	/**
+	 * validate_request()'s bulk branch calls
+	 * `in_array( $plugin, self::$request['plugins'], true )`. If the strict flag is relaxed to
+	 * false, a non-empty string like 'disable-blog' loosely equals boolean true, so a
+	 * $_REQUEST['checked'] entry of `true` would (wrongly) validate as if 'disable-blog' were
+	 * among the checked plugins.
+	 */
+	public function test_deactivate_runs_referer_check_when_bulk_selection_only_loosely_matches_plugin() {
+		$_REQUEST = array(
+			'_wpnonce' => 'nonce-value',
+			'action'   => 'deactivate-selected',
+			'checked'  => array( true ),
+		);
+
+		WP_Mock::userFunction( 'wp_verify_nonce' )
+			->once()
+			->with( 'nonce-value', 'bulk-plugins' )
+			->andReturn( 1 );
+
+		// Present so check_caps() resolves if the bulk selection wrongly validates.
+		WP_Mock::userFunction( 'current_user_can' )
+			->with( 'activate_plugins' )
+			->andReturn( true );
+
+		WP_Mock::userFunction( 'check_admin_referer' )
+			->once()
+			->with( 'bulk-plugins' )
+			->andThrow( new Exception( 'halted' ) );
+
+		WP_Mock::userFunction( 'wp_cache_delete' )->never();
+		WP_Mock::userFunction( 'delete_transient' )->never();
+		WP_Mock::userFunction( 'flush_rewrite_rules' )->never();
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'halted' );
+
+		Disable_Blog_Deactivator::deactivate();
+	}
 }

--- a/tests/php/DisableBlogFunctionsTest.php
+++ b/tests/php/DisableBlogFunctionsTest.php
@@ -77,6 +77,63 @@ class DisableBlogFunctionsTest extends TestCase {
 	}
 
 	/**
+	 * Stubs the dwpb_redirect_status_code filter, asserting the real invoked arguments are
+	 * strictly (===) the literal int default and the two url strings -- safe_offset() casts
+	 * scalars via (string), so a plain ->with( 301, $current_url, $redirect_url ) would still
+	 * route here if the source passed a loosely-equal value (e.g. the string '301') instead
+	 * of the literal int this filter documents.
+	 *
+	 * @param string $current_url  The url being redirected FROM.
+	 * @param string $redirect_url The url being redirected TO.
+	 * @param mixed  $reply        The value the filter should reply with.
+	 * @return void
+	 */
+	private function stub_redirect_status_code_filter( $current_url, $redirect_url, $reply ) {
+		WP_Mock::onFilter( 'dwpb_redirect_status_code' )
+			->with( 301, $current_url, $redirect_url )
+			->reply(
+				new WP_Mock\InvokedFilterValue(
+					function ( $default, $actual_current_url, $actual_redirect_url ) use ( $current_url, $redirect_url, $reply ) {
+						$this->assertSame( 301, $default );
+						$this->assertSame( $current_url, $actual_current_url );
+						$this->assertSame( $redirect_url, $actual_redirect_url );
+
+						return $reply;
+					}
+				)
+			);
+	}
+
+	/**
+	 * Stubs the dwpb_disable_feed filter, asserting the real invoked default and comment-feed
+	 * flag are strictly (===) what's expected -- safe_offset() casts scalars via (string), so
+	 * a plain ->with( true, $post, $is_comment_feed ) would still route here if the source
+	 * passed a loosely-equal value (e.g. int 1) instead of the literal booleans this filter
+	 * documents. $post itself is already matched by object identity (spl_object_hash()), so
+	 * this only needs to assert the two boolean positions.
+	 *
+	 * @param object $post            Global post object.
+	 * @param bool   $is_comment_feed The exact comment-feed flag the filter must receive.
+	 * @param bool   $reply           The value the filter should reply with.
+	 * @return void
+	 */
+	private function stub_disable_feed_filter( $post, $is_comment_feed, $reply ) {
+		WP_Mock::onFilter( 'dwpb_disable_feed' )
+			->with( true, $post, $is_comment_feed )
+			->reply(
+				new WP_Mock\InvokedFilterValue(
+					function ( $default, $actual_post, $actual_is_comment_feed ) use ( $post, $is_comment_feed, $reply ) {
+						$this->assertTrue( $default );
+						$this->assertSame( $post, $actual_post );
+						$this->assertSame( $is_comment_feed, $actual_is_comment_feed );
+
+						return $reply;
+					}
+				)
+			);
+	}
+
+	/**
 	 * redirect()
 	 */
 
@@ -95,7 +152,14 @@ class DisableBlogFunctionsTest extends TestCase {
 		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( true );
 		WP_Mock::userFunction( 'add_query_arg' )
 			->once()
-			->with( array(), 'wp-admin/edit.php' )
+			->with(
+				Mockery::on(
+					function ( $args ) {
+						return array() === $args;
+					}
+				),
+				'wp-admin/edit.php'
+			)
 			->andReturn( 'wp-admin/edit.php' );
 		WP_Mock::userFunction( 'admin_url' )
 			->once()
@@ -112,10 +176,8 @@ class DisableBlogFunctionsTest extends TestCase {
 		$redirect_url = 'https://example.test/wp-admin/options-general.php';
 
 		WP_Mock::userFunction( 'esc_url_raw' )->with( $redirect_url )->andReturn( $redirect_url );
-		WP_Mock::onFilter( 'dwpb_pass_query_string_on_redirect' )->with( false )->reply( false );
-		WP_Mock::onFilter( 'dwpb_redirect_status_code' )
-			->with( 301, 'https://example.test/wp-admin/edit.php', $redirect_url )
-			->reply( 301 );
+		$this->stub_filter_strict( 'dwpb_pass_query_string_on_redirect', false, false );
+		$this->stub_redirect_status_code_filter( 'https://example.test/wp-admin/edit.php', $redirect_url, 301 );
 		$this->stub_real_absint();
 
 		WP_Mock::userFunction( 'wp_safe_redirect' )
@@ -157,10 +219,8 @@ class DisableBlogFunctionsTest extends TestCase {
 		$redirect_url = 'https://example.test/other-page/';
 
 		WP_Mock::userFunction( 'esc_url_raw' )->with( $redirect_url )->andReturn( $redirect_url );
-		WP_Mock::onFilter( 'dwpb_pass_query_string_on_redirect' )->with( false )->reply( false );
-		WP_Mock::onFilter( 'dwpb_redirect_status_code' )
-			->with( 301, 'https://example.test/current-page/?foo=bar', $redirect_url )
-			->reply( 301 );
+		$this->stub_filter_strict( 'dwpb_pass_query_string_on_redirect', false, false );
+		$this->stub_redirect_status_code_filter( 'https://example.test/current-page/?foo=bar', $redirect_url, 301 );
 		$this->stub_real_absint();
 
 		WP_Mock::userFunction( 'wp_safe_redirect' )
@@ -188,7 +248,13 @@ class DisableBlogFunctionsTest extends TestCase {
 		WP_Mock::userFunction( 'wp_unslash' )->never();
 		WP_Mock::userFunction( 'home_url' )
 			->once()
-			->with( '' )
+			->with(
+				Mockery::on(
+					function ( $request_uri ) {
+						return '' === $request_uri;
+					}
+				)
+			)
 			->andReturn( 'https://example.test/' );
 
 		WP_Mock::expectFilterAdded(
@@ -303,8 +369,8 @@ class DisableBlogFunctionsTest extends TestCase {
 		WP_Mock::userFunction( 'esc_url_raw' )->with( $redirect_url )->andReturn( $redirect_url );
 		WP_Mock::userFunction( 'esc_url_raw' )->with( $redirect_url_with_qs )->andReturn( $redirect_url_with_qs );
 
-		WP_Mock::onFilter( 'dwpb_pass_query_string_on_redirect' )->with( false )->reply( true );
-		WP_Mock::onFilter( 'dwpb_allowed_query_vars' )->with( array() )->reply( array( 'foo' ) );
+		$this->stub_filter_strict( 'dwpb_pass_query_string_on_redirect', false, true );
+		$this->stub_filter_strict( 'dwpb_allowed_query_vars', array(), array( 'foo' ) );
 		WP_Mock::userFunction( 'sanitize_key' )->with( 'foo' )->andReturn( 'foo' );
 
 		WP_Mock::userFunction( 'add_query_arg' )
@@ -312,9 +378,7 @@ class DisableBlogFunctionsTest extends TestCase {
 			->with( array( 'foo' => 'bar' ), $redirect_url )
 			->andReturn( $redirect_url_with_qs );
 
-		WP_Mock::onFilter( 'dwpb_redirect_status_code' )
-			->with( 301, 'https://example.test/current-page/', $redirect_url_with_qs )
-			->reply( 301 );
+		$this->stub_redirect_status_code_filter( 'https://example.test/current-page/', $redirect_url_with_qs, 301 );
 		$this->stub_real_absint();
 
 		WP_Mock::userFunction( 'wp_safe_redirect' )
@@ -357,12 +421,10 @@ class DisableBlogFunctionsTest extends TestCase {
 		$redirect_url = 'https://example.test/target/';
 
 		WP_Mock::userFunction( 'esc_url_raw' )->with( $redirect_url )->andReturn( $redirect_url );
-		WP_Mock::onFilter( 'dwpb_pass_query_string_on_redirect' )->with( false )->reply( false );
+		$this->stub_filter_strict( 'dwpb_pass_query_string_on_redirect', false, false );
 		WP_Mock::userFunction( 'add_query_arg' )->never();
 
-		WP_Mock::onFilter( 'dwpb_redirect_status_code' )
-			->with( 301, 'https://example.test/current-page/', $redirect_url )
-			->reply( 301 );
+		$this->stub_redirect_status_code_filter( 'https://example.test/current-page/', $redirect_url, 301 );
 		$this->stub_real_absint();
 
 		WP_Mock::userFunction( 'wp_safe_redirect' )
@@ -403,11 +465,9 @@ class DisableBlogFunctionsTest extends TestCase {
 		$redirect_url = 'https://example.test/target/';
 
 		WP_Mock::userFunction( 'esc_url_raw' )->with( $redirect_url )->andReturn( $redirect_url );
-		WP_Mock::onFilter( 'dwpb_pass_query_string_on_redirect' )->with( false )->reply( false );
+		$this->stub_filter_strict( 'dwpb_pass_query_string_on_redirect', false, false );
 
-		WP_Mock::onFilter( 'dwpb_redirect_status_code' )
-			->with( 301, 'https://example.test/current-page/', $redirect_url )
-			->reply( 302 );
+		$this->stub_redirect_status_code_filter( 'https://example.test/current-page/', $redirect_url, 302 );
 
 		$this->stub_real_absint();
 
@@ -451,10 +511,8 @@ class DisableBlogFunctionsTest extends TestCase {
 		$escaped_redirect_url = 'https://example.test/target/?x=1&#038;y=2';
 
 		WP_Mock::userFunction( 'esc_url_raw' )->with( $raw_redirect_url )->andReturn( $escaped_redirect_url );
-		WP_Mock::onFilter( 'dwpb_pass_query_string_on_redirect' )->with( false )->reply( false );
-		WP_Mock::onFilter( 'dwpb_redirect_status_code' )
-			->with( 301, 'https://example.test/current-page/', $raw_redirect_url )
-			->reply( 301 );
+		$this->stub_filter_strict( 'dwpb_pass_query_string_on_redirect', false, false );
+		$this->stub_redirect_status_code_filter( 'https://example.test/current-page/', $raw_redirect_url, 301 );
 		$this->stub_real_absint();
 
 		WP_Mock::userFunction( 'wp_safe_redirect' )
@@ -506,10 +564,8 @@ class DisableBlogFunctionsTest extends TestCase {
 		$redirect_url = 'https://example.test/target/';
 
 		WP_Mock::userFunction( 'esc_url_raw' )->with( $redirect_url )->andReturn( $redirect_url );
-		WP_Mock::onFilter( 'dwpb_pass_query_string_on_redirect' )->with( false )->reply( false );
-		WP_Mock::onFilter( 'dwpb_redirect_status_code' )
-			->with( 301, 'https://example.test/current-page/', $redirect_url )
-			->reply( 301 );
+		$this->stub_filter_strict( 'dwpb_pass_query_string_on_redirect', false, false );
+		$this->stub_redirect_status_code_filter( 'https://example.test/current-page/', $redirect_url, 301 );
 		$this->stub_real_absint();
 
 		WP_Mock::userFunction( 'wp_safe_redirect' )
@@ -565,7 +621,7 @@ class DisableBlogFunctionsTest extends TestCase {
 
 		$functions = new Disable_Blog_Functions();
 
-		WP_Mock::onFilter( 'dwpb_allowed_query_vars' )->with( array() )->reply( array() );
+		$this->stub_filter_strict( 'dwpb_allowed_query_vars', array(), array() );
 		WP_Mock::userFunction( 'add_query_arg' )->never();
 
 		$this->assertSame(
@@ -583,7 +639,7 @@ class DisableBlogFunctionsTest extends TestCase {
 
 		$functions = new Disable_Blog_Functions();
 
-		WP_Mock::onFilter( 'dwpb_allowed_query_vars' )->with( array() )->reply( array( 'foo', 'empty' ) );
+		$this->stub_filter_strict( 'dwpb_allowed_query_vars', array(), array( 'foo', 'empty' ) );
 		WP_Mock::userFunction( 'sanitize_key' )->with( 'foo' )->andReturn( 'foo' );
 		WP_Mock::userFunction( 'sanitize_key' )->with( 'empty' )->andReturn( 'empty' );
 
@@ -606,7 +662,7 @@ class DisableBlogFunctionsTest extends TestCase {
 
 		$functions = new Disable_Blog_Functions();
 
-		WP_Mock::onFilter( 'dwpb_allowed_query_vars' )->with( array() )->reply( array( 'zzz' ) );
+		$this->stub_filter_strict( 'dwpb_allowed_query_vars', array(), array( 'zzz' ) );
 		WP_Mock::userFunction( 'sanitize_key' )->with( 'zzz' )->andReturn( 'zzz' );
 
 		WP_Mock::userFunction( 'add_query_arg' )->never();
@@ -623,7 +679,7 @@ class DisableBlogFunctionsTest extends TestCase {
 	public function test_get_allowed_query_vars_returns_empty_array_by_default() {
 		$functions = new Disable_Blog_Functions();
 
-		WP_Mock::onFilter( 'dwpb_allowed_query_vars' )->with( array() )->reply( array() );
+		$this->stub_filter_strict( 'dwpb_allowed_query_vars', array(), array() );
 		WP_Mock::userFunction( 'sanitize_key' )->never();
 
 		$this->assertSame( array(), $this->invoke_private( $functions, 'get_allowed_query_vars' ) );
@@ -636,7 +692,7 @@ class DisableBlogFunctionsTest extends TestCase {
 	public function test_get_allowed_query_vars_sanitizes_keys_and_drops_empty_values() {
 		$functions = new Disable_Blog_Functions();
 
-		WP_Mock::onFilter( 'dwpb_allowed_query_vars' )->with( array() )->reply( array( 'Foo', '', 'Bar_Baz' ) );
+		$this->stub_filter_strict( 'dwpb_allowed_query_vars', array(), array( 'Foo', '', 'Bar_Baz' ) );
 		WP_Mock::userFunction( 'sanitize_key' )->with( 'Foo' )->andReturn( 'foo' );
 		WP_Mock::userFunction( 'sanitize_key' )->with( '' )->andReturn( '' );
 		WP_Mock::userFunction( 'sanitize_key' )->with( 'Bar_Baz' )->andReturn( 'bar_baz' );
@@ -663,9 +719,7 @@ class DisableBlogFunctionsTest extends TestCase {
 		$current_url  = 'https://example.test/current/';
 		$redirect_url = 'https://example.test/redirect/';
 
-		WP_Mock::onFilter( 'dwpb_redirect_status_code' )
-			->with( 301, $current_url, $redirect_url )
-			->reply( $filtered_value );
+		$this->stub_redirect_status_code_filter( $current_url, $redirect_url, $filtered_value );
 
 		$this->stub_real_absint();
 
@@ -743,7 +797,7 @@ class DisableBlogFunctionsTest extends TestCase {
 	public function test_author_archive_post_types_returns_filtered_post_types_when_non_empty() {
 		$functions = new Disable_Blog_Functions();
 
-		WP_Mock::onFilter( 'dwpb_author_archive_post_types' )->with( array() )->reply( array( 'book' ) );
+		$this->stub_filter_strict( 'dwpb_author_archive_post_types', array(), array( 'book' ) );
 
 		$this->assertSame( array( 'book' ), $functions->author_archive_post_types() );
 	}
@@ -751,7 +805,7 @@ class DisableBlogFunctionsTest extends TestCase {
 	public function test_author_archive_post_types_returns_false_when_empty_by_default() {
 		$functions = new Disable_Blog_Functions();
 
-		WP_Mock::onFilter( 'dwpb_author_archive_post_types' )->with( array() )->reply( array() );
+		$this->stub_filter_strict( 'dwpb_author_archive_post_types', array(), array() );
 
 		$this->assertFalse( $functions->author_archive_post_types() );
 	}
@@ -763,7 +817,7 @@ class DisableBlogFunctionsTest extends TestCase {
 	public function test_disable_author_archives_defaults_to_false() {
 		$functions = new Disable_Blog_Functions();
 
-		WP_Mock::onFilter( 'dwpb_disable_author_archives' )->with( false )->reply( false );
+		$this->stub_filter_strict( 'dwpb_disable_author_archives', false, false );
 
 		$this->assertFalse( $functions->disable_author_archives() );
 	}
@@ -771,7 +825,7 @@ class DisableBlogFunctionsTest extends TestCase {
 	public function test_disable_author_archives_true_when_filtered() {
 		$functions = new Disable_Blog_Functions();
 
-		WP_Mock::onFilter( 'dwpb_disable_author_archives' )->with( false )->reply( true );
+		$this->stub_filter_strict( 'dwpb_disable_author_archives', false, true );
 
 		$this->assertTrue( $functions->disable_author_archives() );
 	}
@@ -787,7 +841,7 @@ class DisableBlogFunctionsTest extends TestCase {
 		$functions = new Disable_Blog_Functions();
 		$post      = (object) array( 'ID' => 1 );
 
-		WP_Mock::onFilter( 'dwpb_disable_feed' )->with( true, $post, false )->reply( false );
+		$this->stub_disable_feed_filter( $post, false, false );
 
 		$this->assertFalse( $functions->disable_feeds( $post ) );
 	}
@@ -796,7 +850,7 @@ class DisableBlogFunctionsTest extends TestCase {
 		$functions = new Disable_Blog_Functions();
 		$post      = (object) array( 'ID' => 1 );
 
-		WP_Mock::onFilter( 'dwpb_disable_feed' )->with( true, $post, true )->reply( true );
+		$this->stub_disable_feed_filter( $post, true, true );
 
 		$this->assertTrue( $functions->disable_feeds( $post, true ) );
 	}
@@ -805,7 +859,7 @@ class DisableBlogFunctionsTest extends TestCase {
 		$functions = new Disable_Blog_Functions();
 		$post      = (object) array( 'ID' => 1 );
 
-		WP_Mock::onFilter( 'dwpb_disable_feed' )->with( true, $post, false )->reply( false );
+		$this->stub_disable_feed_filter( $post, false, false );
 
 		$this->assertFalse( $functions->disable_feeds( $post, false ) );
 	}

--- a/tests/php/DisableBlogFunctionsTest.php
+++ b/tests/php/DisableBlogFunctionsTest.php
@@ -175,6 +175,38 @@ class DisableBlogFunctionsTest extends TestCase {
 	}
 
 	/**
+	 * When REQUEST_URI is absent from $_SERVER, the isset() ternary must fall back to an
+	 * empty string (not skip the fallback, and not some other placeholder), so home_url()
+	 * receives '' and wp_unslash()/esc_url_raw() are never reached for it.
+	 */
+	public function test_redirect_falls_back_to_empty_string_when_request_uri_is_absent() {
+		unset( $_SERVER['REQUEST_URI'] );
+
+		$functions = new Disable_Blog_Functions();
+
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'wp_unslash' )->never();
+		WP_Mock::userFunction( 'home_url' )
+			->once()
+			->with( '' )
+			->andReturn( 'https://example.test/' );
+
+		WP_Mock::expectFilterAdded(
+			'wp_safe_redirect_fallback',
+			array( $functions, 'wp_safe_redirect_fallback' ),
+			9,
+			1
+		);
+
+		WP_Mock::userFunction( 'wp_safe_redirect' )->never();
+
+		// The redirect url matches the derived current url, so the loop guard returns
+		// before esc_url_raw() is ever called on it -- home_url()'s '' argument alone is
+		// what's under test here.
+		$this->assertNull( $functions->redirect( 'https://example.test/' ) );
+	}
+
+	/**
 	 * The loop guard: when the redirect url matches the current url, redirect() must
 	 * return without calling wp_safe_redirect() at all. The fallback filter is added
 	 * unconditionally before this guard runs (it's the first statement in the non-admin
@@ -391,6 +423,52 @@ class DisableBlogFunctionsTest extends TestCase {
 	}
 
 	/**
+	 * wp_safe_redirect() must receive the esc_url_raw()-escaped form of the redirect url,
+	 * not the raw value -- even though the raw value already passed the earlier loop-guard
+	 * truthiness check and is what's passed into get_redirect_status_code().
+	 */
+	public function test_redirect_passes_escaped_url_to_wp_safe_redirect() {
+		$_SERVER['REQUEST_URI'] = '/current-page/';
+
+		$functions = new Disable_Blog_Functions();
+
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'wp_unslash' )->with( '/current-page/' )->andReturn( '/current-page/' );
+		WP_Mock::userFunction( 'esc_url_raw' )->with( '/current-page/' )->andReturn( '/current-page/' );
+		WP_Mock::userFunction( 'home_url' )
+			->once()
+			->with( '/current-page/' )
+			->andReturn( 'https://example.test/current-page/' );
+
+		WP_Mock::expectFilterAdded(
+			'wp_safe_redirect_fallback',
+			array( $functions, 'wp_safe_redirect_fallback' ),
+			9,
+			1
+		);
+
+		$raw_redirect_url     = 'https://example.test/target/?x=1&y=2';
+		$escaped_redirect_url = 'https://example.test/target/?x=1&#038;y=2';
+
+		WP_Mock::userFunction( 'esc_url_raw' )->with( $raw_redirect_url )->andReturn( $escaped_redirect_url );
+		WP_Mock::onFilter( 'dwpb_pass_query_string_on_redirect' )->with( false )->reply( false );
+		WP_Mock::onFilter( 'dwpb_redirect_status_code' )
+			->with( 301, 'https://example.test/current-page/', $raw_redirect_url )
+			->reply( 301 );
+		$this->stub_real_absint();
+
+		WP_Mock::userFunction( 'wp_safe_redirect' )
+			->once()
+			->with( $escaped_redirect_url, 301 )
+			->andThrow( new Exception( 'halted' ) );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'halted' );
+
+		$functions->redirect( $raw_redirect_url );
+	}
+
+	/**
 	 * parse_query_string() (private)
 	 */
 
@@ -563,6 +641,16 @@ class DisableBlogFunctionsTest extends TestCase {
 	}
 
 	/**
+	 * A valid in-range value must come back through absint() as an int, not pass through
+	 * as whatever type the filter returned -- a numeric string here would satisfy the
+	 * range checks unmodified, so only the absint() cast on the return value tells them
+	 * apart. assertSame() (strict) makes the type mismatch fail.
+	 */
+	public function test_get_redirect_status_code_returns_absint_not_raw_filtered_value() {
+		$this->assert_redirect_status_code( '350', 350 );
+	}
+
+	/**
 	 * wp_safe_redirect_fallback()
 	 */
 
@@ -633,6 +721,18 @@ class DisableBlogFunctionsTest extends TestCase {
 	/**
 	 * disable_feeds()
 	 */
+
+	/**
+	 * $is_comment_feed defaults to false when the argument is omitted.
+	 */
+	public function test_disable_feeds_defaults_is_comment_feed_to_false_when_omitted() {
+		$functions = new Disable_Blog_Functions();
+		$post      = (object) array( 'ID' => 1 );
+
+		WP_Mock::onFilter( 'dwpb_disable_feed' )->with( true, $post, false )->reply( false );
+
+		$this->assertFalse( $functions->disable_feeds( $post ) );
+	}
 
 	public function test_disable_feeds_defaults_to_true_and_passes_post_and_comment_feed_flag_to_filter() {
 		$functions = new Disable_Blog_Functions();

--- a/tests/php/DisableBlogFunctionsTest.php
+++ b/tests/php/DisableBlogFunctionsTest.php
@@ -469,6 +469,64 @@ class DisableBlogFunctionsTest extends TestCase {
 	}
 
 	/**
+	 * terminate() is protected specifically so a test subclass can override it and observe
+	 * whether -- and when relative to wp_safe_redirect() -- it runs, without the process
+	 * actually exiting. Recording both calls into a shared, ordered log proves it's called
+	 * exactly once and only after wp_safe_redirect(), not before or in place of it.
+	 */
+	public function test_redirect_calls_terminate_exactly_once_after_wp_safe_redirect() {
+		$_SERVER['REQUEST_URI'] = '/current-page/';
+
+		$functions = new class() extends Disable_Blog_Functions {
+			/**
+			 * @var string[]
+			 */
+			public $call_log = array();
+
+			protected function terminate() {
+				$this->call_log[] = 'terminate';
+			}
+		};
+
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+		WP_Mock::userFunction( 'wp_unslash' )->with( '/current-page/' )->andReturn( '/current-page/' );
+		WP_Mock::userFunction( 'esc_url_raw' )->with( '/current-page/' )->andReturn( '/current-page/' );
+		WP_Mock::userFunction( 'home_url' )
+			->once()
+			->with( '/current-page/' )
+			->andReturn( 'https://example.test/current-page/' );
+
+		WP_Mock::expectFilterAdded(
+			'wp_safe_redirect_fallback',
+			array( $functions, 'wp_safe_redirect_fallback' ),
+			9,
+			1
+		);
+
+		$redirect_url = 'https://example.test/target/';
+
+		WP_Mock::userFunction( 'esc_url_raw' )->with( $redirect_url )->andReturn( $redirect_url );
+		WP_Mock::onFilter( 'dwpb_pass_query_string_on_redirect' )->with( false )->reply( false );
+		WP_Mock::onFilter( 'dwpb_redirect_status_code' )
+			->with( 301, 'https://example.test/current-page/', $redirect_url )
+			->reply( 301 );
+		$this->stub_real_absint();
+
+		WP_Mock::userFunction( 'wp_safe_redirect' )
+			->once()
+			->with( $redirect_url, 301 )
+			->andReturnUsing(
+				function () use ( $functions ) {
+					$functions->call_log[] = 'wp_safe_redirect';
+				}
+			);
+
+		$this->assertNull( $functions->redirect( $redirect_url ) );
+
+		$this->assertSame( array( 'wp_safe_redirect', 'terminate' ), $functions->call_log );
+	}
+
+	/**
 	 * parse_query_string() (private)
 	 */
 

--- a/tests/php/DisableBlogTest.php
+++ b/tests/php/DisableBlogTest.php
@@ -15,6 +15,43 @@ require_once __DIR__ . '/../../includes/class-disable-blog-public.php';
 require_once __DIR__ . '/../../includes/class-disable-blog.php';
 
 /**
+ * Records the order boot()'s six setup calls run in, without performing any of their real
+ * work. upgrade_check() is protected static, so the recorder has to be a static property:
+ * a static method has no $this to push onto an instance array.
+ */
+class Disable_Blog_Boot_Recorder extends Disable_Blog {
+
+	/**
+	 * @var string[]
+	 */
+	public static $calls = array();
+
+	protected static function upgrade_check() {
+		self::$calls[] = 'upgrade_check';
+	}
+
+	protected function load_dependencies() {
+		self::$calls[] = 'load_dependencies';
+	}
+
+	protected function set_locale() {
+		self::$calls[] = 'set_locale';
+	}
+
+	public function plugin_integrations() {
+		self::$calls[] = 'plugin_integrations';
+	}
+
+	protected function define_admin_hooks() {
+		self::$calls[] = 'define_admin_hooks';
+	}
+
+	protected function define_public_hooks() {
+		self::$calls[] = 'define_public_hooks';
+	}
+}
+
+/**
  * @covers Disable_Blog
  */
 class DisableBlogTest extends TestCase {
@@ -135,6 +172,104 @@ class DisableBlogTest extends TestCase {
 				);
 			},
 			$hooks
+		);
+	}
+
+	/**
+	 * __construct() / boot()
+	 */
+
+	/**
+	 * Uses two clearly distinct values so a swap between the two assignments in
+	 * __construct() shows up as one getter returning the other's value.
+	 */
+	public function test_construct_assigns_plugin_name_and_version_to_the_correct_properties() {
+		$disable_blog = new Disable_Blog( 'disable-blog', '0.5.6', false );
+
+		$this->assertSame( 'disable-blog', $disable_blog->get_plugin_name() );
+		$this->assertSame( '0.5.6', $disable_blog->get_version() );
+	}
+
+	/**
+	 * boot() fires 'dwpb_init' before running any of its six setup calls -- third parties
+	 * hooking dwpb_init depend on it running ahead of load_dependencies() and the rest.
+	 * Asserting the full sequence (not just that all seven happened) is what catches a
+	 * reordering, not only a deletion.
+	 */
+	public function test_boot_runs_dwpb_init_then_the_six_setup_methods_in_order() {
+		Disable_Blog_Boot_Recorder::$calls = array();
+
+		// do_action() is defined by WP_Mock itself (not stubbable via userFunction()) and
+		// dispatches through the event manager; with( null ) matches the no-extra-args call
+		// boot() makes.
+		WP_Mock::onAction( 'dwpb_init' )->with( null )->perform(
+			static function () {
+				Disable_Blog_Boot_Recorder::$calls[] = 'dwpb_init';
+			}
+		);
+
+		$disable_blog = new Disable_Blog_Boot_Recorder( 'disable-blog', '0.5.6', false );
+		$disable_blog->boot();
+
+		$this->assertSame(
+			array(
+				'dwpb_init',
+				'upgrade_check',
+				'load_dependencies',
+				'set_locale',
+				'plugin_integrations',
+				'define_admin_hooks',
+				'define_public_hooks',
+			),
+			Disable_Blog_Boot_Recorder::$calls
+		);
+	}
+
+	/**
+	 * load_dependencies()
+	 */
+
+	/**
+	 * Runs load_dependencies() for real, with a spy loader injected first so the method's
+	 * null-check leaves it in place instead of constructing a Disable_Blog_Loader. Wrong
+	 * directory or file names make the require_once calls fatal (they resolve to real,
+	 * already-loaded files under correct paths, so nothing observable would otherwise
+	 * distinguish a corrupted path from a correct one). The spy also records the exact
+	 * classes handed to the loader's autoloader, in order.
+	 */
+	public function test_load_dependencies_resolves_real_files_and_registers_expected_classes_in_order() {
+		$repo_root        = dirname( __DIR__, 2 );
+		$expected_dir_arg = $repo_root . '/includes';
+
+		WP_Mock::userFunction( 'plugin_dir_path' )
+			->once()
+			->with( $expected_dir_arg )
+			->andReturn( $repo_root . '/' );
+
+		$spy_loader = new class() extends Disable_Blog_Loader {
+			/**
+			 * @var string[]
+			 */
+			public $autoloaded = array();
+
+			public function autoloader( $requested_class ) {
+				$this->autoloaded[] = $requested_class;
+			}
+		};
+
+		$disable_blog = $this->make_disable_blog( 'disable-blog', '0.5.6', $spy_loader );
+
+		$this->invoke_private( $disable_blog, 'load_dependencies' );
+
+		$this->assertSame(
+			array(
+				'Disable_Blog_I18n',
+				'Disable_Blog_Functions',
+				'Disable_Blog_Admin',
+				'Disable_Blog_Public',
+				'Disable_Blog_Integrations',
+			),
+			$spy_loader->autoloaded
 		);
 	}
 

--- a/tests/php/DisableBlogTest.php
+++ b/tests/php/DisableBlogTest.php
@@ -526,11 +526,19 @@ class DisableBlogTest extends TestCase {
 	}
 
 	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
+	 * PHP cannot un-define a constant, so DWPB_VERSION is defined at most once per process via
+	 * this guarded helper, shared by every upgrade_check() test below that needs it.
+	 *
+	 * @return void
 	 */
+	private function ensure_dwpb_version_defined() {
+		if ( ! defined( 'DWPB_VERSION' ) ) {
+			define( 'DWPB_VERSION', '0.5.6' );
+		}
+	}
+
 	public function test_upgrade_check_sets_version_option_on_fresh_install() {
-		define( 'DWPB_VERSION', '0.5.6' );
+		$this->ensure_dwpb_version_defined();
 
 		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( true );
 		WP_Mock::userFunction( 'get_option' )->once()->with( 'dwpb_version', false )->andReturn( false );
@@ -539,12 +547,8 @@ class DisableBlogTest extends TestCase {
 		$this->assertNull( $this->invoke_private_static( 'upgrade_check' ) );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
 	public function test_upgrade_check_does_nothing_when_version_matches() {
-		define( 'DWPB_VERSION', '0.5.6' );
+		$this->ensure_dwpb_version_defined();
 
 		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( true );
 		WP_Mock::userFunction( 'get_option' )->once()->with( 'dwpb_version', false )->andReturn( '0.5.6' );
@@ -553,12 +557,8 @@ class DisableBlogTest extends TestCase {
 		$this->assertNull( $this->invoke_private_static( 'upgrade_check' ) );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
 	public function test_upgrade_check_records_previous_version_and_updates_when_upgrading() {
-		define( 'DWPB_VERSION', '0.5.6' );
+		$this->ensure_dwpb_version_defined();
 
 		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( true );
 		WP_Mock::userFunction( 'get_option' )->once()->with( 'dwpb_version', false )->andReturn( '0.5.4' );

--- a/tests/php/DisableBlogTest.php
+++ b/tests/php/DisableBlogTest.php
@@ -176,6 +176,35 @@ class DisableBlogTest extends TestCase {
 	}
 
 	/**
+	 * Registers the dwpb_post_types_supporting_comments filter (2 arguments:
+	 * $post_types_with_feature, $args) so both positions are asserted strictly.
+	 * safe_offset() flattens both for ->with() routing -- false, '', array(), and null all
+	 * collide there -- so a plain ->with() match cannot tell a corrupted false/array()/''
+	 * apart from the documented value. The InvokedFilterValue responder receives the real
+	 * invoked arguments via func_get_args() regardless of which key matched, so both are
+	 * asserted with assertSame().
+	 *
+	 * @param mixed $post_types_with_feature The exact position-1 value the filter must receive.
+	 * @param mixed $args                    The exact position-2 value the filter must receive.
+	 * @param mixed $reply                   The value the filter should return.
+	 * @return void
+	 */
+	private function stub_post_types_supporting_comments_filter( $post_types_with_feature, $args, $reply ) {
+		WP_Mock::onFilter( 'dwpb_post_types_supporting_comments' )
+			->with( $post_types_with_feature, $args )
+			->reply(
+				new WP_Mock\InvokedFilterValue(
+					function ( $received_post_types_with_feature, $received_args ) use ( $post_types_with_feature, $args, $reply ) {
+						$this->assertSame( $post_types_with_feature, $received_post_types_with_feature, 'dwpb_post_types_supporting_comments must receive the exact post types value it documents.' );
+						$this->assertSame( $args, $received_args, 'dwpb_post_types_supporting_comments must receive the exact $args value it documents.' );
+
+						return $reply;
+					}
+				)
+			);
+	}
+
+	/**
 	 * __construct() / boot()
 	 */
 
@@ -291,9 +320,7 @@ class DisableBlogTest extends TestCase {
 			->once()
 			->with( 'post-types-supporting-comments', 'post-types-by-feature' )
 			->andReturn( array( 'page' ) );
-		WP_Mock::onFilter( 'dwpb_post_types_supporting_comments' )
-			->with( array( 'page' ), array() )
-			->reply( array( 'page' ) );
+		$this->stub_post_types_supporting_comments_filter( array( 'page' ), array(), array( 'page' ) );
 
 		WP_Mock::expectFilterAdded( 'enable_update_services_configuration', '__return_false' );
 		WP_Mock::expectFilterAdded( 'enable_post_by_email_configuration', '__return_false' );
@@ -386,10 +413,20 @@ class DisableBlogTest extends TestCase {
 	public function test_define_admin_hooks_skips_comment_related_hooks_when_no_post_type_supports_comments() {
 		WP_Mock::userFunction( 'esc_attr' )->with( 'comments' )->andReturn( 'comments' );
 		WP_Mock::userFunction( 'wp_cache_get' )->once()->andReturn( false );
-		WP_Mock::userFunction( 'get_post_types' )->once()->with( array(), 'names' )->andReturn( array( 'post' ) );
+		WP_Mock::userFunction( 'get_post_types' )
+			->once()
+			->with(
+				Mockery::on(
+					static function ( $value ) {
+						return array() === $value;
+					}
+				),
+				'names'
+			)
+			->andReturn( array( 'post' ) );
 		WP_Mock::userFunction( 'post_type_supports' )->with( 'post', 'comments' )->andReturn( true );
 		WP_Mock::userFunction( 'wp_cache_set' )->once();
-		WP_Mock::onFilter( 'dwpb_post_types_supporting_comments' )->with( false, array() )->reply( false );
+		$this->stub_post_types_supporting_comments_filter( false, array(), false );
 
 		WP_Mock::expectFilterAdded( 'enable_update_services_configuration', '__return_false' );
 		WP_Mock::expectFilterAdded( 'enable_post_by_email_configuration', '__return_false' );
@@ -443,9 +480,7 @@ class DisableBlogTest extends TestCase {
 			->once()
 			->with( 'post-types-supporting-comments', 'post-types-by-feature' )
 			->andReturn( array( 'page' ) );
-		WP_Mock::onFilter( 'dwpb_post_types_supporting_comments' )
-			->with( array( 'page' ), array() )
-			->reply( array( 'page' ) );
+		$this->stub_post_types_supporting_comments_filter( array( 'page' ), array(), array( 'page' ) );
 
 		$disable_blog = $this->make_disable_blog();
 

--- a/tests/php/HelperFunctionsTest.php
+++ b/tests/php/HelperFunctionsTest.php
@@ -529,4 +529,153 @@ class HelperFunctionsTest extends TestCase {
 
 		$this->assertCount( 2, array_unique( $seen_keys ) );
 	}
+
+	/**
+	 * The no-match case must return strictly `false`, not the empty array that gets
+	 * cached, on both a cache miss (the negative result is freshly computed) and the
+	 * following cache hit (that same empty array is read back from the cache) -- the
+	 * false-normalisation has to run on both paths for the documented array|bool
+	 * contract to hold. assertSame() is required here: `array() == false`, so
+	 * assertEquals() would not catch a regression that skips the normalisation.
+	 *
+	 * This also asserts what the filter actually RECEIVES as its first argument.
+	 * onFilter()->with() alone cannot tell false from array() apart -- safe_offset()
+	 * casts both to the same '' key -- so a WP_Mock\InvokedFilterValue responder is used
+	 * instead: it still gets invoked with the real arguments regardless of which key
+	 * matched, so the captured value reveals whatever the source actually passed in.
+	 *
+	 * @return void
+	 */
+	public function test_post_types_with_feature_no_matches_returns_false_not_array_on_cold_and_warm_cache() {
+		$feature             = 'comments';
+		$args                = array();
+		$seen_filter_values  = array();
+
+		WP_Mock::userFunction( 'esc_attr' )->with( $feature )->andReturn( $feature );
+
+		// False (a real cache miss) on the first call, then the empty array the first
+		// call's wp_cache_set() stored (a real cache hit) on the second.
+		WP_Mock::userFunction( 'wp_cache_get' )
+			->twice()
+			->with( 'post-types-supporting-comments', 'post-types-by-feature' )
+			->andReturn( false, array() );
+
+		WP_Mock::userFunction( 'get_post_types' )
+			->once()
+			->with( $args, 'names' )
+			->andReturn( array( 'post' ) );
+
+		WP_Mock::userFunction( 'post_type_supports' )->with( 'post', $feature )->andReturn( true );
+
+		WP_Mock::userFunction( 'wp_cache_set' )
+			->once()
+			->with( 'post-types-supporting-comments', array(), 'post-types-by-feature' );
+
+		WP_Mock::onFilter( "dwpb_post_types_supporting_{$feature}" )
+			->with( false, $args )
+			->reply(
+				new WP_Mock\InvokedFilterValue(
+					function ( $value ) use ( &$seen_filter_values ) {
+						$seen_filter_values[] = $value;
+
+						return $value;
+					}
+				)
+			);
+
+		$cold_result = dwpb_post_types_with_feature( $feature, $args );
+		$warm_result = dwpb_post_types_with_feature( $feature, $args );
+
+		$this->assertFalse( $cold_result );
+		$this->assertFalse( $warm_result );
+		$this->assertSame( array( false, false ), $seen_filter_values );
+	}
+
+	/**
+	 * Mirrors test_post_types_with_feature_no_matches_returns_false_not_array_on_cold_and_warm_cache():
+	 * the no-match case must return strictly `false`, not the empty array that gets
+	 * cached, on both a cache miss and the cache hit that reads that empty array back.
+	 *
+	 * @return void
+	 */
+	public function test_post_types_with_tax_no_matches_returns_false_not_array_on_cold_and_warm_cache() {
+		$taxonomy  = 'category';
+		$cache_key = $this->tax_cache_key( $taxonomy );
+
+		$this->stub_tax_cache_key_helpers( $taxonomy );
+
+		// False (a real cache miss) on the first call, then the empty array the first
+		// call's wp_cache_set() stored (a real cache hit) on the second.
+		WP_Mock::userFunction( 'wp_cache_get' )
+			->twice()
+			->with( $cache_key, 'post-types-by-tax' )
+			->andReturn( false, array() );
+
+		// Computed unconditionally on every call regardless of cache state (see the
+		// comment above get_post_types() in the source).
+		WP_Mock::userFunction( 'get_post_types' )
+			->twice()
+			->with( array(), 'names' )
+			->andReturn( array( 'page' ) );
+
+		WP_Mock::userFunction( 'get_object_taxonomies' )
+			->once()
+			->with( 'page', 'names' )
+			->andReturn( array( 'post_tag' ) );
+
+		WP_Mock::userFunction( 'wp_cache_set' )
+			->once()
+			->with( $cache_key, array(), 'post-types-by-tax' );
+
+		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
+			->with( null, $taxonomy, array( 'page' ), array(), 'names' )
+			->reply( null );
+
+		$cold_result = dwpb_post_types_with_tax( $taxonomy );
+		$warm_result = dwpb_post_types_with_tax( $taxonomy );
+
+		$this->assertFalse( $cold_result );
+		$this->assertFalse( $warm_result );
+	}
+
+	/**
+	 * `in_array( $taxonomy, $taxonomies, true )` must compare strictly: a post type whose
+	 * taxonomies list contains a value that is only loosely equal to the requested
+	 * taxonomy -- here `true`, which loosely equals any non-empty string including
+	 * 'category', but is never identical to it -- must not be treated as carrying that
+	 * taxonomy.
+	 *
+	 * @return void
+	 */
+	public function test_post_types_with_tax_strict_comparison_excludes_loosely_equal_value() {
+		$taxonomy = 'category';
+
+		$this->stub_tax_cache_key_helpers( $taxonomy );
+
+		WP_Mock::userFunction( 'wp_cache_get' )->once()->andReturn( false );
+
+		// The array's exact contents depend on whether the comparison below is strict,
+		// which is the very thing under test -- only the type is pinned down here.
+		WP_Mock::userFunction( 'wp_cache_set' )
+			->once()
+			->with( $this->tax_cache_key( $taxonomy ), Mockery::type( 'array' ), 'post-types-by-tax' );
+
+		WP_Mock::userFunction( 'get_post_types' )
+			->once()
+			->with( array(), 'names' )
+			->andReturn( array( 'page' ) );
+
+		WP_Mock::userFunction( 'get_object_taxonomies' )
+			->once()
+			->with( 'page', 'names' )
+			->andReturn( array( true ) );
+
+		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
+			->with( null, $taxonomy, array( 'page' ), array(), 'names' )
+			->reply( null );
+
+		$result = dwpb_post_types_with_tax( $taxonomy );
+
+		$this->assertFalse( $result );
+	}
 }

--- a/tests/php/HelperFunctionsTest.php
+++ b/tests/php/HelperFunctionsTest.php
@@ -26,6 +26,23 @@ class HelperFunctionsTest extends TestCase {
 	}
 
 	/**
+	 * A Mockery argument matcher for an empty array, specifically -- Mockery's default
+	 * `with()` comparison is loose `==`, under which `array() == false` is true, so a bare
+	 * `array()` matcher would silently accept `false` too. Used wherever a call is expected
+	 * to receive the literal `$args = array()` default, to catch that default being
+	 * corrupted to `false` (or any other falsy non-array value).
+	 *
+	 * @return Mockery\Matcher\Closure
+	 */
+	private function strict_empty_array() {
+		return Mockery::on(
+			static function ( $value ) {
+				return array() === $value;
+			}
+		);
+	}
+
+	/**
 	 * Computes the same cache key dwpb_post_types_with_tax() builds, given
 	 * stub_tax_cache_key_helpers() has stubbed esc_attr()/maybe_serialize() as passthroughs.
 	 *
@@ -36,6 +53,66 @@ class HelperFunctionsTest extends TestCase {
 	 */
 	private function tax_cache_key( $taxonomy, $args = array(), $output = 'names' ) {
 		return 'post-types-with-tax-' . md5( $taxonomy ) . '-' . md5( $output ) . '-' . md5( serialize( $args ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+	}
+
+	/**
+	 * Registers the dwpb_post_types_supporting_{$feature} filter (2 arguments:
+	 * $post_types_with_feature, $args) so both positions are asserted strictly.
+	 * safe_offset() flattens both for ->with() routing -- false, '', array(), and null all
+	 * collide there -- so a plain ->with() match cannot tell a corrupted false/array()/''
+	 * apart from the documented value. The InvokedFilterValue responder receives the real
+	 * invoked arguments via func_get_args() regardless of which key matched, so both are
+	 * asserted with assertSame().
+	 *
+	 * @param string $filter                   The filter hook name.
+	 * @param mixed  $post_types_with_feature   The exact position-1 value the filter must receive.
+	 * @param mixed  $args                      The exact position-2 value the filter must receive.
+	 * @param mixed  $reply                     The value the filter should return.
+	 * @return void
+	 */
+	private function stub_post_types_supporting_filter( $filter, $post_types_with_feature, $args, $reply ) {
+		WP_Mock::onFilter( $filter )
+			->with( $post_types_with_feature, $args )
+			->reply(
+				new WP_Mock\InvokedFilterValue(
+					function ( $received_post_types_with_feature, $received_args ) use ( $filter, $post_types_with_feature, $args, $reply ) {
+						$this->assertSame( $post_types_with_feature, $received_post_types_with_feature, "{$filter} must receive the exact post types value it documents." );
+						$this->assertSame( $args, $received_args, "{$filter} must receive the exact \$args value it documents." );
+
+						return $reply;
+					}
+				)
+			);
+	}
+
+	/**
+	 * Registers the dwpb_taxonomy_support filter (5 arguments: null, $taxonomy,
+	 * $post_types, $args, $output) so position-4 ($args) is asserted strictly.
+	 * safe_offset() flattens $args for ->with() routing -- the array() default collides
+	 * with false and '' there -- so a plain ->with() match cannot tell a corrupted $args
+	 * apart from the documented array(). The InvokedFilterValue responder receives the
+	 * real invoked $args via func_get_args() regardless of which key matched, so it is
+	 * asserted with assertSame().
+	 *
+	 * @param string|object $taxonomy   The $taxonomy argument.
+	 * @param array         $post_types The $post_types argument.
+	 * @param array         $args       The exact $args value the filter must receive.
+	 * @param string        $output     The $output argument.
+	 * @param mixed         $reply      The value the filter should return.
+	 * @return void
+	 */
+	private function stub_taxonomy_support_filter( $taxonomy, $post_types, $args, $output, $reply ) {
+		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
+			->with( null, $taxonomy, $post_types, $args, $output )
+			->reply(
+				new WP_Mock\InvokedFilterValue(
+					function ( $received_null, $received_taxonomy, $received_post_types, $received_args, $received_output ) use ( $args, $reply ) {
+						$this->assertSame( $args, $received_args, 'dwpb_taxonomy_support must receive the exact $args value it documents.' );
+
+						return $reply;
+					}
+				)
+			);
 	}
 
 	/**
@@ -94,9 +171,22 @@ class HelperFunctionsTest extends TestCase {
 			->once()
 			->with( 'post-types-supporting-comments', array( 'page' ), 'post-types-by-feature' );
 
+		// safe_offset( array( 'page' ) ) === safe_offset( 'page' ), so a plain ->with()
+		// match would also route (and silently pass) if the source ever collapsed the
+		// one-element array to the bare string. The InvokedFilterValue responder receives
+		// the real invoked argument regardless of which key matched, so assertSame() below
+		// catches that.
 		WP_Mock::onFilter( 'dwpb_post_types_supporting_comments' )
 			->with( array( 'page' ), $args )
-			->reply( array( 'page' ) );
+			->reply(
+				new WP_Mock\InvokedFilterValue(
+					function ( $post_types_with_feature ) {
+						$this->assertSame( array( 'page' ), $post_types_with_feature );
+
+						return array( 'page' );
+					}
+				)
+			);
 
 		$result = dwpb_post_types_with_feature( $feature, $args );
 
@@ -127,7 +217,7 @@ class HelperFunctionsTest extends TestCase {
 		WP_Mock::userFunction( 'post_type_supports' )->never();
 		WP_Mock::userFunction( 'wp_cache_set' )->never();
 
-		WP_Mock::onFilter( 'dwpb_post_types_supporting_comments' )->with( $cached, array() )->reply( $cached );
+		$this->stub_post_types_supporting_filter( 'dwpb_post_types_supporting_comments', $cached, array(), $cached );
 
 		$result = dwpb_post_types_with_feature( $feature );
 
@@ -152,16 +242,20 @@ class HelperFunctionsTest extends TestCase {
 
 		WP_Mock::userFunction( 'get_post_types' )
 			->once()
-			->with( array(), 'names' )
+			->with( $this->strict_empty_array(), 'names' )
 			->andReturn( array( 'post' ) );
 
 		WP_Mock::userFunction( 'post_type_supports' )->with( 'post', $feature )->andReturn( true );
 
+		// The empty result array is cached as-is; only the value returned to the caller
+		// (and passed to the filter below) is normalized to false. array() == false, so
+		// a plain ->with( array() ) would also accept a regression that cached false
+		// directly -- strict_empty_array() forces ===.
 		WP_Mock::userFunction( 'wp_cache_set' )
 			->once()
-			->with( 'post-types-supporting-comments', false, 'post-types-by-feature' );
+			->with( 'post-types-supporting-comments', $this->strict_empty_array(), 'post-types-by-feature' );
 
-		WP_Mock::onFilter( 'dwpb_post_types_supporting_comments' )->with( false, array() )->reply( false );
+		$this->stub_post_types_supporting_filter( 'dwpb_post_types_supporting_comments', false, array(), false );
 
 		$result = dwpb_post_types_with_feature( $feature );
 
@@ -180,13 +274,26 @@ class HelperFunctionsTest extends TestCase {
 
 		WP_Mock::userFunction( 'esc_attr' )->with( $feature )->andReturn( $feature );
 		WP_Mock::userFunction( 'wp_cache_get' )->once()->andReturn( false );
-		WP_Mock::userFunction( 'get_post_types' )->once()->with( $args, 'names' )->andReturn( array( 'page' ) );
+		WP_Mock::userFunction( 'get_post_types' )->once()->with( $this->strict_empty_array(), 'names' )->andReturn( array( 'page' ) );
 		WP_Mock::userFunction( 'post_type_supports' )->with( 'page', $feature )->andReturn( true );
 		WP_Mock::userFunction( 'wp_cache_set' )->once();
 
+		// safe_offset( array( 'page' ) ) === safe_offset( 'page' ), so a plain ->with()
+		// match would also route (and silently pass) if the source ever collapsed the
+		// one-element array to the bare string. The InvokedFilterValue responder receives
+		// the real invoked argument regardless of which key matched, so assertSame() below
+		// catches that.
 		WP_Mock::onFilter( "dwpb_post_types_supporting_{$feature}" )
 			->with( array( 'page' ), $args )
-			->reply( $override );
+			->reply(
+				new WP_Mock\InvokedFilterValue(
+					function ( $post_types_with_feature ) use ( $override ) {
+						$this->assertSame( array( 'page' ), $post_types_with_feature );
+
+						return $override;
+					}
+				)
+			);
 
 		$result = dwpb_post_types_with_feature( $feature, $args );
 
@@ -234,7 +341,7 @@ class HelperFunctionsTest extends TestCase {
 
 		WP_Mock::userFunction( 'get_post_types' )
 			->once()
-			->with( array(), 'names' )
+			->with( $this->strict_empty_array(), 'names' )
 			->andReturn( array( 'post', 'page' ) );
 
 		// 'post' is skipped before get_object_taxonomies() would ever be called for it.
@@ -243,9 +350,7 @@ class HelperFunctionsTest extends TestCase {
 			->with( 'page', 'names' )
 			->andReturn( array( 'category', 'post_tag' ) );
 
-		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
-			->with( null, 'category', array( 'post', 'page' ), array(), 'names' )
-			->reply( null );
+		$this->stub_taxonomy_support_filter( 'category', array( 'post', 'page' ), array(), 'names', null );
 
 		$result = dwpb_post_types_with_tax( $taxonomy );
 
@@ -267,15 +372,13 @@ class HelperFunctionsTest extends TestCase {
 
 		WP_Mock::userFunction( 'get_post_types' )
 			->once()
-			->with( array(), 'names' )
+			->with( $this->strict_empty_array(), 'names' )
 			->andReturn( array( 'post', 'page', 'book' ) );
 
 		WP_Mock::userFunction( 'get_object_taxonomies' )->with( 'page', 'names' )->andReturn( array( 'category' ) );
 		WP_Mock::userFunction( 'get_object_taxonomies' )->with( 'book', 'names' )->andReturn( array( 'genre' ) );
 
-		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
-			->with( null, 'category', array( 'post', 'page', 'book' ), array(), 'names' )
-			->reply( null );
+		$this->stub_taxonomy_support_filter( 'category', array( 'post', 'page', 'book' ), array(), 'names', null );
 
 		$result = dwpb_post_types_with_tax( 'category' );
 
@@ -291,13 +394,17 @@ class HelperFunctionsTest extends TestCase {
 	public function test_post_types_with_tax_no_matches_returns_false() {
 		$this->stub_tax_cache_key_helpers( 'category' );
 		WP_Mock::userFunction( 'wp_cache_get' )->once()->andReturn( false );
+		// The empty result array is cached as-is; only the value returned to the caller
+		// is normalized to false. array() == false, so a plain ->with( array() ) would
+		// also accept a regression that cached false directly -- strict_empty_array()
+		// forces ===.
 		WP_Mock::userFunction( 'wp_cache_set' )
 			->once()
-			->with( $this->tax_cache_key( 'category' ), false, 'post-types-by-tax' );
+			->with( $this->tax_cache_key( 'category' ), $this->strict_empty_array(), 'post-types-by-tax' );
 
 		WP_Mock::userFunction( 'get_post_types' )
 			->once()
-			->with( array(), 'names' )
+			->with( $this->strict_empty_array(), 'names' )
 			->andReturn( array( 'page' ) );
 
 		WP_Mock::userFunction( 'get_object_taxonomies' )
@@ -305,9 +412,7 @@ class HelperFunctionsTest extends TestCase {
 			->with( 'page', 'names' )
 			->andReturn( array( 'post_tag' ) );
 
-		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
-			->with( null, 'category', array( 'page' ), array(), 'names' )
-			->reply( null );
+		$this->stub_taxonomy_support_filter( 'category', array( 'page' ), array(), 'names', null );
 
 		$result = dwpb_post_types_with_tax( 'category' );
 
@@ -331,7 +436,7 @@ class HelperFunctionsTest extends TestCase {
 
 		WP_Mock::userFunction( 'get_post_types' )
 			->once()
-			->with( $args, $output )
+			->with( $this->strict_empty_array(), $output )
 			->andReturn( array( 'page' ) );
 
 		WP_Mock::userFunction( 'get_object_taxonomies' )
@@ -339,9 +444,7 @@ class HelperFunctionsTest extends TestCase {
 			->with( 'page', 'names' )
 			->andReturn( array() );
 
-		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
-			->with( null, 'category', array( 'page' ), $args, $output )
-			->reply( $override );
+		$this->stub_taxonomy_support_filter( 'category', array( 'page' ), $args, $output, $override );
 
 		$result = dwpb_post_types_with_tax( 'category', $args, $output );
 
@@ -380,9 +483,7 @@ class HelperFunctionsTest extends TestCase {
 			->once()
 			->with( $this->tax_cache_key( $taxonomy, $args, $output ), array( 'page' ), 'post-types-by-tax' );
 
-		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
-			->with( null, $taxonomy, array( 'post', 'page', 'book' ), $args, $output )
-			->reply( null );
+		$this->stub_taxonomy_support_filter( $taxonomy, array( 'post', 'page', 'book' ), $args, $output, null );
 
 		$result = dwpb_post_types_with_tax( $taxonomy, $args, $output );
 
@@ -409,13 +510,11 @@ class HelperFunctionsTest extends TestCase {
 			->with( $this->tax_cache_key( $taxonomy ), 'post-types-by-tax' )
 			->andReturn( $cached );
 
-		WP_Mock::userFunction( 'get_post_types' )->once()->with( array(), 'names' )->andReturn( array( 'page' ) );
+		WP_Mock::userFunction( 'get_post_types' )->once()->with( $this->strict_empty_array(), 'names' )->andReturn( array( 'page' ) );
 		WP_Mock::userFunction( 'get_object_taxonomies' )->never();
 		WP_Mock::userFunction( 'wp_cache_set' )->never();
 
-		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
-			->with( null, $taxonomy, array( 'page' ), array(), 'names' )
-			->reply( null );
+		$this->stub_taxonomy_support_filter( $taxonomy, array( 'page' ), array(), 'names', null );
 
 		$result = dwpb_post_types_with_tax( $taxonomy );
 
@@ -445,13 +544,11 @@ class HelperFunctionsTest extends TestCase {
 			->with( $this->tax_cache_key( $taxonomy ), 'post-types-by-tax' )
 			->andReturn( $cached );
 
-		WP_Mock::userFunction( 'get_post_types' )->once()->with( array(), 'names' )->andReturn( array( 'page' ) );
+		WP_Mock::userFunction( 'get_post_types' )->once()->with( $this->strict_empty_array(), 'names' )->andReturn( array( 'page' ) );
 		WP_Mock::userFunction( 'get_object_taxonomies' )->never();
 		WP_Mock::userFunction( 'wp_cache_set' )->never();
 
-		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
-			->with( null, $taxonomy, array( 'page' ), array(), 'names' )
-			->reply( $override );
+		$this->stub_taxonomy_support_filter( $taxonomy, array( 'page' ), array(), 'names', $override );
 
 		$result = dwpb_post_types_with_tax( $taxonomy );
 
@@ -471,10 +568,10 @@ class HelperFunctionsTest extends TestCase {
 	public function test_post_types_with_tax_cache_key_does_not_collide_across_taxonomy_output_boundary() {
 		WP_Mock::userFunction( 'esc_attr' )->with( 'cat' )->andReturn( 'cat' );
 		WP_Mock::userFunction( 'esc_attr' )->with( 'cat-single' )->andReturn( 'cat-single' );
-		WP_Mock::userFunction( 'maybe_serialize' )->with( array() )->andReturn( serialize( array() ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		WP_Mock::userFunction( 'maybe_serialize' )->with( $this->strict_empty_array() )->andReturn( serialize( array() ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 
-		WP_Mock::userFunction( 'get_post_types' )->with( array(), 'single-tag' )->andReturn( array() );
-		WP_Mock::userFunction( 'get_post_types' )->with( array(), 'tag' )->andReturn( array() );
+		WP_Mock::userFunction( 'get_post_types' )->with( $this->strict_empty_array(), 'single-tag' )->andReturn( array() );
+		WP_Mock::userFunction( 'get_post_types' )->with( $this->strict_empty_array(), 'tag' )->andReturn( array() );
 
 		$seen_keys = array();
 		WP_Mock::userFunction( 'wp_cache_get' )
@@ -488,8 +585,8 @@ class HelperFunctionsTest extends TestCase {
 			);
 		WP_Mock::userFunction( 'wp_cache_set' )->twice();
 
-		WP_Mock::onFilter( 'dwpb_taxonomy_support' )->with( null, 'cat', array(), array(), 'single-tag' )->reply( null );
-		WP_Mock::onFilter( 'dwpb_taxonomy_support' )->with( null, 'cat-single', array(), array(), 'tag' )->reply( null );
+		$this->stub_taxonomy_support_filter( 'cat', array(), array(), 'single-tag', null );
+		$this->stub_taxonomy_support_filter( 'cat-single', array(), array(), 'tag', null );
 
 		dwpb_post_types_with_tax( 'cat', array(), 'single-tag' );
 		dwpb_post_types_with_tax( 'cat-single', array(), 'tag' );
@@ -506,8 +603,8 @@ class HelperFunctionsTest extends TestCase {
 	public function test_post_types_with_tax_cache_key_distinguishes_calls_that_differ_only_by_output() {
 		$this->stub_tax_cache_key_helpers( 'category' );
 
-		WP_Mock::userFunction( 'get_post_types' )->with( array(), 'names' )->andReturn( array() );
-		WP_Mock::userFunction( 'get_post_types' )->with( array(), 'objects' )->andReturn( array() );
+		WP_Mock::userFunction( 'get_post_types' )->with( $this->strict_empty_array(), 'names' )->andReturn( array() );
+		WP_Mock::userFunction( 'get_post_types' )->with( $this->strict_empty_array(), 'objects' )->andReturn( array() );
 
 		$seen_keys = array();
 		WP_Mock::userFunction( 'wp_cache_get' )
@@ -521,8 +618,8 @@ class HelperFunctionsTest extends TestCase {
 			);
 		WP_Mock::userFunction( 'wp_cache_set' )->twice();
 
-		WP_Mock::onFilter( 'dwpb_taxonomy_support' )->with( null, 'category', array(), array(), 'names' )->reply( null );
-		WP_Mock::onFilter( 'dwpb_taxonomy_support' )->with( null, 'category', array(), array(), 'objects' )->reply( null );
+		$this->stub_taxonomy_support_filter( 'category', array(), array(), 'names', null );
+		$this->stub_taxonomy_support_filter( 'category', array(), array(), 'objects', null );
 
 		dwpb_post_types_with_tax( 'category', array(), 'names' );
 		dwpb_post_types_with_tax( 'category', array(), 'objects' );
@@ -562,14 +659,14 @@ class HelperFunctionsTest extends TestCase {
 
 		WP_Mock::userFunction( 'get_post_types' )
 			->once()
-			->with( $args, 'names' )
+			->with( $this->strict_empty_array(), 'names' )
 			->andReturn( array( 'post' ) );
 
 		WP_Mock::userFunction( 'post_type_supports' )->with( 'post', $feature )->andReturn( true );
 
 		WP_Mock::userFunction( 'wp_cache_set' )
 			->once()
-			->with( 'post-types-supporting-comments', array(), 'post-types-by-feature' );
+			->with( 'post-types-supporting-comments', $this->strict_empty_array(), 'post-types-by-feature' );
 
 		WP_Mock::onFilter( "dwpb_post_types_supporting_{$feature}" )
 			->with( false, $args )
@@ -615,7 +712,7 @@ class HelperFunctionsTest extends TestCase {
 		// comment above get_post_types() in the source).
 		WP_Mock::userFunction( 'get_post_types' )
 			->twice()
-			->with( array(), 'names' )
+			->with( $this->strict_empty_array(), 'names' )
 			->andReturn( array( 'page' ) );
 
 		WP_Mock::userFunction( 'get_object_taxonomies' )
@@ -625,11 +722,9 @@ class HelperFunctionsTest extends TestCase {
 
 		WP_Mock::userFunction( 'wp_cache_set' )
 			->once()
-			->with( $cache_key, array(), 'post-types-by-tax' );
+			->with( $cache_key, $this->strict_empty_array(), 'post-types-by-tax' );
 
-		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
-			->with( null, $taxonomy, array( 'page' ), array(), 'names' )
-			->reply( null );
+		$this->stub_taxonomy_support_filter( $taxonomy, array( 'page' ), array(), 'names', null );
 
 		$cold_result = dwpb_post_types_with_tax( $taxonomy );
 		$warm_result = dwpb_post_types_with_tax( $taxonomy );
@@ -662,7 +757,7 @@ class HelperFunctionsTest extends TestCase {
 
 		WP_Mock::userFunction( 'get_post_types' )
 			->once()
-			->with( array(), 'names' )
+			->with( $this->strict_empty_array(), 'names' )
 			->andReturn( array( 'page' ) );
 
 		WP_Mock::userFunction( 'get_object_taxonomies' )
@@ -670,9 +765,7 @@ class HelperFunctionsTest extends TestCase {
 			->with( 'page', 'names' )
 			->andReturn( array( true ) );
 
-		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
-			->with( null, $taxonomy, array( 'page' ), array(), 'names' )
-			->reply( null );
+		$this->stub_taxonomy_support_filter( $taxonomy, array( 'page' ), array(), 'names', null );
 
 		$result = dwpb_post_types_with_tax( $taxonomy );
 

--- a/tests/php/IntegrationsTest.php
+++ b/tests/php/IntegrationsTest.php
@@ -223,6 +223,28 @@ class IntegrationsTest extends TestCase {
 	}
 
 	/**
+	 * The `0 === $post_id` guard must use strict comparison: `null` is loosely equal to `0`
+	 * but not identical to it, so a loose guard would (wrongly) treat a null post ID as the
+	 * front page and proceed to the version check.
+	 *
+	 * Invoked via Reflection, bypassing the public method's `@param int $post_id` signature,
+	 * so the deliberately-wrong-type `null` used to probe the guard doesn't itself trip static
+	 * analysis of this test file.
+	 */
+	public function test_filter_woocommerce_comment_count_skips_when_post_id_is_loosely_but_not_strictly_zero() {
+		$comments = (object) array( 'foo' => 'bar' );
+
+		$integrations = new Disable_Blog_Integrations();
+
+		WP_Mock::userFunction( 'is_plugin_active' )->never();
+
+		$method = new ReflectionMethod( $integrations, 'filter_woocommerce_comment_count' );
+		$result = $method->invokeArgs( $integrations, array( $comments, null ) );
+
+		$this->assertSame( $comments, $result );
+	}
+
+	/**
 	 * woocommerce_version_check() (private)
 	 */
 

--- a/tests/php/LoaderTest.php
+++ b/tests/php/LoaderTest.php
@@ -199,6 +199,25 @@ class LoaderTest extends TestCase {
 		);
 	}
 
+	public function test_add_filter_buffers_the_tuple_with_default_priority_and_args() {
+		$component = new stdClass();
+
+		$this->loader->add_filter( 'the_content', $component, 'my_filter' );
+
+		$this->assertSame(
+			array(
+				array(
+					'hook'          => 'the_content',
+					'component'     => $component,
+					'callback'      => 'my_filter',
+					'priority'      => 10,
+					'accepted_args' => 1,
+				),
+			),
+			$this->get_loader_property( 'filters' )
+		);
+	}
+
 	public function test_add_filter_buffers_the_tuple_with_explicit_priority_and_args() {
 		$component = new stdClass();
 
@@ -342,6 +361,51 @@ class LoaderTest extends TestCase {
 
 		$this->assertFalse( $result );
 		$this->assertSame( array(), $hook->remove_filter_calls );
+	}
+
+	/**
+	 * The array key that stores each priority's callbacks is an int (PHP normalizes numeric
+	 * array keys), so a caller-supplied priority of the string '10' loosely equals it but must
+	 * not match under the strict comparison the source uses.
+	 */
+	public function test_remove_filter_requires_strict_priority_match_not_loose() {
+		$component = new LoaderTestFakeComponent();
+		$hook      = new LoaderTestFakeWpHook( true );
+		$hook->callbacks[10] = array(
+			array( 'function' => array( $component, 'my_method' ) ),
+		);
+
+		global $wp_filter;
+		$wp_filter = array( 'some_tag' => $hook );
+
+		// Routed through get_object_vars() (rather than passed as a '10' literal) so PHPStan sees
+		// an untracked mixed value: the source's @param int docblock would otherwise flag this
+		// deliberate int/string mismatch as a static error rather than exercising it at runtime.
+		$carrier            = new stdClass();
+		$carrier->priority  = '10';
+		$carrier_vars       = get_object_vars( $carrier );
+
+		$result = $this->loader->remove_filter( 'some_tag', LoaderTestFakeComponent::class, 'my_method', $carrier_vars['priority'] );
+
+		$this->assertFalse( $result );
+		$this->assertSame( array(), $hook->remove_filter_calls );
+	}
+
+	public function test_remove_action_defaults_to_priority_ten() {
+		$component = new LoaderTestFakeComponent();
+		$hook      = new LoaderTestFakeWpHook( true );
+		$hook->callbacks[10] = array(
+			array( 'function' => array( $component, 'my_method' ) ),
+		);
+
+		global $wp_filter;
+		$wp_filter = array( 'some_tag' => $hook );
+
+		// Priority omitted: must still match the default-priority-10 callback.
+		$result = $this->loader->remove_action( 'some_tag', LoaderTestFakeComponent::class, 'my_method' );
+
+		$this->assertTrue( $result );
+		$this->assertCount( 1, $hook->remove_filter_calls );
 	}
 
 	public function test_remove_action_delegates_to_remove_filter_with_the_same_arguments() {

--- a/tests/php/PublicFeedsTest.php
+++ b/tests/php/PublicFeedsTest.php
@@ -70,6 +70,12 @@ class PublicFeedsTest extends TestCase {
 	 * Forces dwpb_post_types_with_feature( $feature ) to return $return_value, via the
 	 * dwpb_post_types_supporting_{$feature} filter that always applies to its computed result.
 	 *
+	 * Asserts the real invoked arguments are strictly (===) the normalized-to-false default
+	 * and the empty $args array -- safe_offset() casts scalars via (string) and flattens
+	 * arrays, so a plain ->with( false, array() ) would still route here if the source passed
+	 * a loosely-equal value (e.g. an empty array) instead of the literal false the "no post
+	 * types found" branch documents.
+	 *
 	 * @param string     $feature      The feature slug (e.g. 'comments').
 	 * @param array|bool $return_value The value dwpb_post_types_with_feature() should return.
 	 * @return void
@@ -79,7 +85,69 @@ class PublicFeedsTest extends TestCase {
 		WP_Mock::userFunction( 'wp_cache_get' )->andReturn( false );
 		WP_Mock::userFunction( 'get_post_types' )->andReturn( array() );
 		WP_Mock::userFunction( 'wp_cache_set' )->andReturn( null );
-		WP_Mock::onFilter( "dwpb_post_types_supporting_{$feature}" )->with( false, array() )->reply( $return_value );
+		WP_Mock::onFilter( "dwpb_post_types_supporting_{$feature}" )->with( false, array() )->reply(
+			new WP_Mock\InvokedFilterValue(
+				function ( $post_types_with_feature, $args ) use ( $return_value ) {
+					$this->assertFalse( $post_types_with_feature );
+					$this->assertSame( array(), $args );
+
+					return $return_value;
+				}
+			)
+		);
+	}
+
+	/**
+	 * Stubs the dwpb_redirect_feeds filter, asserting the real invoked comment-feed flag is
+	 * strictly (===) $is_comment_feed -- safe_offset() casts scalars via (string), so a plain
+	 * ->with( $url, $post, $is_comment_feed ) would still route here if the source passed a
+	 * loosely-equal value (e.g. an empty array) instead of the literal boolean this filter
+	 * documents. $url and $post are already matched exactly (a literal string and object
+	 * identity via spl_object_hash()), so this asserts them too for a single point of truth.
+	 *
+	 * @param string $url             The unfiltered home_url() the filter should receive.
+	 * @param mixed  $post            The global $post (null or a WP_Post) the filter should receive.
+	 * @param bool   $is_comment_feed The exact comment-feed flag the filter must receive.
+	 * @param string $reply           The value the filter should reply with.
+	 * @return void
+	 */
+	private function stub_redirect_feeds_filter( $url, $post, $is_comment_feed, $reply ) {
+		WP_Mock::onFilter( 'dwpb_redirect_feeds' )->with( $url, $post, $is_comment_feed )->reply(
+			new WP_Mock\InvokedFilterValue(
+				function ( $actual_url, $actual_post, $actual_is_comment_feed ) use ( $url, $post, $is_comment_feed, $reply ) {
+					$this->assertSame( $url, $actual_url );
+					$this->assertSame( $post, $actual_post );
+					$this->assertSame( $is_comment_feed, $actual_is_comment_feed );
+
+					return $reply;
+				}
+			)
+		);
+	}
+
+	/**
+	 * Stubs the dwpb_feed_message filter, asserting the real invoked default and comment-feed
+	 * flag are strictly (===) what's expected -- safe_offset() casts scalars via (string), so
+	 * a plain ->with( false, $post, $is_comment_feed ) would still route here if the source
+	 * passed a loosely-equal value instead of the literal booleans this filter documents.
+	 *
+	 * @param mixed $post            The global $post (null or a WP_Post) the filter should receive.
+	 * @param bool  $is_comment_feed The exact comment-feed flag the filter must receive.
+	 * @param bool  $reply           The value the filter should reply with.
+	 * @return void
+	 */
+	private function stub_feed_message_filter( $post, $is_comment_feed, $reply ) {
+		WP_Mock::onFilter( 'dwpb_feed_message' )->with( false, $post, $is_comment_feed )->reply(
+			new WP_Mock\InvokedFilterValue(
+				function ( $default, $actual_post, $actual_is_comment_feed ) use ( $post, $is_comment_feed, $reply ) {
+					$this->assertFalse( $default );
+					$this->assertSame( $post, $actual_post );
+					$this->assertSame( $is_comment_feed, $actual_is_comment_feed );
+
+					return $reply;
+				}
+			)
+		);
 	}
 
 	/**
@@ -167,8 +235,8 @@ class PublicFeedsTest extends TestCase {
 		$wp = (object) array( 'query_vars' => array( 'feed' => 'feed' ) );
 
 		WP_Mock::userFunction( 'home_url' )->once()->andReturn( 'https://example.test/' );
-		WP_Mock::onFilter( 'dwpb_redirect_feeds' )->with( 'https://example.test/', null, false )->reply( 'https://example.test/' );
-		WP_Mock::onFilter( 'dwpb_feed_message' )->with( false, null, false )->reply( false );
+		$this->stub_redirect_feeds_filter( 'https://example.test/', null, false, 'https://example.test/' );
+		$this->stub_feed_message_filter( null, false, false );
 
 		$functions                     = new Disable_Blog_Public_Functions_Double();
 		$functions->disable_feeds_return = true;
@@ -190,10 +258,8 @@ class PublicFeedsTest extends TestCase {
 		$wp   = (object) array( 'query_vars' => array( 'feed' => 'feed' ) );
 
 		WP_Mock::userFunction( 'home_url' )->once()->andReturn( 'https://example.test/' );
-		WP_Mock::onFilter( 'dwpb_redirect_feeds' )
-			->with( 'https://example.test/', $post, true )
-			->reply( 'https://example.test/custom-feed-redirect/' );
-		WP_Mock::onFilter( 'dwpb_feed_message' )->with( false, $post, true )->reply( false );
+		$this->stub_redirect_feeds_filter( 'https://example.test/', $post, true, 'https://example.test/custom-feed-redirect/' );
+		$this->stub_feed_message_filter( $post, true, false );
 
 		$functions                     = new Disable_Blog_Public_Functions_Double();
 		$functions->disable_feeds_return = true;
@@ -213,8 +279,8 @@ class PublicFeedsTest extends TestCase {
 		$wp = (object) array( 'query_vars' => array( 'feed' => 'feed' ) );
 
 		WP_Mock::userFunction( 'home_url' )->once()->andReturn( 'https://example.test/' );
-		WP_Mock::onFilter( 'dwpb_redirect_feeds' )->with( 'https://example.test/', null, false )->reply( 'https://example.test/' );
-		WP_Mock::onFilter( 'dwpb_feed_message' )->with( false, null, false )->reply( true );
+		$this->stub_redirect_feeds_filter( 'https://example.test/', null, false, 'https://example.test/' );
+		$this->stub_feed_message_filter( null, false, true );
 		WP_Mock::userFunction( 'esc_url_raw' )->with( 'https://example.test/' )->andReturn( 'https://example.test/' );
 
 		$expected_message = 'No feed available, please visit our homepage:: <a href="https://example.test/">https://example.test/</a>';
@@ -244,8 +310,8 @@ class PublicFeedsTest extends TestCase {
 		$wp = (object) array( 'query_vars' => array( 'feed' => 'feed' ) );
 
 		WP_Mock::userFunction( 'home_url' )->once()->andReturn( 'https://example.test/' );
-		WP_Mock::onFilter( 'dwpb_redirect_feeds' )->with( 'https://example.test/', null, false )->reply( 'https://example.test/' );
-		WP_Mock::onFilter( 'dwpb_feed_message' )->with( false, null, false )->reply( true );
+		$this->stub_redirect_feeds_filter( 'https://example.test/', null, false, 'https://example.test/' );
+		$this->stub_feed_message_filter( null, false, true );
 		WP_Mock::userFunction( 'esc_url_raw' )->with( 'https://example.test/' )->andReturn( 'https://example.test/' );
 
 		$default_message  = 'No feed available, please visit our homepage:: <a href="https://example.test/">https://example.test/</a>';

--- a/tests/php/PublicFeedsTest.php
+++ b/tests/php/PublicFeedsTest.php
@@ -325,6 +325,20 @@ class PublicFeedsTest extends TestCase {
 		$this->assertTrue( $this->invoke_is_post_feed_request( $public ) );
 	}
 
+	/**
+	 * `true` is loosely == 'post' (a non-empty string is truthy) but never strictly === it, so
+	 * this distinguishes the real strict in_array() check from a loose one without relying on
+	 * PHP-version-sensitive numeric-string coercion.
+	 */
+	public function test_is_post_feed_request_false_when_post_type_array_contains_only_loosely_equal_value() {
+		global $wp;
+		$wp = (object) array( 'query_vars' => array( 'post_type' => array( true ) ) );
+
+		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+
+		$this->assertFalse( $this->invoke_is_post_feed_request( $public ) );
+	}
+
 	public function test_is_post_feed_request_false_when_post_type_array_does_not_contain_post() {
 		global $wp;
 		$wp = (object) array( 'query_vars' => array( 'post_type' => array( 'page', 'book' ) ) );

--- a/tests/php/PublicMiscTest.php
+++ b/tests/php/PublicMiscTest.php
@@ -130,10 +130,27 @@ class PublicMiscTest extends TestCase {
 	 * @return void
 	 */
 	private function stub_tax_lookup_plumbing() {
-		WP_Mock::userFunction( 'get_post_types' )->with( array(), 'names' )->andReturn( array() );
+		WP_Mock::userFunction( 'get_post_types' )
+			->with(
+				Mockery::on(
+					function ( $args ) {
+						return array() === $args;
+					}
+				),
+				'names'
+			)
+			->andReturn( array() );
 		WP_Mock::userFunction( 'wp_cache_get' )->andReturn( false );
 		WP_Mock::userFunction( 'wp_cache_set' )->andReturn( null );
-		WP_Mock::userFunction( 'maybe_serialize' )->with( array() )->andReturn( 'a:0:{}' );
+		WP_Mock::userFunction( 'maybe_serialize' )
+			->with(
+				Mockery::on(
+					function ( $args ) {
+						return array() === $args;
+					}
+				)
+			)
+			->andReturn( 'a:0:{}' );
 	}
 
 	/**
@@ -149,7 +166,16 @@ class PublicMiscTest extends TestCase {
 		WP_Mock::userFunction( 'esc_attr' )->with( $taxonomy )->andReturn( $taxonomy );
 		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
 			->with( null, $taxonomy, array(), array(), 'names' )
-			->reply( $return_value );
+			->reply(
+				new WP_Mock\InvokedFilterValue(
+					function ( $null, $tax, $post_types, $args, $output ) use ( $return_value ) {
+						$this->assertSame( array(), $post_types, 'dwpb_taxonomy_support must receive the exact $post_types array it documents.' );
+						$this->assertSame( array(), $args, 'dwpb_taxonomy_support must receive the exact $args array it documents.' );
+
+						return $return_value;
+					}
+				)
+			);
 	}
 
 	/**
@@ -300,7 +326,7 @@ class PublicMiscTest extends TestCase {
 	 */
 
 	public function test_filter_wp_headers_removes_pingback_header_by_default() {
-		WP_Mock::onFilter( 'dwpb_remove_pingback_header' )->with( true )->reply( true );
+		$this->stub_filter_strict( 'dwpb_remove_pingback_header', true, true );
 
 		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
 
@@ -313,7 +339,7 @@ class PublicMiscTest extends TestCase {
 	}
 
 	public function test_filter_wp_headers_dwpb_remove_pingback_header_filter_false_keeps_header() {
-		WP_Mock::onFilter( 'dwpb_remove_pingback_header' )->with( true )->reply( false );
+		$this->stub_filter_strict( 'dwpb_remove_pingback_header', true, false );
 
 		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
 
@@ -323,7 +349,7 @@ class PublicMiscTest extends TestCase {
 	}
 
 	public function test_filter_wp_headers_noop_when_pingback_header_absent() {
-		WP_Mock::onFilter( 'dwpb_remove_pingback_header' )->with( true )->reply( true );
+		$this->stub_filter_strict( 'dwpb_remove_pingback_header', true, true );
 
 		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
 
@@ -344,7 +370,7 @@ class PublicMiscTest extends TestCase {
 	 * functions!").
 	 */
 	public function test_remove_pingback_header_fallback_returns_early_when_filter_disables_it() {
-		WP_Mock::onFilter( 'dwpb_remove_pingback_header' )->with( true )->reply( false );
+		$this->stub_filter_strict( 'dwpb_remove_pingback_header', true, false );
 
 		$public = new class( 'disable-blog', '0.5.6' ) extends Disable_Blog_Public {
 			/**
@@ -372,7 +398,7 @@ class PublicMiscTest extends TestCase {
 	public function test_remove_pingback_header_fallback_skips_header_remove_once_headers_have_actually_been_sent() {
 		$this->assertTrue( headers_sent(), "Expected PHPUnit's own CLI output to have already marked headers as sent." );
 
-		WP_Mock::onFilter( 'dwpb_remove_pingback_header' )->with( true )->reply( true );
+		$this->stub_filter_strict( 'dwpb_remove_pingback_header', true, true );
 
 		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
 
@@ -389,7 +415,7 @@ class PublicMiscTest extends TestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_remove_pingback_header_fallback_calls_header_remove_when_headers_not_yet_sent() {
-		WP_Mock::onFilter( 'dwpb_remove_pingback_header' )->with( true )->reply( true );
+		$this->stub_filter_strict( 'dwpb_remove_pingback_header', true, true );
 
 		$public = new class( 'disable-blog', '0.5.6' ) extends Disable_Blog_Public {
 			/**
@@ -503,7 +529,7 @@ class PublicMiscTest extends TestCase {
 		$functions->disable_author_archives_return = true;
 		$public                                       = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
 
-		WP_Mock::onFilter( 'dwpb_disable_user_sitemap' )->with( true )->reply( true );
+		$this->stub_filter_strict( 'dwpb_disable_user_sitemap', true, true );
 
 		$this->assertFalse( $public->wp_author_sitemaps( new stdClass(), 'users' ) );
 	}
@@ -514,7 +540,7 @@ class PublicMiscTest extends TestCase {
 		$functions->author_archive_post_types_return = false;
 		$public                                         = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
 
-		WP_Mock::onFilter( 'dwpb_disable_user_sitemap' )->with( true )->reply( true );
+		$this->stub_filter_strict( 'dwpb_disable_user_sitemap', true, true );
 
 		$this->assertFalse( $public->wp_author_sitemaps( new stdClass(), 'users' ) );
 	}
@@ -525,7 +551,7 @@ class PublicMiscTest extends TestCase {
 		$functions->author_archive_post_types_return = array( 'book' );
 		$public                                         = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
 
-		WP_Mock::onFilter( 'dwpb_disable_user_sitemap' )->with( false )->reply( false );
+		$this->stub_filter_strict( 'dwpb_disable_user_sitemap', false, false );
 
 		$provider = new stdClass();
 
@@ -542,7 +568,7 @@ class PublicMiscTest extends TestCase {
 		$functions->author_archive_post_types_return = array( 'book' );
 		$public                                         = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
 
-		WP_Mock::onFilter( 'dwpb_disable_user_sitemap' )->with( false )->reply( true );
+		$this->stub_filter_strict( 'dwpb_disable_user_sitemap', false, true );
 
 		$this->assertFalse( $public->wp_author_sitemaps( new stdClass(), 'users' ) );
 	}
@@ -556,7 +582,7 @@ class PublicMiscTest extends TestCase {
 		$functions->disable_author_archives_return = true;
 		$public                                       = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
 
-		WP_Mock::onFilter( 'dwpb_disable_user_sitemap' )->with( true )->reply( false );
+		$this->stub_filter_strict( 'dwpb_disable_user_sitemap', true, false );
 
 		$provider = new stdClass();
 
@@ -607,7 +633,7 @@ class PublicMiscTest extends TestCase {
 	 */
 	public function test_disable_removed_sitemaps_returns_early_when_wp_sitemaps_get_server_undefined() {
 		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap', '' )->andReturn( 'posts' );
-		WP_Mock::onFilter( 'dwpb_disable_removed_sitemaps' )->with( true )->reply( true );
+		$this->stub_filter_strict( 'dwpb_disable_removed_sitemaps', true, true );
 		$this->assert_no_404_side_effects();
 
 		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
@@ -629,7 +655,7 @@ class PublicMiscTest extends TestCase {
 		}
 
 		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap', '' )->andReturn( 'users' );
-		WP_Mock::onFilter( 'dwpb_disable_removed_sitemaps' )->with( true )->reply( true );
+		$this->stub_filter_strict( 'dwpb_disable_removed_sitemaps', true, true );
 		$this->assert_no_404_side_effects();
 
 		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
@@ -661,7 +687,7 @@ class PublicMiscTest extends TestCase {
 		}
 
 		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap', '' )->andReturn( 'users' );
-		WP_Mock::onFilter( 'dwpb_disable_removed_sitemaps' )->with( true )->reply( true );
+		$this->stub_filter_strict( 'dwpb_disable_removed_sitemaps', true, true );
 		$this->assert_no_404_side_effects();
 
 		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
@@ -683,13 +709,21 @@ class PublicMiscTest extends TestCase {
 		}
 
 		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap', '' )->andReturn( 'users' );
-		WP_Mock::onFilter( 'dwpb_disable_removed_sitemaps' )->with( true )->reply( true );
+		$this->stub_filter_strict( 'dwpb_disable_removed_sitemaps', true, true );
 
 		global $wp_query;
 		$wp_query = Mockery::mock( 'Disable_Blog_Public_Query_Double' );
 		$wp_query->shouldReceive( 'set_404' )->once();
 
-		WP_Mock::userFunction( 'status_header' )->once()->with( 404 );
+		WP_Mock::userFunction( 'status_header' )
+			->once()
+			->with(
+				Mockery::on(
+					function ( $code ) {
+						return 404 === $code;
+					}
+				)
+			);
 		WP_Mock::userFunction( 'nocache_headers' )->once();
 
 		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
@@ -713,7 +747,7 @@ class PublicMiscTest extends TestCase {
 		}
 
 		WP_Mock::userFunction( 'get_query_var' )->with( 'sitemap', '' )->andReturn( 'users' );
-		WP_Mock::onFilter( 'dwpb_disable_removed_sitemaps' )->with( true )->reply( false );
+		$this->stub_filter_strict( 'dwpb_disable_removed_sitemaps', true, false );
 		$this->assert_no_404_side_effects();
 
 		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );

--- a/tests/php/PublicMiscTest.php
+++ b/tests/php/PublicMiscTest.php
@@ -410,11 +410,8 @@ class PublicMiscTest extends TestCase {
 	 * fallback must actually reach do_remove_pingback_header(), not just return null (a void
 	 * method returns null either way, so assertNull() alone can't distinguish "reached" from
 	 * "guarded out").
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
 	 */
-	public function test_remove_pingback_header_fallback_calls_header_remove_when_headers_not_yet_sent() {
+	public function test_remove_pingback_header_fallback_reaches_do_remove_pingback_header_when_filter_allows_it() {
 		$this->stub_filter_strict( 'dwpb_remove_pingback_header', true, true );
 
 		$public = new class( 'disable-blog', '0.5.6' ) extends Disable_Blog_Public {

--- a/tests/php/PublicMiscTest.php
+++ b/tests/php/PublicMiscTest.php
@@ -336,16 +336,29 @@ class PublicMiscTest extends TestCase {
 	 * remove_pingback_header_fallback()
 	 */
 
+	/**
+	 * The guard is a return: the filter disabling removal must stop the fallback before it
+	 * reaches do_remove_pingback_header() at all. Asserted via that seam rather than the
+	 * headers_sent()/header_remove() body it guards, since those are genuine internal PHP
+	 * functions WP_Mock/Patchwork refuses to override ("Cannot override internal PHP
+	 * functions!").
+	 */
 	public function test_remove_pingback_header_fallback_returns_early_when_filter_disables_it() {
 		WP_Mock::onFilter( 'dwpb_remove_pingback_header' )->with( true )->reply( false );
 
-		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+		$public = new class( 'disable-blog', '0.5.6' ) extends Disable_Blog_Public {
+			/**
+			 * @var int
+			 */
+			public $do_remove_pingback_header_calls = 0;
 
-		// The early return means headers_sent()/header_remove() below it are never reached; both
-		// are genuine internal PHP functions WP_Mock/Patchwork refuses to override ("Cannot
-		// override internal PHP functions!"), so unlike every other WP function in this suite,
-		// they can't be stubbed with a ->never() expectation to prove that directly.
+			protected function do_remove_pingback_header() {
+				++$this->do_remove_pingback_header_calls;
+			}
+		};
+
 		$this->assertNull( $public->remove_pingback_header_fallback() );
+		$this->assertSame( 0, $public->do_remove_pingback_header_calls );
 	}
 
 	/**
@@ -367,24 +380,30 @@ class PublicMiscTest extends TestCase {
 	}
 
 	/**
-	 * Isolated: a fresh process has produced no output yet, so headers_sent() genuinely starts
-	 * false here -- unlike the shared-process test above, this reaches the real
-	 * header_remove( 'X-Pingback' ) call rather than skipping it. header_remove() is a real
-	 * internal PHP function with no observable return value or (in the CLI SAPI used by this
-	 * suite) any readable header list, so there is nothing further to assert about its effect;
-	 * this test's purpose is exercising that line for real, not proving its side effect.
+	 * The counterpart to the early-return test above: when the filter allows removal, the
+	 * fallback must actually reach do_remove_pingback_header(), not just return null (a void
+	 * method returns null either way, so assertNull() alone can't distinguish "reached" from
+	 * "guarded out").
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	public function test_remove_pingback_header_fallback_calls_header_remove_when_headers_not_yet_sent() {
-		$this->assertFalse( headers_sent(), 'Expected a fresh process to not have sent headers yet.' );
-
 		WP_Mock::onFilter( 'dwpb_remove_pingback_header' )->with( true )->reply( true );
 
-		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
+		$public = new class( 'disable-blog', '0.5.6' ) extends Disable_Blog_Public {
+			/**
+			 * @var int
+			 */
+			public $do_remove_pingback_header_calls = 0;
+
+			protected function do_remove_pingback_header() {
+				++$this->do_remove_pingback_header_calls;
+			}
+		};
 
 		$this->assertNull( $public->remove_pingback_header_fallback() );
+		$this->assertSame( 1, $public->do_remove_pingback_header_calls );
 	}
 
 	/**
@@ -558,7 +577,7 @@ class PublicMiscTest extends TestCase {
 	}
 
 	/**
-	 * Isolated, with a real registry in place (so a mutated guard would fall through all the
+	 * Isolated, with a real registry in place (so a broken guard would fall through all the
 	 * way to the provider check below): 'index' is never a registered provider name, so if the
 	 * 'index' exclusion itself were dropped, isset( $providers['index'] ) would be false and
 	 * this would 404 instead of returning early. Proves the 'index' check specifically, rather

--- a/tests/php/PublicRedirectsTest.php
+++ b/tests/php/PublicRedirectsTest.php
@@ -107,7 +107,15 @@ class PublicRedirectsTest extends TestCase {
 			$overrides
 		);
 
-		WP_Mock::userFunction( 'is_singular' )->with( 'post' )->andReturn( $c['is_singular_post'] );
+		WP_Mock::userFunction( 'is_singular' )
+			->with(
+				Mockery::on(
+					function ( $type ) {
+						return 'post' === $type;
+					}
+				)
+			)
+			->andReturn( $c['is_singular_post'] );
 		WP_Mock::userFunction( 'is_tag' )->andReturn( $c['is_tag'] );
 		WP_Mock::userFunction( 'is_category' )->andReturn( $c['is_category'] );
 		WP_Mock::userFunction( 'is_feed' )->andReturn( $c['is_feed'] );
@@ -130,10 +138,27 @@ class PublicRedirectsTest extends TestCase {
 	 * @return void
 	 */
 	private function stub_tax_lookup_plumbing() {
-		WP_Mock::userFunction( 'get_post_types' )->with( array(), 'names' )->andReturn( array() );
+		WP_Mock::userFunction( 'get_post_types' )
+			->with(
+				Mockery::on(
+					function ( $args ) {
+						return array() === $args;
+					}
+				),
+				'names'
+			)
+			->andReturn( array() );
 		WP_Mock::userFunction( 'wp_cache_get' )->andReturn( false );
 		WP_Mock::userFunction( 'wp_cache_set' )->andReturn( null );
-		WP_Mock::userFunction( 'maybe_serialize' )->with( array() )->andReturn( 'a:0:{}' );
+		WP_Mock::userFunction( 'maybe_serialize' )
+			->with(
+				Mockery::on(
+					function ( $args ) {
+						return array() === $args;
+					}
+				)
+			)
+			->andReturn( 'a:0:{}' );
 	}
 
 	/**
@@ -149,7 +174,16 @@ class PublicRedirectsTest extends TestCase {
 		WP_Mock::userFunction( 'esc_attr' )->with( $taxonomy )->andReturn( $taxonomy );
 		WP_Mock::onFilter( 'dwpb_taxonomy_support' )
 			->with( null, $taxonomy, array(), array(), 'names' )
-			->reply( $return_value );
+			->reply(
+				new WP_Mock\InvokedFilterValue(
+					function ( $null, $tax, $post_types, $args, $output ) use ( $return_value ) {
+						$this->assertSame( array(), $post_types, 'dwpb_taxonomy_support must receive the exact $post_types array it documents.' );
+						$this->assertSame( array(), $args, 'dwpb_taxonomy_support must receive the exact $args array it documents.' );
+
+						return $return_value;
+					}
+				)
+			);
 	}
 
 	/**
@@ -162,7 +196,7 @@ class PublicRedirectsTest extends TestCase {
 	 * @return void
 	 */
 	private function stub_front_end_redirect_passthrough( $redirect_url ) {
-		WP_Mock::onFilter( 'dwpb_redirect_front_end' )->with( true )->reply( true );
+		$this->stub_filter_strict( 'dwpb_redirect_front_end', true, true );
 		WP_Mock::onFilter( 'dwpb_front_end_redirect_url' )->with( $redirect_url )->reply( $redirect_url );
 	}
 
@@ -556,7 +590,7 @@ class PublicRedirectsTest extends TestCase {
 		$this->stub_redirect_conditions( array( 'is_home' => true ) );
 
 		WP_Mock::onFilter( 'dwpb_redirect_blog_page' )->with( 'https://example.test/' )->reply( 'https://example.test/' );
-		WP_Mock::onFilter( 'dwpb_redirect_front_end' )->with( true )->reply( false );
+		$this->stub_filter_strict( 'dwpb_redirect_front_end', true, false );
 
 		$functions = new Disable_Blog_Public_Functions_Double();
 		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
@@ -575,7 +609,7 @@ class PublicRedirectsTest extends TestCase {
 		$this->stub_redirect_conditions( array( 'is_home' => true ) );
 
 		WP_Mock::onFilter( 'dwpb_redirect_blog_page' )->with( 'https://example.test/' )->reply( 'https://example.test/' );
-		WP_Mock::onFilter( 'dwpb_redirect_front_end' )->with( true )->reply( true );
+		$this->stub_filter_strict( 'dwpb_redirect_front_end', true, true );
 		WP_Mock::onFilter( 'dwpb_front_end_redirect_url' )->with( 'https://example.test/' )->reply( 'https://example.test/global-override/' );
 
 		$functions = new Disable_Blog_Public_Functions_Double();
@@ -753,7 +787,20 @@ class PublicRedirectsTest extends TestCase {
 		$query->shouldReceive( 'is_tag' )->once()->andReturn( true );
 		$query->shouldReceive( 'set' )->once()->with( 'post_type', array( 'book' ) );
 
-		WP_Mock::onFilter( 'dwpb_tag_post_types' )->with( array( 'book' ), $query )->reply( array( 'book' ) );
+		// safe_offset( array( 'book' ) ) === safe_offset( 'book' ), so a plain ->with()
+		// match would also route (and silently pass) if the source ever collapsed the
+		// one-element array to the bare string. The InvokedFilterValue responder receives
+		// the real invoked argument regardless of which key matched, so assertSame() below
+		// catches that.
+		WP_Mock::onFilter( 'dwpb_tag_post_types' )->with( array( 'book' ), $query )->reply(
+			new WP_Mock\InvokedFilterValue(
+				function ( $tag_post_types ) {
+					$this->assertSame( array( 'book' ), $tag_post_types );
+
+					return array( 'book' );
+				}
+			)
+		);
 
 		$functions = new Disable_Blog_Public_Functions_Double();
 		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
@@ -772,7 +819,15 @@ class PublicRedirectsTest extends TestCase {
 		$query->shouldReceive( 'is_tag' )->once()->andReturn( true );
 		$query->shouldReceive( 'set' )->once()->with( 'post_type', array( 'custom_cpt' ) );
 
-		WP_Mock::onFilter( 'dwpb_tag_post_types' )->with( array( 'book' ), $query )->reply( array( 'custom_cpt' ) );
+		WP_Mock::onFilter( 'dwpb_tag_post_types' )->with( array( 'book' ), $query )->reply(
+			new WP_Mock\InvokedFilterValue(
+				function ( $tag_post_types ) {
+					$this->assertSame( array( 'book' ), $tag_post_types );
+
+					return array( 'custom_cpt' );
+				}
+			)
+		);
 
 		$functions = new Disable_Blog_Public_Functions_Double();
 		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
@@ -818,7 +873,20 @@ class PublicRedirectsTest extends TestCase {
 		$query->shouldReceive( 'is_category' )->once()->andReturn( true );
 		$query->shouldReceive( 'set' )->once()->with( 'post_type', array( 'page' ) );
 
-		WP_Mock::onFilter( 'dwpb_category_post_types' )->with( array( 'page' ), $query )->reply( array( 'page' ) );
+		// safe_offset( array( 'page' ) ) === safe_offset( 'page' ), so a plain ->with()
+		// match would also route (and silently pass) if the source ever collapsed the
+		// one-element array to the bare string. The InvokedFilterValue responder receives
+		// the real invoked argument regardless of which key matched, so assertSame() below
+		// catches that.
+		WP_Mock::onFilter( 'dwpb_category_post_types' )->with( array( 'page' ), $query )->reply(
+			new WP_Mock\InvokedFilterValue(
+				function ( $category_post_types ) {
+					$this->assertSame( array( 'page' ), $category_post_types );
+
+					return array( 'page' );
+				}
+			)
+		);
 
 		$functions = new Disable_Blog_Public_Functions_Double();
 		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
@@ -838,7 +906,15 @@ class PublicRedirectsTest extends TestCase {
 		$query->shouldReceive( 'is_category' )->once()->andReturn( true );
 		$query->shouldReceive( 'set' )->once()->with( 'post_type', array( 'custom_cpt' ) );
 
-		WP_Mock::onFilter( 'dwpb_category_post_types' )->with( array( 'page' ), $query )->reply( array( 'custom_cpt' ) );
+		WP_Mock::onFilter( 'dwpb_category_post_types' )->with( array( 'page' ), $query )->reply(
+			new WP_Mock\InvokedFilterValue(
+				function ( $category_post_types ) {
+					$this->assertSame( array( 'page' ), $category_post_types );
+
+					return array( 'custom_cpt' );
+				}
+			)
+		);
 
 		$functions = new Disable_Blog_Public_Functions_Double();
 		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
@@ -947,7 +1023,20 @@ class PublicRedirectsTest extends TestCase {
 		$query = Mockery::mock( 'Disable_Blog_Public_Query_Double' );
 		$query->shouldReceive( 'set' )->once()->with( 'post_type', array( 'overridden' ) );
 
-		WP_Mock::onFilter( 'my_filter' )->with( array( 'book' ), $query )->reply( array( 'overridden' ) );
+		// safe_offset( array( 'book' ) ) === safe_offset( 'book' ), so a plain ->with()
+		// match would also route (and silently pass) if the source ever collapsed the
+		// one-element array to the bare string. The InvokedFilterValue responder receives
+		// the real invoked argument regardless of which key matched, so assertSame() below
+		// catches that.
+		WP_Mock::onFilter( 'my_filter' )->with( array( 'book' ), $query )->reply(
+			new WP_Mock\InvokedFilterValue(
+				function ( $post_types ) {
+					$this->assertSame( array( 'book' ), $post_types );
+
+					return array( 'overridden' );
+				}
+			)
+		);
 
 		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
 
@@ -979,7 +1068,15 @@ class PublicRedirectsTest extends TestCase {
 		$query = Mockery::mock( 'Disable_Blog_Public_Query_Double' );
 		$query->shouldNotReceive( 'set' );
 
-		WP_Mock::onFilter( 'my_filter' )->with( array( 'book' ), $query )->reply( 'oops' );
+		WP_Mock::onFilter( 'my_filter' )->with( array( 'book' ), $query )->reply(
+			new WP_Mock\InvokedFilterValue(
+				function ( $post_types ) {
+					$this->assertSame( array( 'book' ), $post_types );
+
+					return 'oops';
+				}
+			)
+		);
 
 		$public = new Disable_Blog_Public( 'disable-blog', '0.5.6' );
 

--- a/tests/php/PublicRedirectsTest.php
+++ b/tests/php/PublicRedirectsTest.php
@@ -780,6 +780,32 @@ class PublicRedirectsTest extends TestCase {
 		$this->assertNull( $public->modify_query( $query ) );
 	}
 
+	/**
+	 * The tag branch requires BOTH is_tag() AND a non-empty $tag_post_types -- proven
+	 * independently of is_tag() by holding it true while forcing $tag_post_types empty, so a
+	 * relaxed `||` (which would enter the branch and wrongly strip 'post' from its own tag
+	 * archive) is distinguishable from the real `&&`. Mirrors
+	 * test_modify_query_author_branch_skipped_when_author_post_types_empty() below.
+	 */
+	public function test_modify_query_tag_branch_skipped_when_tag_post_types_empty() {
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+		$this->stub_post_types_with_tax_result( 'category', false );
+
+		$query = Mockery::mock( 'Disable_Blog_Public_Query_Double' );
+		$query->shouldReceive( 'is_main_query' )->once()->andReturn( true );
+		$query->shouldReceive( 'is_tag' )->once()->andReturn( true );
+		$query->shouldReceive( 'is_category' )->once()->andReturn( false );
+		$query->shouldReceive( 'is_author' )->once()->andReturn( false );
+		$query->shouldNotReceive( 'set' );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$this->assertNull( $public->modify_query( $query ) );
+	}
+
 	public function test_modify_query_sets_category_post_types_when_category_archive_and_other_post_types_use_category() {
 		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
 		$this->stub_tax_lookup_plumbing();
@@ -813,6 +839,32 @@ class PublicRedirectsTest extends TestCase {
 		$query->shouldReceive( 'set' )->once()->with( 'post_type', array( 'custom_cpt' ) );
 
 		WP_Mock::onFilter( 'dwpb_category_post_types' )->with( array( 'page' ), $query )->reply( array( 'custom_cpt' ) );
+
+		$functions = new Disable_Blog_Public_Functions_Double();
+		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );
+
+		$this->assertNull( $public->modify_query( $query ) );
+	}
+
+	/**
+	 * The category branch requires BOTH is_category() AND a non-empty $category_post_types --
+	 * proven independently of is_category() by holding it true while forcing
+	 * $category_post_types empty, so a relaxed `||` (which would enter the branch and wrongly
+	 * strip 'post' from its own category archive) is distinguishable from the real `&&`.
+	 * Mirrors test_modify_query_author_branch_skipped_when_author_post_types_empty() below.
+	 */
+	public function test_modify_query_category_branch_skipped_when_category_post_types_empty() {
+		WP_Mock::userFunction( 'is_admin' )->once()->andReturn( false );
+		$this->stub_tax_lookup_plumbing();
+		$this->stub_post_types_with_tax_result( 'post_tag', false );
+		$this->stub_post_types_with_tax_result( 'category', false );
+
+		$query = Mockery::mock( 'Disable_Blog_Public_Query_Double' );
+		$query->shouldReceive( 'is_main_query' )->once()->andReturn( true );
+		$query->shouldReceive( 'is_tag' )->once()->andReturn( false );
+		$query->shouldReceive( 'is_category' )->once()->andReturn( true );
+		$query->shouldReceive( 'is_author' )->once()->andReturn( false );
+		$query->shouldNotReceive( 'set' );
 
 		$functions = new Disable_Blog_Public_Functions_Double();
 		$public    = new Disable_Blog_Public( 'disable-blog', '0.5.6', $functions );

--- a/tests/php/includes/TestCase.php
+++ b/tests/php/includes/TestCase.php
@@ -63,4 +63,36 @@ class TestCase extends \Yoast\PHPUnitPolyfills\TestCases\TestCase {
 
 		parent::tear_down();
 	}
+
+	/**
+	 * Registers $filter so it asserts the exact value it receives is $expected before
+	 * replying with $reply.
+	 *
+	 * WP_Mock::onFilter()->with() keys its matches on WP_Mock\Hook::safe_offset(), which
+	 * casts scalars via (string) -- so safe_offset( true ) === safe_offset( 1 ) === '1',
+	 * safe_offset( false ) === safe_offset( '' ) === safe_offset( array() ) === '', and
+	 * safe_offset( array( 'x' ) ) === safe_offset( 'x' ). A plain ->with( true ) therefore
+	 * still matches when the source passes a loosely-equal value instead of the literal
+	 * the filter documents. Mockery::on() cannot fix it either: onFilter() is not
+	 * Mockery-backed, so a matcher object is just another value safe_offset() stringifies.
+	 * WP_Mock\InvokedFilterValue's callback receives the real invoked argument via
+	 * func_get_args() regardless of which (possibly collided) key matched, so the value
+	 * can be asserted strictly.
+	 *
+	 * @param string $filter   The filter hook name.
+	 * @param mixed  $expected The exact value the filter must receive.
+	 * @param mixed  $reply    The value the filter should return.
+	 * @return void
+	 */
+	protected function stub_filter_strict( $filter, $expected, $reply ) {
+		WP_Mock::onFilter( $filter )->with( $expected )->reply(
+			new WP_Mock\InvokedFilterValue(
+				function ( $value ) use ( $filter, $expected, $reply ) {
+					$this->assertSame( $expected, $value, "{$filter} must receive the exact value it documents." );
+
+					return $reply;
+				}
+			)
+		);
+	}
 }


### PR DESCRIPTION
Stacked on #87, which is stacked on #86. Review #87 first — this PR's tests exercise the
seams it adds.

An adversarial audit mutation-tested `includes/` with 521 hand-built mutants and found
**50 confirmed survivors**, each reproduced independently by a second agent. This PR kills
45 of them. The other 5 are accounted for below.

## What the coverage number was hiding

#86 reports 96.97% line coverage. That is accurate, and it is not the useful number:

| | `Disable_Blog_Admin` | `Disable_Blog_Public` |
|---|---|---|
| Line | 100% | 100% |
| **Branch** | **61.39%** | **64.68%** |
| **Path** | **1.04%** | **0.95%** |

Roughly one condition in three was never independently flipped. Separately, 22 of the 28
uncovered lines sat in one class — `Disable_Blog`'s constructor and `load_dependencies()`,
which never executed under test at all.

## The kills

**24 needed no production change** (`de8072c`). The most consequential are
`modify_query()`'s tag and category branches, where `&&` could be relaxed to `||`
undetected: every existing test held both operands true together, so nothing covered a tag
archive whose post types are empty — the case that strips `post` from its own archive. The
author branch already had that coverage; tag and category now match it.

**21 were unkillable without the seams in #87** (`fc1b593`). `boot()` is driven through a
recording subclass that pins **the order** the six setup methods run in, not just that they
ran — reordering them breaks production and previously broke no test. The activation and
deactivation nonce checks are asserted in **both** directions: `terminate()` must run when
`check_admin_referer()` fails *and* must not when it passes. Only the second half kills an
inverted guard.

**Two are documented, not faked.** `xmlrpc_methods()`' `isset()` guard is a genuine
equivalent mutant — `unset()` on a missing key is already a no-op. The autoloader's
`strtolower()` cannot be observed on a case-insensitive filesystem, and `file_exists()` is
an internal function Patchwork will not stub; it would be killable on Linux CI, and a small
production seam would close it properly.

## Two vacuous tests repaired

`remove_pingback_header_fallback()`'s two tests asserted `assertNull()` on a void method,
so deleting the guard they name left both green. They now assert the observable effect
through `do_remove_pingback_header()`. They were not deleted — what they assert was fixed.

## Argument matchers that matched anything (`f720293`)

The suite has **two** independent loose-matching mechanisms, and the second is not
documented anywhere obvious:

- **Mockery's `with()` compares with `==`**, so `array() == false`, `'post' == true` and
  `404 == '404'` all match.
- **`WP_Mock::onFilter()->with()` does not use Mockery at all.** It keys on `safe_offset()`,
  which casts through `(string)` and flattens arrays — so `true`/`1` collide,
  `false`/`''`/`array()`/`null` collide, and `array( 'x' )` collides with `'x'`.
  **`Mockery::on()` cannot fix this one**; it becomes another value to stringify.

`TestCase::stub_filter_strict()` registers a `WP_Mock\InvokedFilterValue` responder whose
callback receives the real invoked argument via `func_get_args()` regardless of which key
matched, and asserts it with `assertSame()`.

**Two assertions were checking the wrong value outright**: `HelperFunctionsTest` asserted
`wp_cache_set()` receives `false` for a negative result, when the cache stores an empty
array. They passed only because `array() == false` — so reintroducing the caching bug #87
fixes would not have failed them.

Assertions rise **528 → 1080 against an unchanged 435 tests**. The concrete check:
regressing `dwpb_post_types_with_feature()`'s normalization from `false` to `''` now fails
**39 tests across 6 files**; every one of those files passed that regression before.

## Term counts and runtime

`get_term_post_count_by_type()` capped its query at one page and counted the rows returned,
so terms with more matching posts displayed a **silently wrong number**. It now reports
`found_posts`. This lands here rather than in #87 because the `WP_Query` double set only
`->posts` — code and double had to change together.

`8e395ab` also covers the memoization added in #87, which had no coverage at all, including
the cached-**zero** case that would otherwise recompute forever.

`1fbf807` drops process isolation from four tests that no longer need it: **24 → 20
isolated tests, 19.96s → 16.86s**. Note this is still above #86's 15.0s baseline — the
memoization tests each overload `WP_Query` and declare `wp_cache_*` functions, so their
isolation is genuine.

## Verification

`OK (435 tests, 1080 assertions)`, PHPStan level 5 `[OK] No errors`, PHPCS clean.
**Order-independence green across 20 random seeds**, plus each modified file run alone.
Every test claiming to kill a mutant was proven to fail with that mutation applied and pass
without it, then re-verified by an independent agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)